### PR TITLE
React classSet is deprecated

### DIFF
--- a/src/js/components/CollapsiblePanelComponent.jsx
+++ b/src/js/components/CollapsiblePanelComponent.jsx
@@ -1,3 +1,4 @@
+var classNames = require("classnames");
 var React = require("react");
 
 var CollapsiblePanelComponent = React.createClass({
@@ -38,7 +39,7 @@ var CollapsiblePanelComponent = React.createClass({
   },
 
   render: function () {
-    var classes = React.addons.classSet({
+    var classes = classNames({
       "clickable panel-title": true,
       "open": this.state.open
     });

--- a/src/js/components/FormGroupComponent.jsx
+++ b/src/js/components/FormGroupComponent.jsx
@@ -1,3 +1,4 @@
+var classNames = require("classnames");
 var React = require("react/addons");
 
 var FormGroupComponent = React.createClass({
@@ -38,7 +39,7 @@ var FormGroupComponent = React.createClass({
 
     var errors = [];
     var attribute = this.props.attribute;
-    var className = React.addons.classSet("form-group", this.props.className);
+    var className = classNames("form-group", this.props.className);
     var fieldId = attribute + "-field";
 
     // Find any errors matching this attribute.


### PR DESCRIPTION
React classSet is deprecated in React 0.13, we are using the classNames library.