### PR TITLE
Enable ENV-replacement for image paths

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@ var gutil = require("gulp-util");
 var less = require("gulp-less");
 var minifyCSS = require("gulp-minify-css");
 var path = require("path");
+var replace = require("gulp-replace");
 var uglify = require("gulp-uglify");
 var war = require("gulp-war");
 var webpack = require("webpack");
@@ -161,6 +162,12 @@ gulp.task("make-war", function () {
     .pipe(gulp.dest(dirs.release));
 });
 
+gulp.task("replace-js-strings", ["webpack", "eslint", "minify-js"], function () {
+  return gulp.src(dirs.dist + "/main.js")
+    .pipe(replace("@@ENV", process.env.GULP_ENV))
+    .pipe(gulp.dest(dirs.dist));
+});
+
 gulp.task("serve", ["default", "connect:server", "watch"]);
 gulp.task("livereload", ["default", "browsersync", "watch"]);
 gulp.task("war", ["default", "make-war"]);
@@ -174,6 +181,6 @@ var tasks = [
 ];
 
 if (process.env.GULP_ENV === "production") {
-  tasks.push("minify-css", "minify-js");
+  tasks.push("minify-css", "minify-js", "replace-js-strings");
 }
 gulp.task("default", tasks);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5128,6 +5128,68 @@
         }
       }
     },
+    "gulp-replace": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/gulp-replace/-/gulp-replace-0.5.3.tgz",
+      "dependencies": {
+        "istextorbinary": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-1.0.2.tgz",
+          "dependencies": {
+            "binaryextensions": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-1.0.0.tgz"
+            },
+            "textextensions": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-1.0.1.tgz"
+            }
+          }
+        },
+        "replacestream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/replacestream/-/replacestream-2.0.0.tgz",
+          "dependencies": {
+            "through": {
+              "version": "2.3.8",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
     "gulp-uglify": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "babel": "^5.6.14",
     "classnames": "^2.1.2",
     "flux": "^2.0.3",
+    "gulp-replace": "^0.5.3",
     "lazy.js": "^0.4.0",
     "moment": "^2.9.0",
     "mousetrap": "^1.4.6",

--- a/src/js/components/Marathon.jsx
+++ b/src/js/components/Marathon.jsx
@@ -195,13 +195,15 @@ var Marathon = React.createClass({
       modal = this.getAboutModal();
     }
 
+    var logoPath = config.rootUrl + "img/marathon-logo.png";
+
     return (
       <div>
         <nav className="navbar navbar-inverse navbar-static-top" role="navigation">
           <div className="container-fluid">
             <div className="navbar-header">
               <a className="navbar-brand" href={window.location.pathname}>
-                <img width="160" height="27" alt="Marathon" src="img/marathon-logo.png" />
+                <img width="160" height="27" alt="Marathon" src={logoPath} />
               </a>
             </div>
             <NavTabsComponent

--- a/src/js/components/modals/AboutModalComponent.jsx
+++ b/src/js/components/modals/AboutModalComponent.jsx
@@ -6,6 +6,8 @@ var InfoStore = require("../../stores/InfoStore");
 var ModalComponent = require("../components/../ModalComponent");
 var ObjectDlComponent = require("../components/../ObjectDlComponent");
 
+var config = require("../../config/config");
+
 var AboutModalComponent = React.createClass({
   displayName: "AboutModalComponent",
 
@@ -51,6 +53,7 @@ var AboutModalComponent = React.createClass({
   render: function () {
     var marathonConfig = this.state.info.marathon_config;
     var zookeeperConfig = this.state.info.zookeeper_config;
+    var logoPath = config.rootUrl + "img/marathon-logo.png";
 
     return (
       <ModalComponent
@@ -61,7 +64,7 @@ var AboutModalComponent = React.createClass({
           <button type="button" className="close"
             aria-hidden="true" onClick={this.destroy}>&times;</button>
           <h3 className="modal-title">
-            <img width="160" height="27" alt="Marathon" src="img/marathon-logo.png" />
+            <img width="160" height="27" alt="Marathon" src={logoPath} />
             <small className="text-muted" style={{"marginLeft": "1em"}}>
               Version {this.getInfo("version")}
             </small>

--- a/src/js/config/config.js
+++ b/src/js/config/config.js
@@ -1,4 +1,7 @@
 var config = {
+  // @@ENV gets replaced by build system
+  environment: "@@ENV",
+  rootUrl: "",
   // Defines the Marathon API URL,
   // leave empty to use the same as the UI is served.
   apiURL: "",
@@ -10,5 +13,7 @@ var config = {
     port: 8181
   }
 };
-
+if (config.environment === "production") {
+  config.rootUrl = "dist/";
+}
 module.exports = config;


### PR DESCRIPTION
This adds a gulp task that ensures that components can reach the assets (in this case the Marathon logo) depending on the environment.

When running `npm run dist` the target will be `dist/img/`, whilst in development mode (`npm run serve`) it will be `img/`.


~~Also, I noticed that the `minify-js` task was not passing any arguments to `.uglify()`, which means we were not actually minifying our assets. This is now fixed.~~
