### PR TITLE
Provide an immutable version of util.extendObject

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,8 @@
     "arrowFunctions": true,
     "objectLiteralComputedProperties": true,
     "templateStrings": true,
-    "defaultParams": true
+    "defaultParams": true,
+    "restParams": true,
   },
 
   "env": {

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -1,4 +1,3 @@
-var _ = require("underscore");
 var classNames = require("classnames");
 var React = require("react/addons");
 
@@ -119,7 +118,7 @@ var AppPageComponent = React.createClass({
       fetchState = States.STATE_LOADING;
     }
 
-    this.setState(_.extend(
+    this.setState(util.extend(
       this.state,
       {fetchState: fetchState},
       this.getRouteSettings()

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -118,7 +118,7 @@ var AppPageComponent = React.createClass({
       fetchState = States.STATE_LOADING;
     }
 
-    this.setState(util.extend(
+    this.setState(util.extendObject(
       this.state,
       {fetchState: fetchState},
       this.getRouteSettings()

--- a/src/js/components/NewAppModalComponent.jsx
+++ b/src/js/components/NewAppModalComponent.jsx
@@ -158,7 +158,7 @@ var NewAppModalComponent = React.createClass({
       modelAttrs.instances = parseInt(modelAttrs.instances, 10);
     }
 
-    var model = util.extend(this.props.attributes, modelAttrs);
+    var model = util.extendObject(this.props.attributes, modelAttrs);
 
     // Create app if validate() returns no errors
     if (appValidator.validate(model) == null) {

--- a/src/js/components/NewAppModalComponent.jsx
+++ b/src/js/components/NewAppModalComponent.jsx
@@ -158,7 +158,7 @@ var NewAppModalComponent = React.createClass({
       modelAttrs.instances = parseInt(modelAttrs.instances, 10);
     }
 
-    var model = _.extend(this.props.attributes, modelAttrs);
+    var model = util.extend(this.props.attributes, modelAttrs);
 
     // Create app if validate() returns no errors
     if (appValidator.validate(model) == null) {

--- a/src/js/helpers/util.js
+++ b/src/js/helpers/util.js
@@ -72,7 +72,10 @@ var util = {
     return element.className &&
       element.className.match(/\S+/g).indexOf(className) > -1;
   },
-  noop: function () {}
+  noop: function () {},
+  extend: function (...sources) {
+    return Object.assign({}, ...sources);
+  }
 };
 
 module.exports = util;

--- a/src/js/helpers/util.js
+++ b/src/js/helpers/util.js
@@ -73,7 +73,7 @@ var util = {
       element.className.match(/\S+/g).indexOf(className) > -1;
   },
   noop: function () {},
-  extend: function (...sources) {
+  extendObject: function (...sources) {
     return Object.assign({}, ...sources);
   }
 };

--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -565,7 +565,7 @@ describe("App validator", function () {
 describe("App Page component", function () {
 
   beforeEach(function () {
-    var app = util.extend(appScheme, {
+    var app = util.extendObject(appScheme, {
       id: "/test-app-1",
       healthChecks: [{path: "/", protocol: "HTTP"}],
       status: AppStatus.RUNNING,
@@ -619,7 +619,7 @@ describe("App Page component", function () {
   });
 
   it("returns the right health message for tasks with unknown health", function () {
-    var app = util.extend(appScheme, {
+    var app = util.extendObject(appScheme, {
       id: "/test-app-1",
       status: AppStatus.RUNNING,
       tasks: [
@@ -637,7 +637,7 @@ describe("App Page component", function () {
   });
 
   it("returns the right health message for healthy tasks", function () {
-    var app = util.extend(appScheme, {
+    var app = util.extendObject(appScheme, {
       id: "/test-app-1",
       status: AppStatus.RUNNING,
       tasks: [

--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -3,6 +3,7 @@ var expect = require("chai").expect;
 var React = require("react/addons");
 var ReactContext = require('react/lib/ReactContext');
 var TestUtils = React.addons.TestUtils;
+var util = require("../js/helpers/util");
 
 var config = require("../js/config/config");
 var AppsActions = require("../js/actions/AppsActions");
@@ -564,7 +565,7 @@ describe("App validator", function () {
 describe("App Page component", function () {
 
   beforeEach(function () {
-    var app = React.addons.update(appScheme, {$merge: {
+    var app = util.extend(appScheme, {
       id: "/test-app-1",
       healthChecks: [{path: "/", protocol: "HTTP"}],
       status: AppStatus.RUNNING,
@@ -581,7 +582,7 @@ describe("App Page component", function () {
           ]
         }
       ]
-    }});
+    });
 
     AppsStore.apps = [app];
 
@@ -618,7 +619,7 @@ describe("App Page component", function () {
   });
 
   it("returns the right health message for tasks with unknown health", function () {
-    var app = React.addons.update(appScheme, {$merge: {
+    var app = util.extend(appScheme, {
       id: "/test-app-1",
       status: AppStatus.RUNNING,
       tasks: [
@@ -628,7 +629,7 @@ describe("App Page component", function () {
           healthStatus: HealthStatus.UNKNOWN,
         }
       ]
-    }});
+    });
 
     AppsStore.apps = [app];
     var msg = this.element.getTaskHealthMessage("test-task-1");
@@ -636,7 +637,7 @@ describe("App Page component", function () {
   });
 
   it("returns the right health message for healthy tasks", function () {
-    var app = React.addons.update(appScheme, {$merge: {
+    var app = util.extend(appScheme, {
       id: "/test-app-1",
       status: AppStatus.RUNNING,
       tasks: [
@@ -646,7 +647,7 @@ describe("App Page component", function () {
           healthStatus: HealthStatus.HEALTHY,
         }
       ]
-    }});
+    });
 
     AppsStore.apps = [app];
     var msg = this.element.getTaskHealthMessage("test-task-1");

--- a/src/test/util.test.js
+++ b/src/test/util.test.js
@@ -38,20 +38,20 @@ describe("util", function () {
 
   });
 
-  describe("extend", function () {
+  describe("extendObject", function () {
 
     it("returns a new object with merged properties", function () {
       var objA = {hello: "world", foo: "bar"};
       var objB = {hello: "there", baz: "foo"};
       var expectedResult = {hello: "there", foo: "bar", baz: "foo"};
-      var result = util.extend(objA, objB);
+      var result = util.extendObject(objA, objB);
       expect(result).to.deep.equal(expectedResult);
     });
 
     it("returns a new object without modifying the source", function () {
       var objA = {hello: "world", foo: "bar"};
       var objB = {hello: "there", baz: "foo"};
-      var result = util.extend(objA, objB);
+      var result = util.extendObject(objA, objB);
       expect(objA).to.deep.equal({hello: "world", foo: "bar"});
     });
 
@@ -67,7 +67,7 @@ describe("util", function () {
         flag: true
       };
 
-      var result = util.extend(objA, objB, objC);
+      var result = util.extendObject(objA, objB, objC);
       expect(result).to.deep.equal(expectedResult);
     });
 

--- a/src/test/util.test.js
+++ b/src/test/util.test.js
@@ -38,4 +38,39 @@ describe("util", function () {
 
   });
 
+  describe("extend", function () {
+
+    it("returns a new object with merged properties", function () {
+      var objA = {hello: "world", foo: "bar"};
+      var objB = {hello: "there", baz: "foo"};
+      var expectedResult = {hello: "there", foo: "bar", baz: "foo"};
+      var result = util.extend(objA, objB);
+      expect(result).to.deep.equal(expectedResult);
+    });
+
+    it("returns a new object without modifying the source", function () {
+      var objA = {hello: "world", foo: "bar"};
+      var objB = {hello: "there", baz: "foo"};
+      var result = util.extend(objA, objB);
+      expect(objA).to.deep.equal({hello: "world", foo: "bar"});
+    });
+
+    it("accepts several sources", function () {
+      var objA = {hello: "world", foo: "bar"};
+      var objB = {hello: "there", baz: "foo"};
+      var objC = {id: null, flag: true};
+      var expectedResult = {
+        hello: "there",
+        foo: "bar",
+        baz: "foo",
+        id: null,
+        flag: true
+      };
+
+      var result = util.extend(objA, objB, objC);
+      expect(result).to.deep.equal(expectedResult);
+    });
+
+  });
+
 });

--- a/src/test/util.test.js
+++ b/src/test/util.test.js
@@ -71,6 +71,11 @@ describe("util", function () {
       expect(result).to.deep.equal(expectedResult);
     });
 
+    it("always returns an object", function () {
+      var expectedResult = {"0": "faz", "1": "bar"};
+      var result = util.extendObject(["foo", "bar"], ["faz"]);
+      expect(result).to.deep.equal(expectedResult);
+    });
   });
 
 });


### PR DESCRIPTION
This utility wraps the ES6 Object.assign() method to enforce an immutable-like behaviour. The same could also be achieved with _.extend({}, ...sources) but we are moving away from that dependency in
the near future.


This fixes https://github.com/mesosphere/marathon/issues/1770