### PR TITLE
Reduce amount of webpack output

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -79,7 +79,15 @@ gulp.task("webpack", function (callback) {
     if (err) {
       throw new gutil.PluginError("webpack", err);
     }
-    gutil.log("[webpack]", stats.toString({colors: true}));
+
+    gutil.log("[webpack]", stats.toString({
+      children: false,
+      chunks: false,
+      colors: true,
+      modules: false,
+      timing: true
+    }));
+
     browserSync.reload();
     callback();
   });


### PR DESCRIPTION
Reduces verbosity of Webpack logs while still keeping track of potential failures.

This addresses AC 8 of mesosphere/marathon#1688