### PR TITLE
Remove lazy when not needed

### DIFF
--- a/src/js/components/TaskViewComponent.jsx
+++ b/src/js/components/TaskViewComponent.jsx
@@ -39,7 +39,7 @@ var TaskViewComponent = React.createClass({
     var selectedTaskIds = Object.keys(this.state.selectedTasks);
 
     var taskIds = lazy(props.tasks).map(function (task) {
-      return lazy(selectedTaskIds).indexOf(task.id) >= 0
+      return selectedTaskIds.indexOf(task.id) >= 0
         ? task.id
         : null;
     }).compact().value();

--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -19,7 +19,7 @@ function removeApp(apps, appId) {
 
 function removeTasks(tasks, relatedAppId, taskIds) {
   return lazy(tasks).reject(function (task) {
-    return (lazy(taskIds).indexOf(task.id) > -1) && task.appId === relatedAppId;
+    return (taskIds.indexOf(task.id) > -1) && task.appId === relatedAppId;
   }).value();
 }
 


### PR DESCRIPTION
As noted [here](https://github.com/mesosphere/marathon-ui/pull/109#discussion_r35738745), we should not use lazy unless we are performing chained operations.

This removes `lazy().indexOf` as it actually introduces a performance hit for no good reason.