### PR TITLE
Use tasks/delete endpoint for killing tasks

### DIFF
--- a/src/js/actions/TasksActions.js
+++ b/src/js/actions/TasksActions.js
@@ -5,20 +5,22 @@ var AppDispatcher = require("../AppDispatcher");
 var TasksEvents = require("../events/TasksEvents");
 
 var TasksActions = {
-  deleteTask: function (appId, taskId) {
+  deleteTasks: function (appId, taskIds = []) {
     this.request({
-      method: "DELETE",
+      method: "POST",
+      data: {
+        "ids": taskIds
+      },
       headers: {
         "Content-Type": "application/json"
       },
-      url: config.apiURL + "v2/apps/" + appId + "/tasks/" + taskId
+      url: config.apiURL + "v2/tasks/delete"
     })
-    .success(function (task) {
+    .success(function () {
       AppDispatcher.dispatch({
         actionType: TasksEvents.DELETE,
-        data: task,
         appId: appId,
-        taskId: taskId
+        taskIds: taskIds
       });
     })
     .error(function (error) {
@@ -28,22 +30,22 @@ var TasksActions = {
       });
     });
   },
-  deleteTaskAndScale: function (appId, taskId) {
+  deleteTasksAndScale: function (appId, taskIds = []) {
     this.request({
-      method: "DELETE",
+      method: "POST",
+      data: {
+        "ids": taskIds
+      },
       headers: {
         "Content-Type": "application/json"
       },
-      url: config.apiURL + "v2/apps/" +
-        appId + "/tasks/" +
-        taskId + "?scale=true"
+      url: config.apiURL + "v2/tasks/delete?scale=true"
     })
-    .success(function (task) {
+    .success(function () {
       AppDispatcher.dispatch({
         actionType: TasksEvents.DELETE,
-        data: task,
         appId: appId,
-        taskId: taskId
+        taskIds: taskIds
       });
     })
     .error(function (error) {

--- a/src/js/components/TaskViewComponent.jsx
+++ b/src/js/components/TaskViewComponent.jsx
@@ -36,20 +36,20 @@ var TaskViewComponent = React.createClass({
 
   handleKillSelectedTasks: function (scaleTask) {
     var props = this.props;
-
     var selectedTaskIds = Object.keys(this.state.selectedTasks);
 
-    lazy(props.tasks)
-    .filter(function (task) {
-      return selectedTaskIds.indexOf(task.id) >= 0;
-    })
-    .each(function (task) {
-      if (!scaleTask) {
-        TasksActions.deleteTask(props.appId, task.id);
-      } else {
-        TasksActions.deleteTaskAndScale(props.appId, task.id);
-      }
-    });
+    var taskIds = lazy(props.tasks).map(function (task) {
+      return lazy(selectedTaskIds).indexOf(task.id) >= 0
+        ? task.id
+        : null;
+    }).compact().value();
+
+    if (!scaleTask) {
+      TasksActions.deleteTasks(props.appId, taskIds);
+    } else {
+      TasksActions.deleteTasksAndScale(props.appId, taskIds);
+    }
+    this.setState({selectedTasks: {}});
   },
 
   toggleAllTasks: function () {

--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -17,9 +17,9 @@ function removeApp(apps, appId) {
   }).value();
 }
 
-function removeTask(tasks, relatedAppId, taskId) {
+function removeTasks(tasks, relatedAppId, taskIds) {
   return lazy(tasks).reject(function (task) {
-    return task.id === taskId && task.appId === relatedAppId;
+    return (lazy(taskIds).indexOf(task.id) > -1) && task.appId === relatedAppId;
   }).value();
 }
 
@@ -207,10 +207,10 @@ AppDispatcher.register(function (action) {
       break;
     case TasksEvents.DELETE:
       AppsStore.currentApp.tasks =
-        removeTask(
+        removeTasks(
           AppsStore.currentApp.tasks,
           action.appId,
-          action.taskId
+          action.taskIds
         );
       AppsStore.emit(AppsEvents.CHANGE);
       break;

--- a/src/test/tasks.test.js
+++ b/src/test/tasks.test.js
@@ -48,14 +48,10 @@ describe("Tasks", function () {
     this.server.stop(done);
   });
 
-  describe("on task deletion", function () {
+  describe("on single task deletion", function () {
 
     it("updates the tasks array on success", function (done) {
-      this.server.setup({
-        "task": {
-          "id": "task-1"
-        }
-      }, 200);
+      this.server.setup("", 200);
 
       AppsStore.once(AppsEvents.CHANGE, function () {
         expectAsync(function () {
@@ -66,7 +62,7 @@ describe("Tasks", function () {
         }, done);
       });
 
-      TasksActions.deleteTask("/app-1", "task-1");
+      TasksActions.deleteTasks("/app-1", ["task-1"]);
     });
 
     it("handles failure gracefully", function (done) {
@@ -78,19 +74,15 @@ describe("Tasks", function () {
         }, done);
       });
 
-      TasksActions.deleteTask("/app-1", "task-3");
+      TasksActions.deleteTasks("/app-1", "task-3");
     });
 
   });
 
-  describe("on task deletion and scale", function () {
+  describe("on single task deletion and scale", function () {
 
     it("updates the tasks array on success", function (done) {
-      this.server.setup({
-        "task": {
-          "id": "task-2"
-        }
-      }, 200);
+      this.server.setup("", 200);
 
       AppsStore.once(AppsEvents.CHANGE, function () {
         expectAsync(function () {
@@ -101,11 +93,38 @@ describe("Tasks", function () {
         }, done);
       });
 
-      TasksActions.deleteTaskAndScale("/app-1", "task-2");
+      TasksActions.deleteTasksAndScale("/app-1", ["task-2"]);
     });
 
   });
 
+  describe("on multiple task deletion", function () {
+
+    it("updates the tasks array on success", function (done) {
+      this.server.setup("", 200);
+
+      AppsStore.once(AppsEvents.CHANGE, function () {
+        expectAsync(function () {
+          expect(AppsStore.currentApp.tasks).to.have.length(0);
+        }, done);
+      });
+
+      TasksActions.deleteTasks("/app-1", ["task-1", "task-2"]);
+    });
+
+    it("handles failure gracefully", function (done) {
+      this.server.setup({message: "Guru Meditation"}, 404);
+
+      AppsStore.once(TasksEvents.DELETE_ERROR, function (error) {
+        expectAsync(function () {
+          expect(error.message).to.equal("Guru Meditation");
+        }, done);
+      });
+
+      TasksActions.deleteTasks("/app-1", "task-3");
+    });
+
+  });
 });
 
 describe("Task List Item component", function () {


### PR DESCRIPTION
The tasks/delete API endpoint has the advantage of accepting an array of
task ids rather than having to pass each individual task id, one per request.

This fixes mesosphere/marathon#1207

PLEASE NOTE
----------

I am kind of unsure if this is a good idea. The problem with this endpoint is that it provides [absolutely no information](https://mesosphere.github.io/marathon/docs/rest-api.html#post-v2-tasks-delete) regarding the actual success of the delete operation, contrary to the [previous endpoint](https://mesosphere.github.io/marathon/docs/rest-api.html#delete-v2-apps-appid-tasks-taskid). 

What we gain in performance, we lose in usability: we can only assume that the request is successful for all involved task IDs.

One possible solution would be to listen for the [related event](https://github.com/mesosphere/marathon/blob/c0e3af11dd7891453f16a961a2800a8a4735deaf/src/main/scala/mesosphere/marathon/event/Events.scala#L216) on the `/events` stream introduced in Marathon v0.10.0 and only mark the tasks as "being deleted" (instead of removing them immediately as done in the PR) until the event is published regarding the actual deletion of the task. 

I believe the solution proposed in this PR is good enough for the time being, we can always come back to this later.
