### PR TITLE
Allow development mode config file

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,6 +29,7 @@
     "no-trailing-spaces": [2, { "skipBlankLines": false }],
     "no-underscore-dangle": 0,
     "no-multiple-empty-lines": [2, {"max": 1}],
+    "no-empty": [2],
     "object-curly-spacing": [2, "never"],
     "space-after-keywords": [2, "always"],
     "space-before-blocks": [2, "always"],

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ npm-debug.log
 .DS_Store
 *.iml
 .idea/*
+
+src/js/config/config.dev.js

--- a/README.md
+++ b/README.md
@@ -18,7 +18,12 @@ If you want to start development on the Marathon UI please follow these steps.
         npm install
         npm install -g gulp
 
-3. Run development environment
+3. Override development configuration
+
+    1. Copy `src/js/config/config.template.js` to `src/js/config/config.dev.js`
+    2. Override variables in `config.dev.js` to reflect your local development configuration
+
+4. Run development environment
 
         npm run serve
 

--- a/src/js/config/config.js
+++ b/src/js/config/config.js
@@ -15,5 +15,8 @@ var config = {
 };
 if (config.environment === "production") {
   config.rootUrl = "dist/";
+} else {
+  var configDev = require("./config.dev");
+  config = Object.assign(config, configDev);
 }
 module.exports = config;

--- a/src/js/config/config.js
+++ b/src/js/config/config.js
@@ -19,6 +19,8 @@ if (config.environment === "production") {
   try {
     var configDev = require("./config.dev");
     config = Object.assign(config, configDev);
-  } catch (e) {}
+  } catch (e) {
+    // Do nothing
+  }
 }
 module.exports = config;

--- a/src/js/config/config.js
+++ b/src/js/config/config.js
@@ -16,7 +16,9 @@ var config = {
 if (config.environment === "production") {
   config.rootUrl = "dist/";
 } else {
-  var configDev = require("./config.dev");
-  config = Object.assign(config, configDev);
+  try {
+    var configDev = require("./config.dev");
+    config = Object.assign(config, configDev);
+  } catch (e) {}
 }
 module.exports = config;

--- a/src/js/config/config.js
+++ b/src/js/config/config.js
@@ -15,7 +15,8 @@ var config = {
 };
 if (config.environment === "production") {
   config.rootUrl = "dist/";
-} else {
+}
+if (process.env.GULP_ENV === "development") {
   try {
     var configDev = require("./config.dev");
     config = Object.assign(config, configDev);

--- a/src/js/config/config.template.js
+++ b/src/js/config/config.template.js
@@ -1,0 +1,6 @@
+var configDev = {
+  // Defines the Marathon API URL,
+  // leave empty to use the same as the UI is served.
+  apiURL: ""
+};
+module.exports = configDev;


### PR DESCRIPTION
Developers can now create a `config.dev.js` by making a copy of `config.template.js` and override the configuration options for development mode.

This file is untracked, so it can live happily in the dev environment.

This fixes mesosphere/marathon#1727