### PR TITLE
Rewrite tests to leave appScheme unmodified

### DIFF
--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -563,7 +563,7 @@ describe("App validator", function () {
 describe("App Page component", function () {
 
   beforeEach(function () {
-    var app = _.extend(appScheme, {
+    var app = React.addons.update(appScheme, {$merge: {
       id: "/test-app-1",
       healthChecks: [{path: "/", protocol: "HTTP"}],
       status: AppStatus.RUNNING,
@@ -580,7 +580,7 @@ describe("App Page component", function () {
           ]
         }
       ]
-    });
+    }});
 
     AppsStore.apps = [app];
 
@@ -605,7 +605,7 @@ describe("App Page component", function () {
   });
 
   it("returns the right health message for tasks with unknown health", function () {
-    var app = _.extend(appScheme, {
+    var app = React.addons.update(appScheme, {$merge: {
       id: "/test-app-1",
       status: AppStatus.RUNNING,
       tasks: [
@@ -615,7 +615,7 @@ describe("App Page component", function () {
           healthStatus: HealthStatus.UNKNOWN,
         }
       ]
-    });
+    }});
 
     AppsStore.apps = [app];
     var msg = this.element.getTaskHealthMessage("test-task-1");
@@ -623,7 +623,7 @@ describe("App Page component", function () {
   });
 
   it("returns the right health message for healthy tasks", function () {
-    var app = _.extend(appScheme, {
+    var app = React.addons.update(appScheme, {$merge: {
       id: "/test-app-1",
       status: AppStatus.RUNNING,
       tasks: [
@@ -633,7 +633,7 @@ describe("App Page component", function () {
           healthStatus: HealthStatus.HEALTHY,
         }
       ]
-    });
+    }});
 
     AppsStore.apps = [app];
     var msg = this.element.getTaskHealthMessage("test-task-1");


### PR DESCRIPTION
As noted by @mlunoe [here](https://github.com/mesosphere/marathon-ui/commit/11c00745a7eb48134e5537181ac462eb250e7e40#commitcomment-12058824), Underscore's _.extend() method has the unfortunate side-effect of modifying the first parameter in-place rather than making a shallow copy and extending that. Instead of wingin' this with _.clone() the best solution is to use React's immutability helpers.