### PR TITLE
Declare propTypes for children prop

### DIFF
--- a/src/js/components/PagedContentComponent.jsx
+++ b/src/js/components/PagedContentComponent.jsx
@@ -4,6 +4,7 @@ module.exports = React.createClass({
     displayName: "PagedContentComponent",
 
     propTypes: {
+      children: React.PropTypes.node,
       className: React.PropTypes.string,
       currentPage: React.PropTypes.number.isRequired,
       itemsPerPage: React.PropTypes.number,


### PR DESCRIPTION
This removes the eslint warning due to the missing propType declaration.
For info see:
https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md