### PR TITLE
Use Browsersync for serve

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,5 @@
 var autoprefixer = require("gulp-autoprefixer");
-var connect = require("gulp-connect");
+var browserSync = require("browser-sync");
 var eslint = require("gulp-eslint");
 var gulp = require("gulp");
 var gutil = require("gulp-util");
@@ -71,6 +71,7 @@ gulp.task("webpack", function (callback) {
     if (err) {
       throw new gutil.PluginError("webpack", err);
     }
+    browserSync.reload();
     callback();
   });
 });
@@ -87,7 +88,8 @@ gulp.task("less", function () {
       paths: [dirs.styles] // @import paths
     }))
     .pipe(autoprefixer())
-    .pipe(gulp.dest(dirs.dist));
+    .pipe(gulp.dest(dirs.dist))
+    .pipe(browserSync.stream());
 });
 
 gulp.task("minify-css", ["less"], function () {
@@ -112,10 +114,10 @@ gulp.task("index", function () {
     .pipe(gulp.dest(dirs.dist));
 });
 gulp.task("connect:server", function () {
-  connect.server({
-    port: 4200,
-    root: dirs.dist,
-    livereload: false // TODO
+  browserSync.init({
+    server: {
+      baseDir: dirs.dist
+    }
   });
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,5 @@
 var autoprefixer = require("gulp-autoprefixer");
+var connect = require("gulp-connect");
 var browserSync = require("browser-sync");
 var eslint = require("gulp-eslint");
 var gulp = require("gulp");
@@ -113,7 +114,15 @@ gulp.task("index", function () {
   return gulp.src(dirs.src + "/" + files.index)
     .pipe(gulp.dest(dirs.dist));
 });
+
 gulp.task("connect:server", function () {
+  connect.server({
+    port: 4200,
+    root: dirs.dist
+  });
+});
+
+gulp.task("browsersync", function () {
   browserSync.init({
     server: {
       baseDir: dirs.dist
@@ -121,11 +130,14 @@ gulp.task("connect:server", function () {
   });
 });
 
-gulp.task("serve", ["default", "connect:server"], function () {
+gulp.task("watch", function () {
   gulp.watch(dirs.styles + "/*", ["less"]);
   gulp.watch(dirs.js + "/**/*.?(js|jsx)", ["eslint", "webpack"]);
   gulp.watch(dirs.img + "/**/*.*", ["images"]);
 });
+
+gulp.task("serve", ["default", "connect:server", "watch"]);
+gulp.task("livereload", ["default", "browsersync", "watch"]);
 
 var tasks = [
   "eslint",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "babel-core": "^5.5.8",
     "babel-loader": "^5.1.4",
+    "browser-sync": "^2.7.12",
     "chai": "^3.0.0",
     "chalk": "^0.5.1",
     "cheerio": "^0.18.0",
@@ -34,7 +35,6 @@
     "eslint-plugin-react": "^2.5.0",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^2.3.1",
-    "gulp-connect": "^2.2.0",
     "gulp-copy": "0.0.2",
     "gulp-eslint": "^0.14.0",
     "gulp-less": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-react": "^2.5.0",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^2.3.1",
+    "gulp-connect": "^2.2.0",
     "gulp-copy": "0.0.2",
     "gulp-eslint": "^0.14.0",
     "gulp-less": "^3.0.3",
@@ -53,6 +54,7 @@
     "dist": "export GULP_ENV=\"production\" && npm run clean && npm run test && npm run build",
     "shrinkwrap": "npm-shrinkwrap --dev",
     "test": "mocha --ui exports --reporter spec --compilers jsx:src/test/helpers/compiler.js src/test/helpers/object-assign-polyfill.js src/test/**/*.test.* src/test/*.test.*",
-    "serve": "export GULP_ENV=\"development\" DISABLE_SOURCE_MAP=false && gulp serve"
+    "serve": "export GULP_ENV=\"development\" DISABLE_SOURCE_MAP=false && gulp serve",
+    "livereload": "export GULP_ENV=\"development\" DISABLE_SOURCE_MAP=false && gulp livereload"
   }
 }


### PR DESCRIPTION
See this in action: https://www.youtube.com/watch?v=bbVA9IsY0uU
I'm pretty excited about this!

`npm run serve` : run the usual gulp-connect task on port 4200
`npm run livereload` : run the browersync server on port 3000