### PR TITLE
Enable webpack output

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -68,10 +68,11 @@ gulp.task("webpack", function (callback) {
     ];
   }
   // run webpack
-  webpack(webpackConfig, function (err) {
+  webpack(webpackConfig, function (err, stats) {
     if (err) {
       throw new gutil.PluginError("webpack", err);
     }
+    gutil.log("[webpack]", stats.toString({colors: true}));
     browserSync.reload();
     callback();
   });


### PR DESCRIPTION
These logs are a bit on the verbose side but they are the only way to
know if something went wrong with missing loaders or similar errors.