### PR TITLE
Remove jQuery dependency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5,8 +5,8 @@
   "node-version": "v0.10.38",
   "dependencies": {
     "babel-core": {
-      "version": "5.6.12",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.6.12.tgz",
+      "version": "5.6.15",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.6.15.tgz",
       "dependencies": {
         "acorn-jsx": {
           "version": "1.0.3",
@@ -19,8 +19,8 @@
           }
         },
         "ast-types": {
-          "version": "0.7.6",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.6.tgz"
+          "version": "0.7.8",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz"
         },
         "babel-plugin-constant-folding": {
           "version": "1.0.1",
@@ -585,8 +585,8 @@
       "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.2.1.tgz"
     },
     "browser-sync": {
-      "version": "2.7.12",
-      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.7.12.tgz",
+      "version": "2.7.13",
+      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.7.13.tgz",
       "dependencies": {
         "anymatch": {
           "version": "1.3.0",
@@ -2021,8 +2021,8 @@
       }
     },
     "eslint": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-0.23.0.tgz",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-0.24.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.0.0",
@@ -2209,12 +2209,12 @@
           }
         },
         "espree": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-2.0.3.tgz"
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-2.0.4.tgz"
         },
         "estraverse": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-2.0.0.tgz"
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.0.tgz"
         },
         "estraverse-fb": {
           "version": "1.3.1",
@@ -2407,8 +2407,8 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-2.5.2.tgz"
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-2.6.2.tgz"
     },
     "flux": {
       "version": "2.0.3",
@@ -3933,8 +3933,8 @@
               }
             },
             "espree": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/espree/-/espree-2.0.3.tgz"
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/espree/-/espree-2.0.4.tgz"
             },
             "estraverse": {
               "version": "2.0.0",
@@ -4281,8 +4281,8 @@
           "resolved": "https://registry.npmjs.org/less/-/less-2.5.1.tgz",
           "dependencies": {
             "errno": {
-              "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.2.tgz",
+              "version": "0.1.3",
+              "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.3.tgz",
               "dependencies": {
                 "prr": {
                   "version": "0.0.0",
@@ -5135,10 +5135,6 @@
           }
         }
       }
-    },
-    "jquery": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.4.tgz"
     },
     "lazy.js": {
       "version": "0.4.0",
@@ -6205,8 +6201,8 @@
               "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.13.tgz",
               "dependencies": {
                 "ast-types": {
-                  "version": "0.7.6",
-                  "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.6.tgz"
+                  "version": "0.7.8",
+                  "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz"
                 },
                 "esprima-fb": {
                   "version": "14001.1.0-dev-harmony-fb",
@@ -6253,8 +6249,8 @@
       }
     },
     "sinon": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.15.3.tgz",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.15.4.tgz",
       "dependencies": {
         "formatio": {
           "version": "1.1.1",
@@ -6323,8 +6319,8 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
     },
     "webpack": {
-      "version": "1.9.12",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.9.12.tgz",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.10.0.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "backbone": "^1.1.2",
     "classnames": "^2.1.2",
     "flux": "^2.0.3",
-    "jquery": "^2.1.3",
     "lazy.js": "^0.4.0",
     "moment": "^2.9.0",
     "mousetrap": "^1.4.6",

--- a/src/js/components/ModalComponent.jsx
+++ b/src/js/components/ModalComponent.jsx
@@ -1,4 +1,4 @@
-var $ = require("jquery");
+var util = require("../helpers/util");
 var classNames = require("classnames");
 var React = require("react/addons");
 
@@ -24,7 +24,7 @@ var ModalComponent = React.createClass({
 
   getDefaultProps: function () {
     return {
-      onDestroy: $.noop,
+      onDestroy: function () {},
       size: null
     };
   },
@@ -36,9 +36,8 @@ var ModalComponent = React.createClass({
   },
 
   onClick: function (event) {
-    var $target = $(event.target);
-
-    if ($target.hasClass("modal") || $target.hasClass("modal-dialog")) {
+    if (util.hasClass(event.target, "modal") ||
+      util.hasClass(event.target, "modal-dialog")) {
       this.destroy();
     }
   },

--- a/src/js/components/NewAppModalComponent.jsx
+++ b/src/js/components/NewAppModalComponent.jsx
@@ -1,6 +1,6 @@
-var $ = require("jquery");
 var _ = require("underscore");
 var React = require("react/addons");
+var util = require("../helpers/util");
 
 var BackboneMixin = require("../mixins/BackboneMixin");
 var App = require("../models/App");
@@ -22,8 +22,8 @@ var NewAppModalComponent = React.createClass({
 
   getDefaultProps: function () {
     return {
-      onCreate: $.noop,
-      onDestroy: $.noop
+      onCreate: _.noop,
+      onDestroy: _.noop
     };
   },
 
@@ -80,7 +80,7 @@ var NewAppModalComponent = React.createClass({
   onSubmit: function (event) {
     event.preventDefault();
 
-    var attrArray = $(event.target).serializeArray();
+    var attrArray = util.serializeArray(event.target);
     var modelAttrs = {};
 
     for (var i = 0; i < attrArray.length; i++) {

--- a/src/js/helpers/util.js
+++ b/src/js/helpers/util.js
@@ -23,6 +23,51 @@ var util = {
     } catch (e) {
       return obj;
     }
+  },
+  serializeArray: function (form) {
+    var serialized = [];
+    // https://github.com/jquery/jquery/blob/2.1-stable/src/serialize.js#L12
+    var rCRLF = /\r?\n/g,
+      rsubmitterTypes = /^(?:submit|button|image|reset|file)$/i,
+      rsubmittable = /^(?:input|select|textarea|keygen)/i,
+      rcheckableType = /^(?:checkbox|radio)$/i;
+
+    var nodeIterator = document.createNodeIterator(
+      form,
+      NodeFilter.SHOW_ELEMENT,
+      function (node) {
+        // The .serializeArray() method uses the standard W3C rules for
+        // successful controls to determine which elements it should include;
+        // in particular the element cannot be disabled and must contain a name
+        // attribute. No submit button value is serialized since the form was
+        // not submitted using a button. Data from file select elements is not
+        // serialized.
+        var type = node.type;
+
+        return node.name &&
+          !node.disabled &&
+          rsubmittable.test(node.nodeName) &&
+          !rsubmitterTypes.test(type) &&
+          (node.checked || !rcheckableType.test(type))
+            ? NodeFilter.FILTER_ACCEPT
+            : NodeFilter.FILTER_REJECT;
+      },
+      false
+    );
+    var field;
+    /*eslint-disable no-cond-assign */
+    while (field = nodeIterator.nextNode()) {
+      var val = field.value;
+      if (val) {
+        serialized.push({name: field.name, value: val.replace(rCRLF, "\r\n")});
+      }
+    }
+    /*eslint-enable no-cond-assign */
+    return serialized;
+  },
+  hasClass: function (element, className) {
+    return element.className &&
+      element.className.match(/\S+/g).indexOf(className) > -1;
   }
 };
 

--- a/src/js/helpers/util.js
+++ b/src/js/helpers/util.js
@@ -13,6 +13,16 @@ var util = {
     /*eslint-disable no-alert */
     return global.prompt.apply(null, arguments);
     /*eslint-enable no-alert */
+  },
+  param: function (obj) {
+    try {
+      return Object.keys(obj).reduce(function (a, k) {
+        a.push(k + "=" + encodeURIComponent(obj[k]));
+        return a;
+      }, []).join("&");
+    } catch (e) {
+      return obj;
+    }
   }
 };
 

--- a/src/js/models/Task.js
+++ b/src/js/models/Task.js
@@ -1,5 +1,5 @@
 var Backbone = require("backbone");
-var $ = require("jquery");
+var util = require("../helpers/util");
 
 var STATUS_STAGED = "Staged";
 var STATUS_STARTED = "Started";
@@ -68,7 +68,7 @@ var Task = Backbone.Model.extend({
       // parameters. Construct the param string and append it to the normal
       // URL.
       _options.url = this.collection.url() + "/tasks/" + model.id +
-        "?" + $.param({scale: _options.scale});
+        "?" + util.param({scale: _options.scale});
     }
 
     return Backbone.sync.call(this, method, model, _options);

--- a/src/test/util.test.js
+++ b/src/test/util.test.js
@@ -1,0 +1,41 @@
+var expect = require("chai").expect;
+var util = require("../js/helpers/util");
+
+describe("util", function () {
+
+  describe("param", function () {
+
+    it("returns a valid urlencoded query string", function () {
+      var obj = {
+        hello: "world",
+        foo: "bar"
+      };
+      expect(util.param(obj)).to.equal("hello=world&foo=bar");
+    });
+
+    it("handles spaces and other entities correctly", function () {
+      var obj = {
+        q: "is:open is:issue label:gui"
+      };
+      expect(util.param(obj))
+        .to.equal("q=is%3Aopen%20is%3Aissue%20label%3Agui");
+    });
+
+    it("handles bad input gracefully", function () {
+      var obj = {};
+      expect(util.param(obj)).to.equal("");
+
+      obj = [1, 2, 3];
+      expect(util.param(obj)).to.equal("0=1&1=2&2=3");
+
+      obj = null;
+      expect(util.param(obj)).to.equal(null);
+
+      obj = "already=foo&also=bar";
+      expect(util.param(obj)).to.equal("already=foo&also=bar");
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
We were depending on jQuery for just the following:

- `$.noop` 
- `$.param()`
- `$.hasClass()`
- `$.serializeArray()`

While the first 3 were pretty trivial to solve, `serializeArray` was a bit more tedious. I have decided to implement it using [createNodeIterator](the https://developer.mozilla.org/en-US/docs/Web/API/Document/createNodeIterator) API which is 
> Supported in FF 3.5+, Chrome 1+, Opera 9+, Safari 3+, IE9+

Hopefully the resulting code is easier on the :eyes: . 

In general, I tried to stick to [what jQuery is actually doing](https://github.com/jquery/jquery/blob/master/src/serialize.js#L87-L111). For lack of better ideas (maybe we should implement a fake DOM in our tests?) I setup a jsFiddle to make sure I was on the right track  : 

http://jsfiddle.net/5re8hpzm/2/ 

In my tests on Marathon everything seems OK, but I would really appreciate your help on defining a proper test-routine for this to be "scientifically" sure :laughing: 

https://github.com/mesosphere/marathon/issues/1223