### PR TITLE
Small successive changes to the delay feature

### DIFF
--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -82,7 +82,7 @@ function processApps(apps) {
 }
 
 function applyAppDelayStatus(app, queue) {
-  var changed = false;
+  var hasChanges = false;
   var status;
 
   var queueEntry = lazy(queue).find(function (entry) {
@@ -99,21 +99,21 @@ function applyAppDelayStatus(app, queue) {
 
     if (status) {
       if (app.status !== status) {
-        changed = true;
+        hasChanges = true;
       }
       app.status = status;
     }
   }
 
-  return changed;
+  return hasChanges;
 }
 
 function applyAppDelayStatusOnAllApps(apps, queue) {
-  var changed = false;
+  var hasChanges = false;
   apps.forEach(function (app) {
-    changed = applyAppDelayStatus(app, queue) || changed;
+    hasChanges = applyAppDelayStatus(app, queue) || hasChanges;
   });
-  return changed;
+  return hasChanges;
 }
 
 var AppsStore = lazy(EventEmitter.prototype).extend({

--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -83,13 +83,14 @@ function processApps(apps) {
 
 function applyAppDelayStatus(app, queue) {
   var hasChanges = false;
-  var status;
 
   var queueEntry = lazy(queue).find(function (entry) {
     return entry.app != null && app.id === entry.app.id && entry.delay != null;
   });
 
   if (queueEntry) {
+    let status;
+
     if (queueEntry.delay.overdue === false
         && queueEntry.delay.timeLeftSeconds > 0) {
       status = AppStatus.DELAYED;

--- a/src/js/stores/QueueStore.js
+++ b/src/js/stores/QueueStore.js
@@ -1,23 +1,24 @@
 var EventEmitter = require("events").EventEmitter;
-var lazy = require("lazy.js");
 
 var AppDispatcher = require("../AppDispatcher");
 var QueueEvents = require("../events/QueueEvents");
 var queueScheme = require("./queueScheme");
 
+var util = require("../helpers/util");
+
 function processQueue(queue = []) {
-  return lazy(queue).map(function (entry) {
-    return lazy(queueScheme).extend(entry).value();
-  }).value();
+  return queue.map(function (entry) {
+    return util.extendObject(queueScheme, entry);
+  });
 }
 
-var QueueStore = lazy(EventEmitter.prototype).extend({
+var QueueStore = util.extendObject(EventEmitter.prototype, {
   queue: [],
 
   getDelayByAppId: function (appId) {
     var timeLeftSeconds = 0;
 
-    var queueEntry = lazy(this.queue).find(function (entry) {
+    var queueEntry = this.queue.find(function (entry) {
       return entry.app.id === appId && entry.delay != null;
     });
 
@@ -27,7 +28,7 @@ var QueueStore = lazy(EventEmitter.prototype).extend({
 
     return timeLeftSeconds;
   }
-}).value();
+});
 
 AppDispatcher.register(function (action) {
   switch (action.actionType) {


### PR DESCRIPTION
If we are not chaining functions, lazy.js isn't the powerful, so we can easily use the native array functions, we got all with babel. But if we can chain function like .map.filter.take(5) always use lazy.js.
If it's working good with the QueueStore I will look in the others stores too, to replace the array functions.