### PR TITLE
Children PropTypes should be node, not object

### DIFF
--- a/src/js/components/FormGroupComponent.jsx
+++ b/src/js/components/FormGroupComponent.jsx
@@ -5,7 +5,7 @@ var FormGroupComponent = React.createClass({
 
   propTypes: {
     attribute: React.PropTypes.string,
-    children: React.PropTypes.object.isRequired,
+    children: React.PropTypes.node.isRequired,
     errors: React.PropTypes.array,
     help: React.PropTypes.string,
     label: React.PropTypes.string,


### PR DESCRIPTION
'node' accepts anything that can be rendered: numbers, strings, elements or
an array containing these types.