### PR TITLE
Fix: Action emits on success or on fail

### DIFF
--- a/src/js/actions/DeploymentActions.js
+++ b/src/js/actions/DeploymentActions.js
@@ -9,7 +9,13 @@ var DeploymentActions = {
     this.request({
       url: config.apiURL + "v2/deployments"
     })
+    .start(function (status) {
+      this.status = status;
+    })
     .done(function (deployments) {
+      if (this.status !== 200) {
+        return;
+      }
       AppDispatcher.dispatch({
         actionType: DeploymentEvents.REQUEST,
         data: deployments
@@ -27,7 +33,13 @@ var DeploymentActions = {
       method: "DELETE",
       url: config.apiURL + "v2/deployments/" + deploymentID
     })
+    .start(function (status) {
+      this.status = status;
+    })
     .done(function (deployment) {
+      if (this.status !== 200) {
+        return;
+      }
       AppDispatcher.dispatch({
         actionType: DeploymentEvents.REVERT,
         data: deployment,
@@ -46,7 +58,13 @@ var DeploymentActions = {
       method: "DELETE",
       url: config.apiURL + "v2/deployments/" + deploymentID + "?force=true"
     })
+    .start(function (status) {
+      this.status = status;
+    })
     .done(function (deployment) {
+      if (this.status !== 202) {
+        return;
+      }
       AppDispatcher.dispatch({
         actionType: DeploymentEvents.STOP,
         data: deployment,


### PR DESCRIPTION
The done-function should only emit on a successful request, even if the done() is called on every finished request (successful or not) .