### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "marathon",
     "mesos"
   ],
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/mesosphere/marathon-ui.git"


### PR DESCRIPTION
Fixes [#1928](https://github.com/mesosphere/marathon/issues/1928)