### PR TITLE
Fix: Remove correct revert error handler

### DIFF
--- a/src/js/components/DeploymentsListComponent.jsx
+++ b/src/js/components/DeploymentsListComponent.jsx
@@ -33,7 +33,7 @@ var DeploymentListComponent = React.createClass({
       this.onDeploymentsChange);
     DeploymentStore.removeListener(DeploymentEvents.REQUEST_ERROR,
       this.onRequestError);
-    DeploymentStore.removeListener(DeploymentEvents.STOP_ERROR,
+    DeploymentStore.removeListener(DeploymentEvents.REVERT_ERROR,
       this.onRevertError);
     DeploymentStore.removeListener(DeploymentEvents.STOP_ERROR,
       this.onStopError);


### PR DESCRIPTION
This resolves a just discovered bug, if receiving revert errors.
This led to this console error:
```
currentQueue is null
```