### PR TITLE
Fix - #548 UI showing empty list after scaling when on page > 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
     grouped together
   * It is now possible to specify Docker container settings
 
+### Fixed
+- #548 - UI showing empty list after scaling when on page > 1
+  * The task list shows the last available page
+    if tasks count decreases after scaling.
+
 ## 0.10.0 - 2015-07-10
 ### Added
 - #1754 - UI: Allow administratively zeroing / resetting the taskLaunchDelay

--- a/src/js/components/PagedNavComponent.jsx
+++ b/src/js/components/PagedNavComponent.jsx
@@ -33,8 +33,6 @@ var PagedNavComponent = React.createClass({
         pageNum < noPages &&
         pageNum !== this.props.currentPage) {
       this.props.onPageChange(pageNum);
-    } else {
-      return false;
     }
   },
 

--- a/src/js/components/TaskListComponent.jsx
+++ b/src/js/components/TaskListComponent.jsx
@@ -47,9 +47,9 @@ var TaskListComponent = React.createClass({
   getTasks: function () {
     var props = this.props;
     var state = this.state;
-    var sortKey = state.sortKey;
-    var hasHealth = !!props.hasHealth;
     var dropCount = this.props.currentPage * this.props.itemsPerPage;
+    var hasHealth = !!props.hasHealth;
+    var sortKey = state.sortKey;
 
     return lazy(this.props.tasks)
       .sortBy(function (app) {

--- a/src/js/components/TaskListComponent.jsx
+++ b/src/js/components/TaskListComponent.jsx
@@ -4,7 +4,6 @@ var React = require("react/addons");
 
 var States = require("../constants/States");
 var TaskListItemComponent = require("../components/TaskListItemComponent");
-var PagedContentComponent = require("../components/PagedContentComponent");
 
 var TaskListComponent = React.createClass({
   displayName: "TaskListComponent",
@@ -50,11 +49,14 @@ var TaskListComponent = React.createClass({
     var state = this.state;
     var sortKey = state.sortKey;
     var hasHealth = !!props.hasHealth;
+    var dropCount = this.props.currentPage * this.props.itemsPerPage;
 
     return lazy(this.props.tasks)
       .sortBy(function (app) {
         return app[sortKey];
       }, state.sortDescending)
+      .drop(dropCount)
+      .take(this.props.itemsPerPage)
       .map(function (task) {
         var isActive = props.selectedTasks[task.id] === true;
 
@@ -68,7 +70,8 @@ var TaskListComponent = React.createClass({
             task={task}
             taskHealthMessage={props.getTaskHealthMessage(task.id)}/>
         );
-      }).value();
+      })
+      .value();
   },
 
   getCaret: function (sortKey) {
@@ -167,10 +170,7 @@ var TaskListComponent = React.createClass({
                 </th>
             </tr>
           </thead>
-          <PagedContentComponent
-              currentPage={this.props.currentPage}
-              itemsPerPage={this.props.itemsPerPage}
-              tag="tbody" >
+          <tbody>
             <tr className={noTasksClassSet}>
               <td className="text-center" colSpan="7">
                 No tasks running.
@@ -182,7 +182,7 @@ var TaskListComponent = React.createClass({
               </td>
             </tr>
             {this.getTasks()}
-          </PagedContentComponent>
+          </tbody>
         </table>
       </div>
     );

--- a/src/js/components/TaskViewComponent.jsx
+++ b/src/js/components/TaskViewComponent.jsx
@@ -20,10 +20,22 @@ var TaskViewComponent = React.createClass({
 
   getInitialState: function () {
     return {
-      selectedTasks: {},
       currentPage: 0,
-      itemsPerPage: 8
+      itemsPerPage: 8,
+      selectedTasks: {}
     };
+  },
+
+  componentWillReceiveProps: function (nextProps) {
+    var state = this.state;
+    var tasksLength = nextProps.tasks.length;
+
+    if (state.currentPage * state.itemsPerPage > tasksLength) {
+      this.setState({
+        currentPage: parseInt(tasksLength / state.itemsPerPage, 10),
+        selectedTasks: {}
+      });
+    }
   },
 
   handlePageChange: function (pageNum) {


### PR DESCRIPTION
Fixes https://github.com/mesosphere/marathon/issues/548

Now the list goes to the last page with content, if it overruns the page count after scaling.

Also I moved the "plucking" of the tasks to the lazy chain for performance reasons.
Before all TaskListItems were created, what can be 5.000, even if we only display 8 of them.