### PR TITLE
Allow dialogs to stay open when clicking outside

### DIFF
--- a/src/js/components/ModalComponent.jsx
+++ b/src/js/components/ModalComponent.jsx
@@ -10,6 +10,7 @@ var ModalComponent = React.createClass({
   displayName: "ModalComponent",
   propTypes: {
     children: React.PropTypes.node,
+    dismissOnClickOutside: React.PropTypes.bool,
     onDestroy: React.PropTypes.func,
     size: React.PropTypes.string
   },
@@ -24,6 +25,7 @@ var ModalComponent = React.createClass({
 
   getDefaultProps: function () {
     return {
+      dismissOnClickOutside: true,
       onDestroy: util.noop,
       size: null
     };
@@ -36,8 +38,9 @@ var ModalComponent = React.createClass({
   },
 
   onClick: function (event) {
-    if (util.hasClass(event.target, "modal") ||
-      util.hasClass(event.target, "modal-dialog")) {
+    if (this.props.dismissOnClickOutside &&
+      (util.hasClass(event.target, "modal") ||
+      util.hasClass(event.target, "modal-dialog"))) {
       this.destroy();
     }
   },

--- a/src/js/components/NewAppModalComponent.jsx
+++ b/src/js/components/NewAppModalComponent.jsx
@@ -181,7 +181,10 @@ var NewAppModalComponent = React.createClass({
     var helpMessage = "Comma-separated list of valid constraints. Valid constraint format is \"field:operator[:value]\".";
 
     return (
-      <ModalComponent ref="modalComponent" onDestroy={this.props.onDestroy}>
+      <ModalComponent
+        dismissOnClickOutside={false}
+        ref="modalComponent"
+        onDestroy={this.props.onDestroy}>
         <form method="post" role="form" onSubmit={this.onSubmit}>
           <div className="modal-header">
             <button type="button" className="close"


### PR DESCRIPTION
A new property `dismissOnClickOutside` allows us to define if a `ModalComponent` should stay open even when the user clicks outside of the dialog.

https://github.com/mesosphere/marathon/issues/948