### PR TITLE
Extract complicated switch logic to own method, fix return type

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,9 @@
   "ecmaFeatures": {
     "jsx": true,
     "arrowFunctions": true,
-    "objectLiteralComputedProperties": true
+    "objectLiteralComputedProperties": true,
+    "templateStrings": true,
+    "defaultParams": true
   },
 
   "env": {

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -182,6 +182,22 @@ var AppPageComponent = React.createClass({
     }
   },
 
+  getUnhealthyTaskMessage: function (healthCheckResults = []) {
+    return healthCheckResults.map((hc, index) => {
+      if (hc && !hc.alive) {
+        var failedCheck = this.state.app.healthChecks[index];
+        return `Warning: Health check
+          '${(failedCheck.protocol ? failedCheck.protocol + " " : "")}
+          ${(this.state.app.host ? this.state.app.host : "")}
+          ${(failedCheck.path ? failedCheck.path : "")}'
+          ${(hc.lastFailureCause
+            ? " returned with status: '" + hc.lastFailureCause + "'"
+            : " failed"
+          )}.`;
+      }
+    }).join(" ");
+  },
+
   getTaskHealthMessage: function (taskId) {
     var task = AppsStore.getTask(this.props.appId, taskId);
 
@@ -189,7 +205,6 @@ var AppPageComponent = React.createClass({
       return null;
     }
 
-    var model = this.state.app;
     var msg;
 
     switch (task.healthStatus) {
@@ -197,22 +212,7 @@ var AppPageComponent = React.createClass({
         msg = "Healthy";
         break;
       case HealthStatus.UNHEALTHY:
-        var healthCheckResults = task.healthCheckResults;
-        if (healthCheckResults != null) {
-          msg = healthCheckResults.map(function (hc, index) {
-            if (hc && !hc.alive) {
-              var failedCheck = model.healthChecks[index];
-              return "Warning: Health check '" +
-                (failedCheck.protocol ? failedCheck.protocol + " " : "") +
-                (model.host ? model.host : "") +
-                (failedCheck.path ? failedCheck.path : "") + "'" +
-                (hc.lastFailureCause ?
-                  " returned with status: '" + hc.lastFailureCause + "'" :
-                  " failed") +
-                ".";
-            }
-          });
-        }
+        msg = this.getUnhealthyTaskMessage(task.healthCheckResults);
         break;
       default:
         msg = "Unknown";

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -186,14 +186,18 @@ var AppPageComponent = React.createClass({
     return healthCheckResults.map((hc, index) => {
       if (hc && !hc.alive) {
         var failedCheck = this.state.app.healthChecks[index];
-        return `Warning: Health check
-          '${(failedCheck.protocol ? failedCheck.protocol + " " : "")}
-          ${(this.state.app.host ? this.state.app.host : "")}
-          ${(failedCheck.path ? failedCheck.path : "")}'
-          ${(hc.lastFailureCause
-            ? " returned with status: '" + hc.lastFailureCause + "'"
-            : " failed"
-          )}.`;
+
+        var protocol = failedCheck.protocol
+          ? `${failedCheck.protocol} `
+          : "";
+        var host = this.state.app.host || "";
+        var path = failedCheck.path || "";
+        var lastFailureCause = hc.lastFailureCause
+          ? `returned with status: '${hc.lastFailureCause}'`
+          : "failed";
+
+        return "Warning: Health check " +
+          `'${protocol + host + path}' ${lastFailureCause}.`;
       }
     }).join(" ");
   },

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -183,8 +183,8 @@ var AppPageComponent = React.createClass({
   },
 
   getUnhealthyTaskMessage: function (healthCheckResults = []) {
-    return healthCheckResults.map((hc, index) => {
-      if (hc && !hc.alive) {
+    return healthCheckResults.map((healthCheck, index) => {
+      if (healthCheck && !healthCheck.alive) {
         var failedCheck = this.state.app.healthChecks[index];
 
         var protocol = failedCheck.protocol
@@ -192,8 +192,8 @@ var AppPageComponent = React.createClass({
           : "";
         var host = this.state.app.host || "";
         var path = failedCheck.path || "";
-        var lastFailureCause = hc.lastFailureCause
-          ? `returned with status: '${hc.lastFailureCause}'`
+        var lastFailureCause = healthCheck.lastFailureCause
+          ? `returned with status: '${healthCheck.lastFailureCause}'`
           : "failed";
 
         return "Warning: Health check " +

--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -566,28 +566,15 @@ describe("App Page component", function () {
     var app = _.extend(appScheme, {
       id: "/test-app-1",
       healthChecks: [{path: "/", protocol: "HTTP"}],
-      tasksStaged: 0,
-      tasksRunning: 1,
-      tasksHealthy: 0,
-      tasksUnhealthy: 1,
       status: AppStatus.RUNNING,
       tasks: [
         {
           id: "test-task-1",
-          host: "127.0.0.1",
-          ports: [31857],
-          startedAt: "2015-07-07T09:01:11.689Z",
-          stagedAt: "2015-07-07T09:01:11.130Z",
-          version: "2015-07-06T15:13:21.875Z",
           appId: "/test-app-1",
           healthStatus: HealthStatus.UNHEALTHY,
           healthCheckResults: [
             {
               alive: false,
-              consecutiveFailures: 3,
-              firstSuccess: "2015-07-07T09:15:31.752Z",
-              lastFailure: "2015-07-07T09:18:08.943Z",
-              lastSuccess: "2015-07-07T09:17:52.306Z",
               taskId: "test-task-1"
             }
           ]

--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -604,4 +604,39 @@ describe("App Page component", function () {
     expect(msg).to.equal("Warning: Health check 'HTTP /' failed.");
   });
 
+  it("returns the right health message for tasks with unknown health", function () {
+    var app = _.extend(appScheme, {
+      id: "/test-app-1",
+      status: AppStatus.RUNNING,
+      tasks: [
+        {
+          id: "test-task-1",
+          appId: "/test-app-1",
+          healthStatus: HealthStatus.UNKNOWN,
+        }
+      ]
+    });
+
+    AppsStore.apps = [app];
+    var msg = this.element.getTaskHealthMessage("test-task-1");
+    expect(msg).to.equal("Unknown");
+  });
+
+  it("returns the right health message for healthy tasks", function () {
+    var app = _.extend(appScheme, {
+      id: "/test-app-1",
+      status: AppStatus.RUNNING,
+      tasks: [
+        {
+          id: "test-task-1",
+          appId: "/test-app-1",
+          healthStatus: HealthStatus.HEALTHY,
+        }
+      ]
+    });
+
+    AppsStore.apps = [app];
+    var msg = this.element.getTaskHealthMessage("test-task-1");
+    expect(msg).to.equal("Healthy");
+  });
 });


### PR DESCRIPTION
getTaskHealthMessage was a bit unwieldy and deserved to be  moved outside of the switch. 
During my tests I also found out it was returning an array of strings than a joined string causing a Warning in the browser console. 

Side note: I am using a couple ES6 tricks here: `templateStrings` and `defaultParams` which are pretty cool.

This fixes https://github.com/mesosphere/marathon/issues/1734
