### PR TITLE
Move qajax from devDependencies into dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "moment": "^2.9.0",
     "mousetrap": "^1.4.6",
     "oboe": "^2.1.2",
+    "qajax": "^1.3.0",
     "react": "^0.13.2",
     "react-tools": "^0.13.2",
     "underscore": "^1.7.0"
@@ -44,7 +45,6 @@
     "gulp-util": "^3.0.5",
     "mocha": "^2.1.0",
     "npm-shrinkwrap": "^5.4.0",
-    "qajax": "^1.3.0",
     "sinon": "^1.12.2",
     "source-map-loader": "^0.1.5",
     "transform-loader": "^0.2.2",


### PR DESCRIPTION
qajax was in the wrong place in `package.json`. We didn't notice this because of shrinkwrap, which does not discriminate between the dependency hashes. 

OT: the funky branch name is me trying out some waffle.io linking functionality