### PR TITLE
Refactor form components: State vs Props

### DIFF
--- a/src/js/components/FormGroupComponent.jsx
+++ b/src/js/components/FormGroupComponent.jsx
@@ -15,17 +15,20 @@ var FormGroupComponent = React.createClass({
 
   getInitialState: function () {
     return {
+      model: this.props.model,
       validationError: null
     };
   },
 
   onInputChange: function (event) {
     var props = this.props;
-
-    props.model[event.target.name] = event.target.value;
+    var model = React.addons.update(this.state.model, {
+      [event.target.name]: {$set: event.target.value}
+    });
 
     this.setState({
-      validationError: props.validator.validate(props.model)
+      model: model,
+      validationError: props.validator.validate(model)
     });
   },
 
@@ -62,7 +65,7 @@ var FormGroupComponent = React.createClass({
         id: fieldId,
         name: attribute,
         onChange: this.onInputChange,
-        value: this.props.model[attribute]
+        value: this.state.model[attribute]
       }
     );
 

--- a/src/js/components/NewAppModalComponent.jsx
+++ b/src/js/components/NewAppModalComponent.jsx
@@ -16,16 +16,11 @@ var NewAppModalComponent = React.createClass({
   displayName: "NewAppModalComponent",
 
   propTypes: {
+    attributes: React.PropTypes.object,
     onDestroy: React.PropTypes.func
   },
 
   getDefaultProps: function () {
-    return {
-      onDestroy: util.noop
-    };
-  },
-
-  getInitialState: function () {
     return {
       attributes: lazy(appScheme).extend({
         cpus: 0.1,
@@ -33,6 +28,12 @@ var NewAppModalComponent = React.createClass({
         mem: 16.0,
         disk: 0.0
       }).value(),
+      onDestroy: util.noop
+    };
+  },
+
+  getInitialState: function () {
+    return {
       errors: []
     };
   },
@@ -157,7 +158,7 @@ var NewAppModalComponent = React.createClass({
       modelAttrs.instances = parseInt(modelAttrs.instances, 10);
     }
 
-    var model = _.extend(this.state.attributes, modelAttrs);
+    var model = _.extend(this.props.attributes, modelAttrs);
 
     // Create app if validate() returns no errors
     if (appValidator.validate(model) == null) {
@@ -166,7 +167,7 @@ var NewAppModalComponent = React.createClass({
   },
 
   render: function () {
-    var model = this.state.attributes;
+    var model = this.props.attributes;
     var errors = this.state.errors;
 
     var generalErrors = errors.filter(function (e) {


### PR DESCRIPTION
Modifying properties directly can have side effects. This commit
treats the this.props.model as the initial value for this.state.model so
that the FormGroupComponents can link the form fields to an owned
internal state rather than having to rely on the parent component.

https://github.com/mesosphere/marathon/issues/1735