### PR TITLE
Refactor deployments badge counter

### DIFF
--- a/src/js/components/Marathon.jsx
+++ b/src/js/components/Marathon.jsx
@@ -15,8 +15,6 @@ var NavTabsComponent = require("../components/NavTabsComponent");
 
 var AppsActions = require("../actions/AppsActions");
 var DeploymentActions = require("../actions/DeploymentActions");
-var DeploymentEvents = require("../events/DeploymentEvents");
-var DeploymentStore = require("../stores/DeploymentStore");
 
 var tabs = [
   {id: "apps", text: "Apps"},
@@ -37,16 +35,6 @@ var Marathon = React.createClass({
       activeTabId: tabs[0].id,
       modalClass: null
     };
-  },
-
-  componentWillMount: function () {
-    // TODO: #1738 - That should be handled directly on the NavTabs
-    DeploymentStore.on(DeploymentEvents.CHANGE, function () {
-      if (tabs[1].badge !== DeploymentStore.deployments.length) {
-        tabs[1].badge = DeploymentStore.deployments.length;
-        this.forceUpdate();
-      }
-    }.bind(this));
   },
 
   componentDidMount: function () {

--- a/src/js/components/NavTabsComponent.jsx
+++ b/src/js/components/NavTabsComponent.jsx
@@ -10,14 +10,13 @@ var NavTabsComponent = React.createClass({
 
   propTypes: {
     activeTabId: React.PropTypes.string.isRequired,
-    activeDeployments: React.PropTypes.number,
     className: React.PropTypes.string,
     tabs: React.PropTypes.array.isRequired
   },
 
   getInitialState: function () {
     return {
-      activeDeployments: this.props.activeDeployments || 0
+      activeDeployments: DeploymentStore.deployments.length
     };
   },
 
@@ -33,6 +32,13 @@ var NavTabsComponent = React.createClass({
     });
   },
 
+  getBadge: function (tab) {
+    if (tab.id !== "deployments" || this.state.activeDeployments < 1 ) {
+      return null;
+    }
+    return <span className="badge">{this.state.activeDeployments}</span>;
+  },
+
   render: function () {
     var activeTabId = this.props.activeTabId;
 
@@ -41,9 +47,7 @@ var NavTabsComponent = React.createClass({
         "active": tab.id === activeTabId
       });
 
-      var badge = tab.id === "deployments" && this.state.activeDeployments > 0 ?
-        <span className="badge">{this.state.activeDeployments}</span> :
-        null;
+      var badge = this.getBadge(tab);
 
       return (
         <li className={tabClassSet} key={tab.id}>

--- a/src/js/components/NavTabsComponent.jsx
+++ b/src/js/components/NavTabsComponent.jsx
@@ -33,10 +33,11 @@ var NavTabsComponent = React.createClass({
   },
 
   getBadge: function (tab) {
-    if (tab.id !== "deployments" || this.state.activeDeployments < 1 ) {
+    var state = this.state;
+    if (tab.id !== "deployments" || state.activeDeployments < 1 ) {
       return null;
     }
-    return <span className="badge">{this.state.activeDeployments}</span>;
+    return <span className="badge">{state.activeDeployments}</span>;
   },
 
   render: function () {
@@ -47,14 +48,12 @@ var NavTabsComponent = React.createClass({
         "active": tab.id === activeTabId
       });
 
-      var badge = this.getBadge(tab);
-
       return (
         <li className={tabClassSet} key={tab.id}>
           <a href={"#" + tab.id}>
             {tab.text}
           </a>
-          {badge}
+          {this.getBadge(tab)}
         </li>
       );
     }, this);

--- a/src/js/components/NavTabsComponent.jsx
+++ b/src/js/components/NavTabsComponent.jsx
@@ -1,19 +1,36 @@
 var classNames = require("classnames");
 var React = require("react/addons");
 
+var DeploymentEvents = require("../events/DeploymentEvents");
+var DeploymentStore = require("../stores/DeploymentStore");
+var DeploymentActions = require("../actions/DeploymentActions");
+
 var NavTabsComponent = React.createClass({
   displayName: "NavTabsComponent",
 
   propTypes: {
     activeTabId: React.PropTypes.string.isRequired,
+    activeDeployments: React.PropTypes.number,
     className: React.PropTypes.string,
     tabs: React.PropTypes.array.isRequired
+  },
+
+  getInitialState: function () {
+    return {
+      activeDeployments: this.props.activeDeployments || 0
+    };
   },
 
   getDefaultProps: function () {
     return {
       className: ""
     };
+  },
+
+  componentWillMount: function () {
+    DeploymentStore.on(DeploymentEvents.CHANGE, () => {
+      this.setState({activeDeployments: DeploymentStore.deployments.length});
+    });
   },
 
   render: function () {
@@ -24,8 +41,8 @@ var NavTabsComponent = React.createClass({
         "active": tab.id === activeTabId
       });
 
-      var badge = tab.badge > 0 ?
-        <span className="badge">{tab.badge}</span> :
+      var badge = tab.id === "deployments" && this.state.activeDeployments > 0 ?
+        <span className="badge">{this.state.activeDeployments}</span> :
         null;
 
       return (

--- a/src/test/deployments.test.js
+++ b/src/test/deployments.test.js
@@ -137,9 +137,14 @@ describe("Deployments", function () {
 describe("Deployments navigation badge", function () {
 
   beforeEach(function () {
+
+    DeploymentStore.deployments = [
+      {id: "deployment-1"},
+      {id: "deployment-2"}
+    ];
+
     var props = {
       activeTabId: "deployments",
-      activeDeployments: 3,
       tabs: [
         {id: "apps", text: "Apps"},
         {id: "deployments", text: "Deployments"}
@@ -158,7 +163,7 @@ describe("Deployments navigation badge", function () {
   it("has the correct amount of deployments", function () {
     var badge = this.component.props.children[1].props.children[1];
     expect(badge.props.className).to.equal("badge");
-    expect(badge.props.children).to.equal(3);
+    expect(badge.props.children).to.equal(2);
   });
 
 });

--- a/src/test/deployments.test.js
+++ b/src/test/deployments.test.js
@@ -6,6 +6,7 @@ var TestUtils = React.addons.TestUtils;
 var config = require("../js/config/config");
 var DeploymentActions = require("../js/actions/DeploymentActions");
 var DeploymentComponent = require("../js/components/DeploymentComponent");
+var NavTabsComponent = require("../js/components/NavTabsComponent");
 var DeploymentEvents = require("../js/events/DeploymentEvents");
 var DeploymentStore = require("../js/stores/DeploymentStore");
 
@@ -129,6 +130,35 @@ describe("Deployments", function () {
       DeploymentActions.stopDeployment();
     });
 
+  });
+
+});
+
+describe("Deployments navigation badge", function () {
+
+  beforeEach(function () {
+    var props = {
+      activeTabId: "deployments",
+      activeDeployments: 3,
+      tabs: [
+        {id: "apps", text: "Apps"},
+        {id: "deployments", text: "Deployments"}
+      ]
+    };
+
+    this.renderer = TestUtils.createRenderer();
+    this.renderer.render(<NavTabsComponent {...props} />);
+    this.component = this.renderer.getRenderOutput();
+  });
+
+  afterEach(function () {
+    this.renderer.unmount();
+  });
+
+  it("has the correct amount of deployments", function () {
+    var badge = this.component.props.children[1].props.children[1];
+    expect(badge.props.className).to.equal("badge");
+    expect(badge.props.children).to.equal(3);
   });
 
 });


### PR DESCRIPTION
The Marathon component is now only responsible for "polling" the DeploymentsStore rather than resolving the badge indicator. This also has the positive side-effect of removing the direct manipulation of the tabs property that was happening inside Marathon.

The NavTabsComponent now bind directly the DeploymentStore and react to the changes by updating its own internal state.

This fixes https://github.com/mesosphere/marathon/issues/1738

