### PR TITLE
Reintroduce jQuery :(

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -35208,19 +35208,19 @@
 	var React = __webpack_require__(4);
 	var States = __webpack_require__(181);
 	var AppCollection = __webpack_require__(182);
-	var AppListComponent = __webpack_require__(189);
-	var AboutModalComponent = __webpack_require__(194);
-	var AppPageComponent = __webpack_require__(212);
+	var AppListComponent = __webpack_require__(190);
+	var AboutModalComponent = __webpack_require__(195);
+	var AppPageComponent = __webpack_require__(213);
 	var DeploymentsListComponent = __webpack_require__(314);
 	var NewAppModalComponent = __webpack_require__(321);
-	var TabPaneComponent = __webpack_require__(213);
-	var TogglableTabsComponent = __webpack_require__(311);
-	var NavTabsComponent = __webpack_require__(312);
+	var TabPaneComponent = __webpack_require__(214);
+	var TogglableTabsComponent = __webpack_require__(312);
+	var NavTabsComponent = __webpack_require__(313);
 
 	var DeploymentActions = __webpack_require__(316);
 	var DeploymentEvents = __webpack_require__(319);
 	var DeploymentStore = __webpack_require__(320);
-	var util = __webpack_require__(313);
+	var util = __webpack_require__(188);
 
 	var tabs = [{ id: "apps", text: "Apps" }, { id: "deployments", text: "Deployments" }];
 
@@ -36819,7 +36819,7 @@
 	var AppVersion = __webpack_require__(184);
 	var AppVersionCollection = __webpack_require__(185);
 	var Task = __webpack_require__(187);
-	var TaskCollection = __webpack_require__(188);
+	var TaskCollection = __webpack_require__(189);
 
 	function ValidationError(attribute, message) {
 	  this.attribute = attribute;
@@ -37205,7 +37205,7 @@
 	"use strict";
 
 	var Backbone = __webpack_require__(1);
-	var $ = __webpack_require__(3);
+	var util = __webpack_require__(188);
 
 	var STATUS_STAGED = "Staged";
 	var STATUS_STARTED = "Started";
@@ -37277,7 +37277,7 @@
 	      // The "/kill" endpoint expects certain POST values to be query
 	      // parameters. Construct the param string and append it to the normal
 	      // URL.
-	      _options.url = this.collection.url() + "/tasks/" + model.id + "?" + $.param({ scale: _options.scale });
+	      _options.url = this.collection.url() + "/tasks/" + model.id + "?" + util.param({ scale: _options.scale });
 	    }
 
 	    return Backbone.sync.call(this, method, model, _options);
@@ -37288,6 +37288,76 @@
 
 /***/ },
 /* 188 */
+/***/ function(module, exports) {
+
+	/* WEBPACK VAR INJECTION */(function(global) {"use strict";
+
+	var util = {
+	  alert: function alert() {
+	    /*eslint-disable no-alert */
+	    return global.alert.apply(null, arguments);
+	    /*eslint-enable no-alert */
+	  },
+	  confirm: function confirm() {
+	    /*eslint-disable no-alert */
+	    return global.confirm.apply(null, arguments);
+	    /*eslint-enable no-alert */
+	  },
+	  prompt: function prompt() {
+	    /*eslint-disable no-alert */
+	    return global.prompt.apply(null, arguments);
+	    /*eslint-enable no-alert */
+	  },
+	  param: function param(obj) {
+	    try {
+	      return Object.keys(obj).reduce(function (a, k) {
+	        a.push(k + "=" + encodeURIComponent(obj[k]));
+	        return a;
+	      }, []).join("&");
+	    } catch (e) {
+	      return obj;
+	    }
+	  },
+	  serializeArray: function serializeArray(form) {
+	    var serialized = [];
+	    // https://github.com/jquery/jquery/blob/2.1-stable/src/serialize.js#L12
+	    var rCRLF = /\r?\n/g,
+	        rsubmitterTypes = /^(?:submit|button|image|reset|file)$/i,
+	        rsubmittable = /^(?:input|select|textarea|keygen)/i,
+	        rcheckableType = /^(?:checkbox|radio)$/i;
+
+	    var nodeIterator = document.createNodeIterator(form, NodeFilter.SHOW_ELEMENT, function (node) {
+	      // The .serializeArray() method uses the standard W3C rules for
+	      // successful controls to determine which elements it should include;
+	      // in particular the element cannot be disabled and must contain a name
+	      // attribute. No submit button value is serialized since the form was
+	      // not submitted using a button. Data from file select elements is not
+	      // serialized.
+	      var type = node.type;
+
+	      return node.name && !node.disabled && rsubmittable.test(node.nodeName) && !rsubmitterTypes.test(type) && (node.checked || !rcheckableType.test(type)) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
+	    }, false);
+	    var field;
+	    /*eslint-disable no-cond-assign */
+	    while (field = nodeIterator.nextNode()) {
+	      var val = field.value;
+	      if (val) {
+	        serialized.push({ name: field.name, value: val.replace(rCRLF, "\r\n") });
+	      }
+	    }
+	    /*eslint-enable no-cond-assign */
+	    return serialized;
+	  },
+	  hasClass: function hasClass(element, className) {
+	    return element.className && element.className.match(/\S+/g).indexOf(className) > -1;
+	  }
+	};
+
+	module.exports = util;
+	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
+
+/***/ },
+/* 189 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -37317,17 +37387,17 @@
 	module.exports = TaskCollection;
 
 /***/ },
-/* 189 */
+/* 190 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 
-	var classNames = __webpack_require__(190);
+	var classNames = __webpack_require__(191);
 	var React = __webpack_require__(4);
 
 	var States = __webpack_require__(181);
-	var AppComponent = __webpack_require__(191);
-	var BackboneMixin = __webpack_require__(193);
+	var AppComponent = __webpack_require__(192);
+	var BackboneMixin = __webpack_require__(194);
 
 	var AppListComponent = React.createClass({
 	  displayName: "AppListComponent",
@@ -37504,7 +37574,7 @@
 	module.exports = AppListComponent;
 
 /***/ },
-/* 190 */
+/* 191 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_RESULT__;/*!
@@ -37559,15 +37629,15 @@
 
 
 /***/ },
-/* 191 */
+/* 192 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 
-	var classNames = __webpack_require__(190);
+	var classNames = __webpack_require__(191);
 	var React = __webpack_require__(4);
 
-	var AppHealthComponent = __webpack_require__(192);
+	var AppHealthComponent = __webpack_require__(193);
 
 	var AppComponent = React.createClass({
 	  displayName: "AppComponent",
@@ -37646,12 +37716,12 @@
 	module.exports = AppComponent;
 
 /***/ },
-/* 192 */
+/* 193 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 
-	var classNames = __webpack_require__(190);
+	var classNames = __webpack_require__(191);
 	var React = __webpack_require__(4);
 
 	function roundWorkaround(x) {
@@ -37739,7 +37809,7 @@
 	module.exports = AppHealthComponent;
 
 /***/ },
-/* 193 */
+/* 194 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -37764,18 +37834,18 @@
 	module.exports = BackboneMixin;
 
 /***/ },
-/* 194 */
+/* 195 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 
 	var React = __webpack_require__(4);
 
-	var InfoActions = __webpack_require__(205);
-	var InfoEvents = __webpack_require__(204);
-	var InfoStore = __webpack_require__(195);
-	var ModalComponent = __webpack_require__(210);
-	var ObjectDlComponent = __webpack_require__(211);
+	var InfoActions = __webpack_require__(206);
+	var InfoEvents = __webpack_require__(205);
+	var InfoStore = __webpack_require__(196);
+	var ModalComponent = __webpack_require__(211);
+	var ObjectDlComponent = __webpack_require__(212);
 
 	var AboutModalComponent = React.createClass({
 	  displayName: "AboutModalComponent",
@@ -37910,16 +37980,16 @@
 	module.exports = AboutModalComponent;
 
 /***/ },
-/* 195 */
+/* 196 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 
-	var EventEmitter = __webpack_require__(196).EventEmitter;
-	var lazy = __webpack_require__(197);
+	var EventEmitter = __webpack_require__(197).EventEmitter;
+	var lazy = __webpack_require__(198);
 
-	var AppDispatcher = __webpack_require__(200);
-	var InfoEvents = __webpack_require__(204);
+	var AppDispatcher = __webpack_require__(201);
+	var InfoEvents = __webpack_require__(205);
 
 	var InfoStore = lazy(EventEmitter.prototype).extend({
 	  info: {}
@@ -37940,7 +38010,7 @@
 	module.exports = InfoStore;
 
 /***/ },
-/* 196 */
+/* 197 */
 /***/ function(module, exports) {
 
 	// Copyright Joyent, Inc. and other Node contributors.
@@ -38247,7 +38317,7 @@
 
 
 /***/ },
-/* 197 */
+/* 198 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(setImmediate, clearImmediate, module) {/*
@@ -44590,10 +44660,10 @@
 
 	}(this));
 
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(198).setImmediate, __webpack_require__(198).clearImmediate, __webpack_require__(199)(module)))
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(199).setImmediate, __webpack_require__(199).clearImmediate, __webpack_require__(200)(module)))
 
 /***/ },
-/* 198 */
+/* 199 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(setImmediate, clearImmediate) {var nextTick = __webpack_require__(6).nextTick;
@@ -44672,10 +44742,10 @@
 	exports.clearImmediate = typeof clearImmediate === "function" ? clearImmediate : function(id) {
 	  delete immediateIds[id];
 	};
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(198).setImmediate, __webpack_require__(198).clearImmediate))
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(199).setImmediate, __webpack_require__(199).clearImmediate))
 
 /***/ },
-/* 199 */
+/* 200 */
 /***/ function(module, exports) {
 
 	module.exports = function(module) {
@@ -44691,17 +44761,17 @@
 
 
 /***/ },
-/* 200 */
+/* 201 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 
-	var Dispatcher = __webpack_require__(201).Dispatcher;
+	var Dispatcher = __webpack_require__(202).Dispatcher;
 
 	module.exports = new Dispatcher();
 
 /***/ },
-/* 201 */
+/* 202 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -44713,11 +44783,11 @@
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 */
 
-	module.exports.Dispatcher = __webpack_require__(202)
+	module.exports.Dispatcher = __webpack_require__(203)
 
 
 /***/ },
-/* 202 */
+/* 203 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -44734,7 +44804,7 @@
 
 	"use strict";
 
-	var invariant = __webpack_require__(203);
+	var invariant = __webpack_require__(204);
 
 	var _lastID = 1;
 	var _prefix = 'ID_';
@@ -44973,7 +45043,7 @@
 
 
 /***/ },
-/* 203 */
+/* 204 */
 /***/ function(module, exports) {
 
 	/**
@@ -45032,7 +45102,7 @@
 
 
 /***/ },
-/* 204 */
+/* 205 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -45046,16 +45116,16 @@
 	module.exports = InfoEvents;
 
 /***/ },
-/* 205 */
+/* 206 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 
-	var qajaxWrapper = __webpack_require__(206);
+	var qajaxWrapper = __webpack_require__(207);
 
 	var config = __webpack_require__(178);
-	var AppDispatcher = __webpack_require__(200);
-	var InfoEvents = __webpack_require__(204);
+	var AppDispatcher = __webpack_require__(201);
+	var InfoEvents = __webpack_require__(205);
 
 	var InfoActions = {
 	  requestInfo: function requestInfo() {
@@ -45079,12 +45149,12 @@
 	module.exports = InfoActions;
 
 /***/ },
-/* 206 */
+/* 207 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 
-	var qajax = __webpack_require__(207);
+	var qajax = __webpack_require__(208);
 
 	var qajaxWrapper = function qajaxWrapper(options) {
 	  var response = {
@@ -45139,14 +45209,14 @@
 	module.exports = qajaxWrapper;
 
 /***/ },
-/* 207 */
+/* 208 */
 /***/ function(module, exports, __webpack_require__) {
 
-	module.exports = __webpack_require__(208)(__webpack_require__(209), window.XMLHttpRequest, window.FormData);
+	module.exports = __webpack_require__(209)(__webpack_require__(210), window.XMLHttpRequest, window.FormData);
 
 
 /***/ },
-/* 208 */
+/* 209 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -45412,7 +45482,7 @@
 
 
 /***/ },
-/* 209 */
+/* 210 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(process, setImmediate) {// vim:ts=4:sts=4:sw=4:
@@ -47464,16 +47534,16 @@
 
 	});
 
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(6), __webpack_require__(198).setImmediate))
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(6), __webpack_require__(199).setImmediate))
 
 /***/ },
-/* 210 */
+/* 211 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 
-	var $ = __webpack_require__(3);
-	var classNames = __webpack_require__(190);
+	var util = __webpack_require__(188);
+	var classNames = __webpack_require__(191);
 	var React = __webpack_require__(4);
 
 	function modalSizeClassName(size) {
@@ -47498,7 +47568,7 @@
 
 	  getDefaultProps: function getDefaultProps() {
 	    return {
-	      onDestroy: $.noop,
+	      onDestroy: function onDestroy() {},
 	      size: null
 	    };
 	  },
@@ -47510,9 +47580,7 @@
 	  },
 
 	  onClick: function onClick(event) {
-	    var $target = $(event.target);
-
-	    if ($target.hasClass("modal") || $target.hasClass("modal-dialog")) {
+	    if (util.hasClass(event.target, "modal") || util.hasClass(event.target, "modal-dialog")) {
 	      this.destroy();
 	    }
 	  },
@@ -47562,7 +47630,7 @@
 	module.exports = ModalComponent;
 
 /***/ },
-/* 211 */
+/* 212 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -47634,22 +47702,22 @@
 	module.exports = ObjectDlComponent;
 
 /***/ },
-/* 212 */
+/* 213 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 
 	var _ = __webpack_require__(2);
-	var classNames = __webpack_require__(190);
+	var classNames = __webpack_require__(191);
 	var React = __webpack_require__(4);
 
-	var AppBreadcrumbsComponent = __webpack_require__(214);
-	var AppVersionListComponent = __webpack_require__(215);
-	var TabPaneComponent = __webpack_require__(213);
-	var TaskDetailComponent = __webpack_require__(220);
-	var TaskViewComponent = __webpack_require__(223);
-	var TogglableTabsComponent = __webpack_require__(311);
-	var util = __webpack_require__(313);
+	var AppBreadcrumbsComponent = __webpack_require__(215);
+	var AppVersionListComponent = __webpack_require__(216);
+	var TabPaneComponent = __webpack_require__(214);
+	var TaskDetailComponent = __webpack_require__(221);
+	var TaskViewComponent = __webpack_require__(224);
+	var TogglableTabsComponent = __webpack_require__(312);
+	var util = __webpack_require__(188);
 
 	var tabsTemplate = [{ id: "apps/:appid", text: "Tasks" }, { id: "apps/:appid/configuration", text: "Configuration" }];
 
@@ -47871,12 +47939,12 @@
 	module.exports = AppPageComponent;
 
 /***/ },
-/* 213 */
+/* 214 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 
-	var classNames = __webpack_require__(190);
+	var classNames = __webpack_require__(191);
 	var React = __webpack_require__(4);
 
 	var TabPaneComponent = React.createClass({
@@ -47918,12 +47986,12 @@
 	module.exports = TabPaneComponent;
 
 /***/ },
-/* 214 */
+/* 215 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 
-	var classNames = __webpack_require__(190);
+	var classNames = __webpack_require__(191);
 	var React = __webpack_require__(4);
 
 	var AppBreadcrumbsComponent = React.createClass({
@@ -48002,21 +48070,21 @@
 	module.exports = AppBreadcrumbsComponent;
 
 /***/ },
-/* 215 */
+/* 216 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 
-	var classNames = __webpack_require__(190);
+	var classNames = __webpack_require__(191);
 	var React = __webpack_require__(4);
 
 	var States = __webpack_require__(181);
 	var App = __webpack_require__(183);
-	var BackboneMixin = __webpack_require__(193);
-	var AppVersionComponent = __webpack_require__(216);
-	var AppVersionListItemComponent = __webpack_require__(217);
-	var PagedContentComponent = __webpack_require__(218);
-	var PagedNavComponent = __webpack_require__(219);
+	var BackboneMixin = __webpack_require__(194);
+	var AppVersionComponent = __webpack_require__(217);
+	var AppVersionListItemComponent = __webpack_require__(218);
+	var PagedContentComponent = __webpack_require__(219);
+	var PagedNavComponent = __webpack_require__(220);
 
 	var AppVersionListComponent = React.createClass({
 	  displayName: "AppVersionListComponent",
@@ -48159,7 +48227,7 @@
 	module.exports = AppVersionListComponent;
 
 /***/ },
-/* 216 */
+/* 217 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -48423,19 +48491,19 @@
 	module.exports = AppVersionComponent;
 
 /***/ },
-/* 217 */
+/* 218 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 
-	var classNames = __webpack_require__(190);
+	var classNames = __webpack_require__(191);
 	var React = __webpack_require__(4);
 
 	var States = __webpack_require__(181);
 	var App = __webpack_require__(183);
 	var AppVersion = __webpack_require__(184);
-	var BackboneMixin = __webpack_require__(193);
-	var AppVersionComponent = __webpack_require__(216);
+	var BackboneMixin = __webpack_require__(194);
+	var AppVersionComponent = __webpack_require__(217);
 
 	var AppVersionListItemComponent = React.createClass({
 	  displayName: "AppVersionListItemComponent",
@@ -48576,7 +48644,7 @@
 	module.exports = AppVersionListItemComponent;
 
 /***/ },
-/* 218 */
+/* 219 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -48629,12 +48697,12 @@
 	});
 
 /***/ },
-/* 219 */
+/* 220 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 
-	var classNames = __webpack_require__(190);
+	var classNames = __webpack_require__(191);
 	var React = __webpack_require__(4);
 
 	var PagedNavComponent = React.createClass({
@@ -48793,19 +48861,19 @@
 	module.exports = PagedNavComponent;
 
 /***/ },
-/* 220 */
+/* 221 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 
-	var classNames = __webpack_require__(190);
+	var classNames = __webpack_require__(191);
 	var React = __webpack_require__(4);
 
-	var BackboneMixin = __webpack_require__(193);
+	var BackboneMixin = __webpack_require__(194);
 	var States = __webpack_require__(181);
 	var Task = __webpack_require__(187);
-	var TimeFieldComponent = __webpack_require__(221);
-	var TaskHealthComponent = __webpack_require__(222);
+	var TimeFieldComponent = __webpack_require__(222);
+	var TaskHealthComponent = __webpack_require__(223);
 
 	var TaskDetailComponent = React.createClass({
 	  displayName: "TaskDetailComponent",
@@ -48946,7 +49014,7 @@
 	module.exports = TaskDetailComponent;
 
 /***/ },
-/* 221 */
+/* 222 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -48990,13 +49058,13 @@
 	module.exports = TimeFieldComponent;
 
 /***/ },
-/* 222 */
+/* 223 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 
 	var React = __webpack_require__(4);
-	var TimeFieldComponent = __webpack_require__(221);
+	var TimeFieldComponent = __webpack_require__(222);
 
 	var TaskHealthComponent = React.createClass({
 	  displayName: "TaskHealthComponent",
@@ -49087,16 +49155,16 @@
 	module.exports = TaskHealthComponent;
 
 /***/ },
-/* 223 */
+/* 224 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 
-	var classNames = __webpack_require__(190);
+	var classNames = __webpack_require__(191);
 	var React = __webpack_require__(4);
 
-	var PagedNavComponent = __webpack_require__(219);
-	var TaskListComponent = __webpack_require__(224);
+	var PagedNavComponent = __webpack_require__(220);
+	var TaskListComponent = __webpack_require__(225);
 
 	var TaskViewComponent = React.createClass({
 	  displayName: "TaskViewComponent",
@@ -49274,18 +49342,18 @@
 	module.exports = TaskViewComponent;
 
 /***/ },
-/* 224 */
+/* 225 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 
-	var classNames = __webpack_require__(190);
+	var classNames = __webpack_require__(191);
 	var React = __webpack_require__(4);
 
 	var States = __webpack_require__(181);
-	var BackboneMixin = __webpack_require__(193);
-	var TaskListItemComponent = __webpack_require__(225);
-	var PagedContentComponent = __webpack_require__(218);
+	var BackboneMixin = __webpack_require__(194);
+	var TaskListItemComponent = __webpack_require__(226);
+	var PagedContentComponent = __webpack_require__(219);
 
 	var TaskListComponent = React.createClass({
 	  displayName: "TaskListComponent",
@@ -49507,14 +49575,14 @@
 	module.exports = TaskListComponent;
 
 /***/ },
-/* 225 */
+/* 226 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 
-	var classNames = __webpack_require__(190);
+	var classNames = __webpack_require__(191);
 	var React = __webpack_require__(4);
-	var Moment = __webpack_require__(226);
+	var Moment = __webpack_require__(227);
 
 	var Task = __webpack_require__(187);
 
@@ -49697,7 +49765,7 @@
 	module.exports = TaskListItemComponent;
 
 /***/ },
-/* 226 */
+/* 227 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(module) {//! moment.js
@@ -49963,7 +50031,7 @@
 	                module && module.exports) {
 	            try {
 	                oldLocale = globalLocale._abbr;
-	                __webpack_require__(227)("./" + name);
+	                __webpack_require__(228)("./" + name);
 	                // because defineLocale currently also sets the global locale, we
 	                // want to undo that for lazy loaded locales
 	                locale_locales__getSetGlobalLocale(oldLocale);
@@ -52811,179 +52879,179 @@
 	    return _moment;
 
 	}));
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(199)(module)))
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(200)(module)))
 
 /***/ },
-/* 227 */
+/* 228 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var map = {
-		"./af": 228,
-		"./af.js": 228,
-		"./ar": 229,
-		"./ar-ma": 230,
-		"./ar-ma.js": 230,
-		"./ar-sa": 231,
-		"./ar-sa.js": 231,
-		"./ar-tn": 232,
-		"./ar-tn.js": 232,
-		"./ar.js": 229,
-		"./az": 233,
-		"./az.js": 233,
-		"./be": 234,
-		"./be.js": 234,
-		"./bg": 235,
-		"./bg.js": 235,
-		"./bn": 236,
-		"./bn.js": 236,
-		"./bo": 237,
-		"./bo.js": 237,
-		"./br": 238,
-		"./br.js": 238,
-		"./bs": 239,
-		"./bs.js": 239,
-		"./ca": 240,
-		"./ca.js": 240,
-		"./cs": 241,
-		"./cs.js": 241,
-		"./cv": 242,
-		"./cv.js": 242,
-		"./cy": 243,
-		"./cy.js": 243,
-		"./da": 244,
-		"./da.js": 244,
-		"./de": 245,
-		"./de-at": 246,
-		"./de-at.js": 246,
-		"./de.js": 245,
-		"./el": 247,
-		"./el.js": 247,
-		"./en-au": 248,
-		"./en-au.js": 248,
-		"./en-ca": 249,
-		"./en-ca.js": 249,
-		"./en-gb": 250,
-		"./en-gb.js": 250,
-		"./eo": 251,
-		"./eo.js": 251,
-		"./es": 252,
-		"./es.js": 252,
-		"./et": 253,
-		"./et.js": 253,
-		"./eu": 254,
-		"./eu.js": 254,
-		"./fa": 255,
-		"./fa.js": 255,
-		"./fi": 256,
-		"./fi.js": 256,
-		"./fo": 257,
-		"./fo.js": 257,
-		"./fr": 258,
-		"./fr-ca": 259,
-		"./fr-ca.js": 259,
-		"./fr.js": 258,
-		"./fy": 260,
-		"./fy.js": 260,
-		"./gl": 261,
-		"./gl.js": 261,
-		"./he": 262,
-		"./he.js": 262,
-		"./hi": 263,
-		"./hi.js": 263,
-		"./hr": 264,
-		"./hr.js": 264,
-		"./hu": 265,
-		"./hu.js": 265,
-		"./hy-am": 266,
-		"./hy-am.js": 266,
-		"./id": 267,
-		"./id.js": 267,
-		"./is": 268,
-		"./is.js": 268,
-		"./it": 269,
-		"./it.js": 269,
-		"./ja": 270,
-		"./ja.js": 270,
-		"./jv": 271,
-		"./jv.js": 271,
-		"./ka": 272,
-		"./ka.js": 272,
-		"./km": 273,
-		"./km.js": 273,
-		"./ko": 274,
-		"./ko.js": 274,
-		"./lb": 275,
-		"./lb.js": 275,
-		"./lt": 276,
-		"./lt.js": 276,
-		"./lv": 277,
-		"./lv.js": 277,
-		"./me": 278,
-		"./me.js": 278,
-		"./mk": 279,
-		"./mk.js": 279,
-		"./ml": 280,
-		"./ml.js": 280,
-		"./mr": 281,
-		"./mr.js": 281,
-		"./ms-my": 282,
-		"./ms-my.js": 282,
-		"./my": 283,
-		"./my.js": 283,
-		"./nb": 284,
-		"./nb.js": 284,
-		"./ne": 285,
-		"./ne.js": 285,
-		"./nl": 286,
-		"./nl.js": 286,
-		"./nn": 287,
-		"./nn.js": 287,
-		"./pl": 288,
-		"./pl.js": 288,
-		"./pt": 289,
-		"./pt-br": 290,
-		"./pt-br.js": 290,
-		"./pt.js": 289,
-		"./ro": 291,
-		"./ro.js": 291,
-		"./ru": 292,
-		"./ru.js": 292,
-		"./si": 293,
-		"./si.js": 293,
-		"./sk": 294,
-		"./sk.js": 294,
-		"./sl": 295,
-		"./sl.js": 295,
-		"./sq": 296,
-		"./sq.js": 296,
-		"./sr": 297,
-		"./sr-cyrl": 298,
-		"./sr-cyrl.js": 298,
-		"./sr.js": 297,
-		"./sv": 299,
-		"./sv.js": 299,
-		"./ta": 300,
-		"./ta.js": 300,
-		"./th": 301,
-		"./th.js": 301,
-		"./tl-ph": 302,
-		"./tl-ph.js": 302,
-		"./tr": 303,
-		"./tr.js": 303,
-		"./tzm": 304,
-		"./tzm-latn": 305,
-		"./tzm-latn.js": 305,
-		"./tzm.js": 304,
-		"./uk": 306,
-		"./uk.js": 306,
-		"./uz": 307,
-		"./uz.js": 307,
-		"./vi": 308,
-		"./vi.js": 308,
-		"./zh-cn": 309,
-		"./zh-cn.js": 309,
-		"./zh-tw": 310,
-		"./zh-tw.js": 310
+		"./af": 229,
+		"./af.js": 229,
+		"./ar": 230,
+		"./ar-ma": 231,
+		"./ar-ma.js": 231,
+		"./ar-sa": 232,
+		"./ar-sa.js": 232,
+		"./ar-tn": 233,
+		"./ar-tn.js": 233,
+		"./ar.js": 230,
+		"./az": 234,
+		"./az.js": 234,
+		"./be": 235,
+		"./be.js": 235,
+		"./bg": 236,
+		"./bg.js": 236,
+		"./bn": 237,
+		"./bn.js": 237,
+		"./bo": 238,
+		"./bo.js": 238,
+		"./br": 239,
+		"./br.js": 239,
+		"./bs": 240,
+		"./bs.js": 240,
+		"./ca": 241,
+		"./ca.js": 241,
+		"./cs": 242,
+		"./cs.js": 242,
+		"./cv": 243,
+		"./cv.js": 243,
+		"./cy": 244,
+		"./cy.js": 244,
+		"./da": 245,
+		"./da.js": 245,
+		"./de": 246,
+		"./de-at": 247,
+		"./de-at.js": 247,
+		"./de.js": 246,
+		"./el": 248,
+		"./el.js": 248,
+		"./en-au": 249,
+		"./en-au.js": 249,
+		"./en-ca": 250,
+		"./en-ca.js": 250,
+		"./en-gb": 251,
+		"./en-gb.js": 251,
+		"./eo": 252,
+		"./eo.js": 252,
+		"./es": 253,
+		"./es.js": 253,
+		"./et": 254,
+		"./et.js": 254,
+		"./eu": 255,
+		"./eu.js": 255,
+		"./fa": 256,
+		"./fa.js": 256,
+		"./fi": 257,
+		"./fi.js": 257,
+		"./fo": 258,
+		"./fo.js": 258,
+		"./fr": 259,
+		"./fr-ca": 260,
+		"./fr-ca.js": 260,
+		"./fr.js": 259,
+		"./fy": 261,
+		"./fy.js": 261,
+		"./gl": 262,
+		"./gl.js": 262,
+		"./he": 263,
+		"./he.js": 263,
+		"./hi": 264,
+		"./hi.js": 264,
+		"./hr": 265,
+		"./hr.js": 265,
+		"./hu": 266,
+		"./hu.js": 266,
+		"./hy-am": 267,
+		"./hy-am.js": 267,
+		"./id": 268,
+		"./id.js": 268,
+		"./is": 269,
+		"./is.js": 269,
+		"./it": 270,
+		"./it.js": 270,
+		"./ja": 271,
+		"./ja.js": 271,
+		"./jv": 272,
+		"./jv.js": 272,
+		"./ka": 273,
+		"./ka.js": 273,
+		"./km": 274,
+		"./km.js": 274,
+		"./ko": 275,
+		"./ko.js": 275,
+		"./lb": 276,
+		"./lb.js": 276,
+		"./lt": 277,
+		"./lt.js": 277,
+		"./lv": 278,
+		"./lv.js": 278,
+		"./me": 279,
+		"./me.js": 279,
+		"./mk": 280,
+		"./mk.js": 280,
+		"./ml": 281,
+		"./ml.js": 281,
+		"./mr": 282,
+		"./mr.js": 282,
+		"./ms-my": 283,
+		"./ms-my.js": 283,
+		"./my": 284,
+		"./my.js": 284,
+		"./nb": 285,
+		"./nb.js": 285,
+		"./ne": 286,
+		"./ne.js": 286,
+		"./nl": 287,
+		"./nl.js": 287,
+		"./nn": 288,
+		"./nn.js": 288,
+		"./pl": 289,
+		"./pl.js": 289,
+		"./pt": 290,
+		"./pt-br": 291,
+		"./pt-br.js": 291,
+		"./pt.js": 290,
+		"./ro": 292,
+		"./ro.js": 292,
+		"./ru": 293,
+		"./ru.js": 293,
+		"./si": 294,
+		"./si.js": 294,
+		"./sk": 295,
+		"./sk.js": 295,
+		"./sl": 296,
+		"./sl.js": 296,
+		"./sq": 297,
+		"./sq.js": 297,
+		"./sr": 298,
+		"./sr-cyrl": 299,
+		"./sr-cyrl.js": 299,
+		"./sr.js": 298,
+		"./sv": 300,
+		"./sv.js": 300,
+		"./ta": 301,
+		"./ta.js": 301,
+		"./th": 302,
+		"./th.js": 302,
+		"./tl-ph": 303,
+		"./tl-ph.js": 303,
+		"./tr": 304,
+		"./tr.js": 304,
+		"./tzm": 305,
+		"./tzm-latn": 306,
+		"./tzm-latn.js": 306,
+		"./tzm.js": 305,
+		"./uk": 307,
+		"./uk.js": 307,
+		"./uz": 308,
+		"./uz.js": 308,
+		"./vi": 309,
+		"./vi.js": 309,
+		"./zh-cn": 310,
+		"./zh-cn.js": 310,
+		"./zh-tw": 311,
+		"./zh-tw.js": 311
 	};
 	function webpackContext(req) {
 		return __webpack_require__(webpackContextResolve(req));
@@ -52996,11 +53064,11 @@
 	};
 	webpackContext.resolve = webpackContextResolve;
 	module.exports = webpackContext;
-	webpackContext.id = 227;
+	webpackContext.id = 228;
 
 
 /***/ },
-/* 228 */
+/* 229 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -53008,7 +53076,7 @@
 	//! author : Werner Mollentze : https://github.com/wernerm
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -53077,7 +53145,7 @@
 	}));
 
 /***/ },
-/* 229 */
+/* 230 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -53087,7 +53155,7 @@
 	//! Native plural forms: forabi https://github.com/forabi
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -53217,7 +53285,7 @@
 	}));
 
 /***/ },
-/* 230 */
+/* 231 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -53226,7 +53294,7 @@
 	//! author : Abdel Said : https://github.com/abdelsaid
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -53280,7 +53348,7 @@
 	}));
 
 /***/ },
-/* 231 */
+/* 232 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -53288,7 +53356,7 @@
 	//! author : Suhail Alkowaileet : https://github.com/xsoh
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -53387,14 +53455,14 @@
 	}));
 
 /***/ },
-/* 232 */
+/* 233 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
 	//! locale  : Tunisian Arabic (ar-tn)
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -53448,7 +53516,7 @@
 	}));
 
 /***/ },
-/* 233 */
+/* 234 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -53456,7 +53524,7 @@
 	//! author : topchiyev : https://github.com/topchiyev
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -53556,7 +53624,7 @@
 	}));
 
 /***/ },
-/* 234 */
+/* 235 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -53566,7 +53634,7 @@
 	//! Author : Menelion Elensúle : https://github.com/Oire
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -53707,7 +53775,7 @@
 	}));
 
 /***/ },
-/* 235 */
+/* 236 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -53715,7 +53783,7 @@
 	//! author : Krasen Borisov : https://github.com/kraz
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -53801,7 +53869,7 @@
 	}));
 
 /***/ },
-/* 236 */
+/* 237 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -53809,7 +53877,7 @@
 	//! author : Kaushik Gandhi : https://github.com/kaushikgandhi
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -53918,7 +53986,7 @@
 	}));
 
 /***/ },
-/* 237 */
+/* 238 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -53926,7 +53994,7 @@
 	//! author : Thupten N. Chakrishar : https://github.com/vajradog
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -54032,7 +54100,7 @@
 	}));
 
 /***/ },
-/* 238 */
+/* 239 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -54040,7 +54108,7 @@
 	//! author : Jean-Baptiste Le Duigou : https://github.com/jbleduigou
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -54143,7 +54211,7 @@
 	}));
 
 /***/ },
-/* 239 */
+/* 240 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -54152,7 +54220,7 @@
 	//! based on (hr) translation by Bojan Marković
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -54288,7 +54356,7 @@
 	}));
 
 /***/ },
-/* 240 */
+/* 241 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -54296,7 +54364,7 @@
 	//! author : Juan G. Hurtado : https://github.com/juanghurtado
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -54371,7 +54439,7 @@
 	}));
 
 /***/ },
-/* 241 */
+/* 242 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -54379,7 +54447,7 @@
 	//! author : petrbela : https://github.com/petrbela
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -54532,7 +54600,7 @@
 	}));
 
 /***/ },
-/* 242 */
+/* 243 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -54540,7 +54608,7 @@
 	//! author : Anatoly Mironov : https://github.com/mirontoli
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -54599,7 +54667,7 @@
 	}));
 
 /***/ },
-/* 243 */
+/* 244 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -54607,7 +54675,7 @@
 	//! author : Robert Allen
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -54682,7 +54750,7 @@
 	}));
 
 /***/ },
-/* 244 */
+/* 245 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -54690,7 +54758,7 @@
 	//! author : Ulrik Nielsen : https://github.com/mrbase
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -54746,7 +54814,7 @@
 	}));
 
 /***/ },
-/* 245 */
+/* 246 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -54755,7 +54823,7 @@
 	//! author: Menelion Elensúle: https://github.com/Oire
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -54825,7 +54893,7 @@
 	}));
 
 /***/ },
-/* 246 */
+/* 247 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -54835,7 +54903,7 @@
 	//! author : Martin Groller : https://github.com/MadMG
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -54905,7 +54973,7 @@
 	}));
 
 /***/ },
-/* 247 */
+/* 248 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -54913,7 +54981,7 @@
 	//! author : Aggelos Karalias : https://github.com/mehiel
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -55003,14 +55071,14 @@
 	}));
 
 /***/ },
-/* 248 */
+/* 249 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
 	//! locale : australian english (en-au)
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -55073,7 +55141,7 @@
 	}));
 
 /***/ },
-/* 249 */
+/* 250 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -55081,7 +55149,7 @@
 	//! author : Jonathan Abourbih : https://github.com/jonbca
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -55140,7 +55208,7 @@
 	}));
 
 /***/ },
-/* 250 */
+/* 251 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -55148,7 +55216,7 @@
 	//! author : Chris Gedrim : https://github.com/chrisgedrim
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -55211,7 +55279,7 @@
 	}));
 
 /***/ },
-/* 251 */
+/* 252 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -55221,7 +55289,7 @@
 	//!          Se ne, bonvolu korekti kaj avizi min por ke mi povas lerni!
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -55288,7 +55356,7 @@
 	}));
 
 /***/ },
-/* 252 */
+/* 253 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -55296,7 +55364,7 @@
 	//! author : Julio Napurí : https://github.com/julionc
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -55371,7 +55439,7 @@
 	}));
 
 /***/ },
-/* 253 */
+/* 254 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -55380,7 +55448,7 @@
 	//! improvements : Illimar Tambek : https://github.com/ragulka
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -55455,7 +55523,7 @@
 	}));
 
 /***/ },
-/* 254 */
+/* 255 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -55463,7 +55531,7 @@
 	//! author : Eneko Illarramendi : https://github.com/eillarra
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -55523,7 +55591,7 @@
 	}));
 
 /***/ },
-/* 255 */
+/* 256 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -55531,7 +55599,7 @@
 	//! author : Ebrahim Byagowi : https://github.com/ebraminio
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -55632,7 +55700,7 @@
 	}));
 
 /***/ },
-/* 256 */
+/* 257 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -55640,7 +55708,7 @@
 	//! author : Tarmo Aidantausta : https://github.com/bleadof
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -55743,7 +55811,7 @@
 	}));
 
 /***/ },
-/* 257 */
+/* 258 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -55751,7 +55819,7 @@
 	//! author : Ragnar Johannesen : https://github.com/ragnar123
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -55807,7 +55875,7 @@
 	}));
 
 /***/ },
-/* 258 */
+/* 259 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -55815,7 +55883,7 @@
 	//! author : John Fischer : https://github.com/jfroffice
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -55873,7 +55941,7 @@
 	}));
 
 /***/ },
-/* 259 */
+/* 260 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -55881,7 +55949,7 @@
 	//! author : Jonathan Abourbih : https://github.com/jonbca
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -55935,7 +56003,7 @@
 	}));
 
 /***/ },
-/* 260 */
+/* 261 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -55943,7 +56011,7 @@
 	//! author : Robin van der Vliet : https://github.com/robin0van0der0v
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -56010,7 +56078,7 @@
 	}));
 
 /***/ },
-/* 261 */
+/* 262 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -56018,7 +56086,7 @@
 	//! author : Juan G. Hurtado : https://github.com/juanghurtado
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -56089,7 +56157,7 @@
 	}));
 
 /***/ },
-/* 262 */
+/* 263 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -56099,7 +56167,7 @@
 	//! author : Tal Ater : https://github.com/TalAter
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -56175,7 +56243,7 @@
 	}));
 
 /***/ },
-/* 263 */
+/* 264 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -56183,7 +56251,7 @@
 	//! author : Mayank Singhal : https://github.com/mayanksinghal
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -56302,7 +56370,7 @@
 	}));
 
 /***/ },
-/* 264 */
+/* 265 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -56310,7 +56378,7 @@
 	//! author : Bojan Marković : https://github.com/bmarkovic
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -56446,7 +56514,7 @@
 	}));
 
 /***/ },
-/* 265 */
+/* 266 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -56454,7 +56522,7 @@
 	//! author : Adam Brunner : https://github.com/adambrunner
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -56559,7 +56627,7 @@
 	}));
 
 /***/ },
-/* 266 */
+/* 267 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -56567,7 +56635,7 @@
 	//! author : Armendarabyan : https://github.com/armendarabyan
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -56674,7 +56742,7 @@
 	}));
 
 /***/ },
-/* 267 */
+/* 268 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -56683,7 +56751,7 @@
 	//! reference: http://id.wikisource.org/wiki/Pedoman_Umum_Ejaan_Bahasa_Indonesia_yang_Disempurnakan
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -56761,7 +56829,7 @@
 	}));
 
 /***/ },
-/* 268 */
+/* 269 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -56769,7 +56837,7 @@
 	//! author : Hinrik Örn Sigurðsson : https://github.com/hinrik
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -56892,7 +56960,7 @@
 	}));
 
 /***/ },
-/* 269 */
+/* 270 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -56901,7 +56969,7 @@
 	//! author: Mattia Larentis: https://github.com/nostalgiaz
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -56966,7 +57034,7 @@
 	}));
 
 /***/ },
-/* 270 */
+/* 271 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -56974,7 +57042,7 @@
 	//! author : LI Long : https://github.com/baryon
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -57035,7 +57103,7 @@
 	}));
 
 /***/ },
-/* 271 */
+/* 272 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -57044,7 +57112,7 @@
 	//! reference: http://jv.wikipedia.org/wiki/Basa_Jawa
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -57122,7 +57190,7 @@
 	}));
 
 /***/ },
-/* 272 */
+/* 273 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -57130,7 +57198,7 @@
 	//! author : Irakli Janiashvili : https://github.com/irakli-janiashvili
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -57229,7 +57297,7 @@
 	}));
 
 /***/ },
-/* 273 */
+/* 274 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -57237,7 +57305,7 @@
 	//! author : Kruy Vanna : https://github.com/kruyvanna
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -57291,7 +57359,7 @@
 	}));
 
 /***/ },
-/* 274 */
+/* 275 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -57303,7 +57371,7 @@
 	//! - Jeeeyul Lee <jeeeyul@gmail.com>
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -57363,7 +57431,7 @@
 	}));
 
 /***/ },
-/* 275 */
+/* 276 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -57371,7 +57439,7 @@
 	//! author : mweimerskirch : https://github.com/mweimerskirch, David Raison : https://github.com/kwisatz
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -57501,7 +57569,7 @@
 	}));
 
 /***/ },
-/* 276 */
+/* 277 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -57509,7 +57577,7 @@
 	//! author : Mindaugas Mozūras : https://github.com/mmozuras
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -57620,7 +57688,7 @@
 	}));
 
 /***/ },
-/* 277 */
+/* 278 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -57629,7 +57697,7 @@
 	//! author : Jānis Elmeris : https://github.com/JanisE
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -57720,7 +57788,7 @@
 	}));
 
 /***/ },
-/* 278 */
+/* 279 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -57728,7 +57796,7 @@
 	//! author : Miodrag Nikač <miodrag@restartit.me> : https://github.com/miodragnikac
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -57833,7 +57901,7 @@
 	}));
 
 /***/ },
-/* 279 */
+/* 280 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -57841,7 +57909,7 @@
 	//! author : Borislav Mickov : https://github.com/B0k0
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -57927,7 +57995,7 @@
 	}));
 
 /***/ },
-/* 280 */
+/* 281 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -57935,7 +58003,7 @@
 	//! author : Floyd Pink : https://github.com/floydpink
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -58002,7 +58070,7 @@
 	}));
 
 /***/ },
-/* 281 */
+/* 282 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -58010,7 +58078,7 @@
 	//! author : Harshad Kale : https://github.com/kalehv
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -58127,7 +58195,7 @@
 	}));
 
 /***/ },
-/* 282 */
+/* 283 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -58135,7 +58203,7 @@
 	//! author : Weldan Jamili : https://github.com/weldan
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -58213,7 +58281,7 @@
 	}));
 
 /***/ },
-/* 283 */
+/* 284 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -58221,7 +58289,7 @@
 	//! author : Squar team, mysquar.com
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -58310,7 +58378,7 @@
 	}));
 
 /***/ },
-/* 284 */
+/* 285 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -58319,7 +58387,7 @@
 	//!           Sigurd Gartmann : https://github.com/sigurdga
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -58375,7 +58443,7 @@
 	}));
 
 /***/ },
-/* 285 */
+/* 286 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -58383,7 +58451,7 @@
 	//! author : suvash : https://github.com/suvash
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -58502,7 +58570,7 @@
 	}));
 
 /***/ },
-/* 286 */
+/* 287 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -58510,7 +58578,7 @@
 	//! author : Joris Röling : https://github.com/jjupiter
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -58577,7 +58645,7 @@
 	}));
 
 /***/ },
-/* 287 */
+/* 288 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -58585,7 +58653,7 @@
 	//! author : https://github.com/mechuwind
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -58641,7 +58709,7 @@
 	}));
 
 /***/ },
-/* 288 */
+/* 289 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -58649,7 +58717,7 @@
 	//! author : Rafal Hirsz : https://github.com/evoL
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -58750,7 +58818,7 @@
 	}));
 
 /***/ },
-/* 289 */
+/* 290 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -58758,7 +58826,7 @@
 	//! author : Jefferson : https://github.com/jalex79
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -58818,7 +58886,7 @@
 	}));
 
 /***/ },
-/* 290 */
+/* 291 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -58826,7 +58894,7 @@
 	//! author : Caio Ribeiro Pereira : https://github.com/caio-ribeiro-pereira
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -58882,7 +58950,7 @@
 	}));
 
 /***/ },
-/* 291 */
+/* 292 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -58891,7 +58959,7 @@
 	//! author : Valentin Agachi : https://github.com/avaly
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -58960,7 +59028,7 @@
 	}));
 
 /***/ },
-/* 292 */
+/* 293 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -58969,7 +59037,7 @@
 	//! Author : Menelion Elensúle : https://github.com/Oire
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -59128,7 +59196,7 @@
 	}));
 
 /***/ },
-/* 293 */
+/* 294 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -59136,7 +59204,7 @@
 	//! author : Sampath Sitinamaluwa : https://github.com/sampathsris
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -59197,7 +59265,7 @@
 	}));
 
 /***/ },
-/* 294 */
+/* 295 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -59206,7 +59274,7 @@
 	//! based on work of petrbela : https://github.com/petrbela
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -59359,7 +59427,7 @@
 	}));
 
 /***/ },
-/* 295 */
+/* 296 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -59367,7 +59435,7 @@
 	//! author : Robert Sedovšek : https://github.com/sedovsek
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -59523,7 +59591,7 @@
 	}));
 
 /***/ },
-/* 296 */
+/* 297 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -59533,7 +59601,7 @@
 	//! author : Oerd Cukalla : https://github.com/oerd (fixes)
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -59596,7 +59664,7 @@
 	}));
 
 /***/ },
-/* 297 */
+/* 298 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -59604,7 +59672,7 @@
 	//! author : Milan Janačković<milanjanackovic@gmail.com> : https://github.com/milan-j
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -59708,7 +59776,7 @@
 	}));
 
 /***/ },
-/* 298 */
+/* 299 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -59716,7 +59784,7 @@
 	//! author : Milan Janačković<milanjanackovic@gmail.com> : https://github.com/milan-j
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -59820,7 +59888,7 @@
 	}));
 
 /***/ },
-/* 299 */
+/* 300 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -59828,7 +59896,7 @@
 	//! author : Jens Alm : https://github.com/ulmus
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -59891,7 +59959,7 @@
 	}));
 
 /***/ },
-/* 300 */
+/* 301 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -59899,7 +59967,7 @@
 	//! author : Arjunkumar Krishnamoorthy : https://github.com/tk120404
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -59990,7 +60058,7 @@
 	}));
 
 /***/ },
-/* 301 */
+/* 302 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -59998,7 +60066,7 @@
 	//! author : Kridsada Thanabulpong : https://github.com/sirn
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -60059,7 +60127,7 @@
 	}));
 
 /***/ },
-/* 302 */
+/* 303 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -60067,7 +60135,7 @@
 	//! author : Dan Hagman
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -60125,7 +60193,7 @@
 	}));
 
 /***/ },
-/* 303 */
+/* 304 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -60134,7 +60202,7 @@
 	//!           Burak Yiğit Kaya: https://github.com/BYK
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -60219,7 +60287,7 @@
 	}));
 
 /***/ },
-/* 304 */
+/* 305 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -60227,7 +60295,7 @@
 	//! author : Abdel Said : https://github.com/abdelsaid
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -60281,7 +60349,7 @@
 	}));
 
 /***/ },
-/* 305 */
+/* 306 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -60289,7 +60357,7 @@
 	//! author : Abdel Said : https://github.com/abdelsaid
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -60343,7 +60411,7 @@
 	}));
 
 /***/ },
-/* 306 */
+/* 307 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -60352,7 +60420,7 @@
 	//! Author : Menelion Elensúle : https://github.com/Oire
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -60500,7 +60568,7 @@
 	}));
 
 /***/ },
-/* 307 */
+/* 308 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -60508,7 +60576,7 @@
 	//! author : Sardor Muminov : https://github.com/muminoff
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -60562,7 +60630,7 @@
 	}));
 
 /***/ },
-/* 308 */
+/* 309 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -60570,7 +60638,7 @@
 	//! author : Bang Nguyen : https://github.com/bangnk
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -60632,7 +60700,7 @@
 	}));
 
 /***/ },
-/* 309 */
+/* 310 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -60641,7 +60709,7 @@
 	//! author : Zeno Zeng : https://github.com/zenozeng
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -60763,7 +60831,7 @@
 	}));
 
 /***/ },
-/* 310 */
+/* 311 */
 /***/ function(module, exports, __webpack_require__) {
 
 	//! moment.js locale configuration
@@ -60771,7 +60839,7 @@
 	//! author : Ben : https://github.com/ben-lin
 
 	(function (global, factory) {
-	   true ? factory(__webpack_require__(226)) :
+	   true ? factory(__webpack_require__(227)) :
 	   typeof define === 'function' && define.amd ? define(['moment'], factory) :
 	   factory(global.moment)
 	}(this, function (moment) { 'use strict';
@@ -60868,15 +60936,15 @@
 	}));
 
 /***/ },
-/* 311 */
+/* 312 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 
-	var classNames = __webpack_require__(190);
+	var classNames = __webpack_require__(191);
 	var React = __webpack_require__(4);
 
-	var NavTabsComponent = __webpack_require__(312);
+	var NavTabsComponent = __webpack_require__(313);
 
 	module.exports = React.createClass({
 	  displayName: "TogglableTabsComponent",
@@ -60924,12 +60992,12 @@
 	});
 
 /***/ },
-/* 312 */
+/* 313 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 
-	var classNames = __webpack_require__(190);
+	var classNames = __webpack_require__(191);
 	var React = __webpack_require__(4);
 
 	var NavTabsComponent = React.createClass({
@@ -60984,40 +61052,13 @@
 	module.exports = NavTabsComponent;
 
 /***/ },
-/* 313 */
-/***/ function(module, exports) {
-
-	/* WEBPACK VAR INJECTION */(function(global) {"use strict";
-
-	var util = {
-	  alert: function alert() {
-	    /*eslint-disable no-alert */
-	    return global.alert.apply(null, arguments);
-	    /*eslint-enable no-alert */
-	  },
-	  confirm: function confirm() {
-	    /*eslint-disable no-alert */
-	    return global.confirm.apply(null, arguments);
-	    /*eslint-enable no-alert */
-	  },
-	  prompt: function prompt() {
-	    /*eslint-disable no-alert */
-	    return global.prompt.apply(null, arguments);
-	    /*eslint-enable no-alert */
-	  }
-	};
-
-	module.exports = util;
-	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
-
-/***/ },
 /* 314 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 
-	var classNames = __webpack_require__(190);
-	var lazy = __webpack_require__(197);
+	var classNames = __webpack_require__(191);
+	var lazy = __webpack_require__(198);
 	var React = __webpack_require__(4);
 
 	var States = __webpack_require__(181);
@@ -61243,13 +61284,13 @@
 
 	"use strict";
 
-	var classNames = __webpack_require__(190);
-	var lazy = __webpack_require__(197);
+	var classNames = __webpack_require__(191);
+	var lazy = __webpack_require__(198);
 
 	var React = __webpack_require__(4);
 
 	var DeploymentActions = __webpack_require__(316);
-	var util = __webpack_require__(313);
+	var util = __webpack_require__(188);
 
 	var DeploymentComponent = React.createClass({
 	  displayName: "DeploymentComponent",
@@ -61414,7 +61455,7 @@
 	var oboeWrapper = __webpack_require__(317);
 
 	var config = __webpack_require__(178);
-	var AppDispatcher = __webpack_require__(200);
+	var AppDispatcher = __webpack_require__(201);
 	var DeploymentEvents = __webpack_require__(319);
 
 	var DeploymentActions = {
@@ -64280,10 +64321,10 @@
 
 	"use strict";
 
-	var EventEmitter = __webpack_require__(196).EventEmitter;
-	var lazy = __webpack_require__(197);
+	var EventEmitter = __webpack_require__(197).EventEmitter;
+	var lazy = __webpack_require__(198);
 
-	var AppDispatcher = __webpack_require__(200);
+	var AppDispatcher = __webpack_require__(201);
 	var DeploymentEvents = __webpack_require__(319);
 
 	function processDeployments(deployments) {
@@ -64346,14 +64387,14 @@
 
 	"use strict";
 
-	var $ = __webpack_require__(3);
 	var _ = __webpack_require__(2);
 	var React = __webpack_require__(4);
+	var util = __webpack_require__(188);
 
-	var BackboneMixin = __webpack_require__(193);
+	var BackboneMixin = __webpack_require__(194);
 	var App = __webpack_require__(183);
 	var FormGroupComponent = __webpack_require__(322);
-	var ModalComponent = __webpack_require__(210);
+	var ModalComponent = __webpack_require__(211);
 
 	function ValidationError(attribute, message) {
 	  this.attribute = attribute;
@@ -64370,8 +64411,8 @@
 
 	  getDefaultProps: function getDefaultProps() {
 	    return {
-	      onCreate: $.noop,
-	      onDestroy: $.noop
+	      onCreate: _.noop,
+	      onDestroy: _.noop
 	    };
 	  },
 
@@ -64418,7 +64459,7 @@
 	  onSubmit: function onSubmit(event) {
 	    event.preventDefault();
 
-	    var attrArray = $(event.target).serializeArray();
+	    var attrArray = util.serializeArray(event.target);
 	    var modelAttrs = {};
 
 	    for (var i = 0; i < attrArray.length; i++) {
@@ -64582,7 +64623,7 @@
 	              label: "Instances",
 	              model: model,
 	              errors: errors },
-	            React.createElement("input", { min: "1", step: "1", type: "number", required: true })
+	            React.createElement("input", { min: "0", step: "1", type: "number", required: true })
 	          ),
 	          React.createElement("hr", null),
 	          React.createElement(

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -243,8 +243,8 @@
           }
         },
         "lodash": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz"
+          "version": "3.9.3",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
         },
         "minimatch": {
           "version": "2.0.8",
@@ -1063,8 +1063,8 @@
               }
             },
             "lodash.merge": {
-              "version": "3.3.2",
-              "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
+              "version": "3.3.1",
+              "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.1.tgz",
               "dependencies": {
                 "lodash._arraycopy": {
                   "version": "3.0.0",
@@ -1093,20 +1093,20 @@
                   }
                 },
                 "lodash._getnative": {
-                  "version": "3.9.1",
-                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                  "version": "3.9.0",
+                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
                 },
                 "lodash.isarguments": {
-                  "version": "3.0.4",
-                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz"
                 },
                 "lodash.isarray": {
-                  "version": "3.0.4",
-                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz"
                 },
                 "lodash.isplainobject": {
-                  "version": "3.2.0",
-                  "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.1.0.tgz",
                   "dependencies": {
                     "lodash._basefor": {
                       "version": "3.0.2",
@@ -1119,8 +1119,8 @@
                   "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.2.tgz"
                 },
                 "lodash.keys": {
-                  "version": "3.1.2",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+                  "version": "3.1.1",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz"
                 },
                 "lodash.keysin": {
                   "version": "3.0.8",
@@ -1195,8 +1195,8 @@
           }
         },
         "lodash": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz"
+          "version": "3.9.3",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
         },
         "longest": {
           "version": "1.0.1",
@@ -1420,7 +1420,7 @@
                 },
                 "mime": {
                   "version": "1.3.4",
-                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+                  "resolved": "http://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
                 },
                 "ms": {
                   "version": "0.7.1",
@@ -2221,8 +2221,8 @@
           "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
         },
         "globals": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-8.2.0.tgz"
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-8.1.0.tgz"
         },
         "inquirer": {
           "version": "0.8.5",
@@ -2241,8 +2241,8 @@
               "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
             },
             "lodash": {
-              "version": "3.10.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz"
+              "version": "3.9.3",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
             },
             "readline2": {
               "version": "0.1.1",
@@ -2305,8 +2305,8 @@
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
               "dependencies": {
                 "lodash": {
-                  "version": "3.10.0",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz"
+                  "version": "3.9.3",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
                 },
                 "sprintf-js": {
                   "version": "1.0.2",
@@ -2407,8 +2407,8 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-2.6.3.tgz"
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-2.6.2.tgz"
     },
     "flux": {
       "version": "2.0.3",
@@ -3945,8 +3945,8 @@
               "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
             },
             "globals": {
-              "version": "8.2.0",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-8.2.0.tgz"
+              "version": "8.1.0",
+              "resolved": "https://registry.npmjs.org/globals/-/globals-8.1.0.tgz"
             },
             "inquirer": {
               "version": "0.8.5",
@@ -3965,8 +3965,8 @@
                   "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
                 },
                 "lodash": {
-                  "version": "3.10.0",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz"
+                  "version": "3.9.3",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
                 },
                 "readline2": {
                   "version": "0.1.1",
@@ -4029,8 +4029,8 @@
                   "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                   "dependencies": {
                     "lodash": {
-                      "version": "3.10.0",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz"
+                      "version": "3.9.3",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
                     },
                     "sprintf-js": {
                       "version": "1.0.2",
@@ -4217,8 +4217,8 @@
               "resolved": "https://registry.npmjs.org/indx/-/indx-0.2.3.tgz"
             },
             "lodash": {
-              "version": "3.10.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz"
+              "version": "3.9.3",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
             },
             "resolve": {
               "version": "1.1.6",
@@ -4300,7 +4300,7 @@
             },
             "mime": {
               "version": "1.3.4",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+              "resolved": "http://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
             },
             "mkdirp": {
               "version": "0.5.1",
@@ -4385,8 +4385,8 @@
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc1.tgz",
                   "dependencies": {
                     "async": {
-                      "version": "1.3.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-1.3.0.tgz"
+                      "version": "1.2.1",
+                      "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz"
                     },
                     "mime-types": {
                       "version": "2.1.2",
@@ -4983,16 +4983,16 @@
           "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
         },
         "lodash.template": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.1.tgz",
           "dependencies": {
             "lodash._basecopy": {
               "version": "3.0.1",
               "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
             },
             "lodash._basetostring": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
             },
             "lodash._basevalues": {
               "version": "3.0.0",
@@ -5007,20 +5007,20 @@
               "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
             },
             "lodash.keys": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz",
               "dependencies": {
                 "lodash._getnative": {
-                  "version": "3.9.1",
-                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                  "version": "3.9.0",
+                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
                 },
                 "lodash.isarguments": {
-                  "version": "3.0.4",
-                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz"
                 },
                 "lodash.isarray": {
-                  "version": "3.0.4",
-                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz"
                 }
               }
             },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,7 +2,7 @@
   "name": "marathon-ui",
   "version": "0.9.0",
   "npm-shrinkwrap-version": "5.4.0",
-  "node-version": "v0.10.38",
+  "node-version": "v0.12.4",
   "dependencies": {
     "babel-core": {
       "version": "5.6.15",
@@ -243,8 +243,8 @@
           }
         },
         "lodash": {
-          "version": "3.9.3",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz"
         },
         "minimatch": {
           "version": "2.0.8",
@@ -1063,8 +1063,8 @@
               }
             },
             "lodash.merge": {
-              "version": "3.3.1",
-              "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.1.tgz",
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
               "dependencies": {
                 "lodash._arraycopy": {
                   "version": "3.0.0",
@@ -1093,20 +1093,20 @@
                   }
                 },
                 "lodash._getnative": {
-                  "version": "3.9.0",
-                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
+                  "version": "3.9.1",
+                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                 },
                 "lodash.isarguments": {
-                  "version": "3.0.3",
-                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz"
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
                 },
                 "lodash.isarray": {
-                  "version": "3.0.3",
-                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz"
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                 },
                 "lodash.isplainobject": {
-                  "version": "3.1.0",
-                  "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.1.0.tgz",
+                  "version": "3.2.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
                   "dependencies": {
                     "lodash._basefor": {
                       "version": "3.0.2",
@@ -1119,8 +1119,8 @@
                   "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.2.tgz"
                 },
                 "lodash.keys": {
-                  "version": "3.1.1",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz"
+                  "version": "3.1.2",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
                 },
                 "lodash.keysin": {
                   "version": "3.0.8",
@@ -1195,8 +1195,8 @@
           }
         },
         "lodash": {
-          "version": "3.9.3",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz"
         },
         "longest": {
           "version": "1.0.1",
@@ -1420,7 +1420,7 @@
                 },
                 "mime": {
                   "version": "1.3.4",
-                  "resolved": "http://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
                 },
                 "ms": {
                   "version": "0.7.1",
@@ -2221,8 +2221,8 @@
           "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
         },
         "globals": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-8.1.0.tgz"
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-8.2.0.tgz"
         },
         "inquirer": {
           "version": "0.8.5",
@@ -2241,8 +2241,8 @@
               "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
             },
             "lodash": {
-              "version": "3.9.3",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
+              "version": "3.10.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz"
             },
             "readline2": {
               "version": "0.1.1",
@@ -2305,8 +2305,8 @@
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
               "dependencies": {
                 "lodash": {
-                  "version": "3.9.3",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
+                  "version": "3.10.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz"
                 },
                 "sprintf-js": {
                   "version": "1.0.2",
@@ -2407,8 +2407,8 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-2.6.2.tgz"
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-2.6.3.tgz"
     },
     "flux": {
       "version": "2.0.3",
@@ -3945,8 +3945,8 @@
               "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
             },
             "globals": {
-              "version": "8.1.0",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-8.1.0.tgz"
+              "version": "8.2.0",
+              "resolved": "https://registry.npmjs.org/globals/-/globals-8.2.0.tgz"
             },
             "inquirer": {
               "version": "0.8.5",
@@ -3965,8 +3965,8 @@
                   "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
                 },
                 "lodash": {
-                  "version": "3.9.3",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
+                  "version": "3.10.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz"
                 },
                 "readline2": {
                   "version": "0.1.1",
@@ -4029,8 +4029,8 @@
                   "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                   "dependencies": {
                     "lodash": {
-                      "version": "3.9.3",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
+                      "version": "3.10.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz"
                     },
                     "sprintf-js": {
                       "version": "1.0.2",
@@ -4217,8 +4217,8 @@
               "resolved": "https://registry.npmjs.org/indx/-/indx-0.2.3.tgz"
             },
             "lodash": {
-              "version": "3.9.3",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
+              "version": "3.10.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz"
             },
             "resolve": {
               "version": "1.1.6",
@@ -4300,7 +4300,7 @@
             },
             "mime": {
               "version": "1.3.4",
-              "resolved": "http://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
             },
             "mkdirp": {
               "version": "0.5.1",
@@ -4385,8 +4385,8 @@
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc1.tgz",
                   "dependencies": {
                     "async": {
-                      "version": "1.2.1",
-                      "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz"
+                      "version": "1.3.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-1.3.0.tgz"
                     },
                     "mime-types": {
                       "version": "2.1.2",
@@ -4983,16 +4983,16 @@
           "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
         },
         "lodash.template": {
-          "version": "3.6.1",
-          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.1.tgz",
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
           "dependencies": {
             "lodash._basecopy": {
               "version": "3.0.1",
               "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
             },
             "lodash._basetostring": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
             },
             "lodash._basevalues": {
               "version": "3.0.0",
@@ -5007,20 +5007,20 @@
               "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
             },
             "lodash.keys": {
-              "version": "3.1.1",
-              "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz",
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
               "dependencies": {
                 "lodash._getnative": {
-                  "version": "3.9.0",
-                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
+                  "version": "3.9.1",
+                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                 },
                 "lodash.isarguments": {
-                  "version": "3.0.3",
-                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz"
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
                 },
                 "lodash.isarray": {
-                  "version": "3.0.3",
-                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz"
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                 }
               }
             },
@@ -5135,6 +5135,10 @@
           }
         }
       }
+    },
+    "jquery": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.4.tgz"
     },
     "lazy.js": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "backbone": "^1.1.2",
     "classnames": "^2.1.2",
     "flux": "^2.0.3",
+    "jquery": "^2.1.4",
     "lazy.js": "^0.4.0",
     "moment": "^2.9.0",
     "mousetrap": "^1.4.6",


### PR DESCRIPTION
Backbone requires jQuery and if jQuery isn't present, we get build errors.
This commit temporarily reintroduces jQuery until we can remove
Backbone completely.