### PR TITLE
Rename util to PascalCase Util

### DIFF
--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -14,7 +14,7 @@ var TabPaneComponent = require("../components/TabPaneComponent");
 var TaskDetailComponent = require("../components/TaskDetailComponent");
 var TaskViewComponent = require("../components/TaskViewComponent");
 var TogglableTabsComponent = require("../components/TogglableTabsComponent");
-var util = require("../helpers/util");
+var Util = require("../helpers/Util");
 var QueueActions = require("../actions/QueueActions");
 var QueueEvents = require("../events/QueueEvents");
 var QueueStore = require("../stores/QueueStore");
@@ -121,7 +121,7 @@ var AppPageComponent = React.createClass({
       fetchState = States.STATE_LOADING;
     }
 
-    this.setState(util.extendObject(
+    this.setState(Util.extendObject(
       this.state,
       {fetchState: fetchState},
       this.getRouteSettings()
@@ -146,16 +146,16 @@ var AppPageComponent = React.createClass({
   },
 
   onScaleAppError: function (errorMessage) {
-    util.alert("Not scaling: " + (errorMessage.message || errorMessage));
+    Util.alert("Not scaling: " + (errorMessage.message || errorMessage));
   },
 
   onRestartAppError: function (errorMessage) {
-    util.alert("Error restarting app: " +
+    Util.alert("Error restarting app: " +
       (errorMessage.message || errorMessage));
   },
 
   onDeleteAppError: function (errorMessage) {
-    util.alert("Error destroying app: " +
+    Util.alert("Error destroying app: " +
       (errorMessage.message || errorMessage));
   },
 
@@ -164,11 +164,11 @@ var AppPageComponent = React.createClass({
   },
 
   onResetDelaySuccess: function () {
-    util.alert("Delay reset succesfully");
+    Util.alert("Delay reset succesfully");
   },
 
   onResetDelayError: function (errorMessage) {
-    util.alert("Error resetting delay on app: " +
+    Util.alert("Error resetting delay on app: " +
       (errorMessage.message || errorMessage));
   },
 
@@ -181,7 +181,7 @@ var AppPageComponent = React.createClass({
   handleScaleApp: function () {
     var model = this.state.app;
 
-    var instancesString = util.prompt("Scale to how many instances?",
+    var instancesString = Util.prompt("Scale to how many instances?",
       model.instances);
 
     if (instancesString != null && instancesString !== "") {
@@ -192,21 +192,21 @@ var AppPageComponent = React.createClass({
   },
 
   handleSuspendApp: function () {
-    if (util.confirm("Suspend app by scaling to 0 instances?")) {
+    if (Util.confirm("Suspend app by scaling to 0 instances?")) {
       AppsActions.scaleApp(this.state.appId, 0);
     }
   },
 
   handleRestartApp: function () {
     var appId = this.state.appId;
-    if (util.confirm("Restart app '" + appId + "'?")) {
+    if (Util.confirm("Restart app '" + appId + "'?")) {
       AppsActions.restartApp(appId);
     }
   },
 
   handleDestroyApp: function () {
     var appId = this.state.appId;
-    if (util.confirm("Destroy app '" + appId +
+    if (Util.confirm("Destroy app '" + appId +
       "'?\nThis is irreversible.")) {
       AppsActions.deleteApp(appId);
     }

--- a/src/js/components/AppVersionListComponent.jsx
+++ b/src/js/components/AppVersionListComponent.jsx
@@ -12,7 +12,7 @@ var AppVersionListItemComponent =
   require("../components/AppVersionListItemComponent");
 var PagedContentComponent = require("../components/PagedContentComponent");
 var PagedNavComponent = require("../components/PagedNavComponent");
-var util = require("../helpers/util");
+var Util = require("../helpers/Util");
 
 var AppVersionListComponent = React.createClass({
   displayName: "AppVersionListComponent",
@@ -77,7 +77,7 @@ var AppVersionListComponent = React.createClass({
   },
 
   onAppApplySettingsError: function (errorMessage) {
-    util.alert("Could not update to chosen version: " +
+    Util.alert("Could not update to chosen version: " +
       (errorMessage.message || errorMessage));
   },
 

--- a/src/js/components/DeploymentComponent.jsx
+++ b/src/js/components/DeploymentComponent.jsx
@@ -3,7 +3,7 @@ var Link = require("react-router").Link;
 var React = require("react/addons");
 
 var DeploymentActions = require("../actions/DeploymentActions");
-var util = require("../helpers/util");
+var Util = require("../helpers/Util");
 
 var DeploymentComponent = React.createClass({
   displayName: "DeploymentComponent",
@@ -25,7 +25,7 @@ var DeploymentComponent = React.createClass({
       "Destroy deployment of apps: '" + model.affectedAppsString +
       "'?\nDestroying this deployment will create and start a new " +
       "deployment to revert the affected app to its previous version.";
-    if (util.confirm(confirmMessage)) {
+    if (Util.confirm(confirmMessage)) {
       this.setState({loading: true});
       DeploymentActions.revertDeployment(model.id);
     }
@@ -38,7 +38,7 @@ var DeploymentComponent = React.createClass({
       "Stop deployment of apps: '" + model.affectedAppsString +
       "'?\nThis will stop the deployment immediately and leave it in the " +
       "current state.";
-    if (util.confirm(confirmMessage)) {
+    if (Util.confirm(confirmMessage)) {
       this.setState({loading: true});
       DeploymentActions.stopDeployment(model.id);
     }

--- a/src/js/components/ModalComponent.jsx
+++ b/src/js/components/ModalComponent.jsx
@@ -1,4 +1,4 @@
-var util = require("../helpers/util");
+var Util = require("../helpers/Util");
 var classNames = require("classnames");
 var React = require("react/addons");
 
@@ -26,7 +26,7 @@ var ModalComponent = React.createClass({
   getDefaultProps: function () {
     return {
       dismissOnClickOutside: true,
-      onDestroy: util.noop,
+      onDestroy: Util.noop,
       size: null
     };
   },
@@ -39,8 +39,8 @@ var ModalComponent = React.createClass({
 
   onClick: function (event) {
     if (this.props.dismissOnClickOutside &&
-      (util.hasClass(event.target, "modal") ||
-      util.hasClass(event.target, "modal-dialog"))) {
+      (Util.hasClass(event.target, "modal") ||
+      Util.hasClass(event.target, "modal-dialog"))) {
       this.destroy();
     }
   },

--- a/src/js/components/NewAppModalComponent.jsx
+++ b/src/js/components/NewAppModalComponent.jsx
@@ -1,7 +1,7 @@
 var _ = require("underscore");
 var lazy = require("lazy.js");
 var React = require("react/addons");
-var util = require("../helpers/util");
+var Util = require("../helpers/Util");
 
 var AppsActions = require("../actions/AppsActions");
 var AppsEvents = require("../events/AppsEvents");
@@ -34,7 +34,7 @@ var NewAppModalComponent = React.createClass({
         mem: 16.0,
         disk: 0.0
       }).value(),
-      onDestroy: util.noop
+      onDestroy: Util.noop
     };
   },
 
@@ -117,10 +117,10 @@ var NewAppModalComponent = React.createClass({
   onSubmit: function (event) {
     event.preventDefault();
 
-    var attrArray = util.serializeArray(event.target)
+    var attrArray = Util.serializeArray(event.target)
       .filter((key) => key.value !== "");
 
-    var modelAttrs = util.serializedArrayToDictionary(attrArray);
+    var modelAttrs = Util.serializedArrayToDictionary(attrArray);
 
     // URIs should be an Array of Strings.
     if ("uris" in modelAttrs) {
@@ -164,7 +164,7 @@ var NewAppModalComponent = React.createClass({
       modelAttrs.instances = parseInt(modelAttrs.instances, 10);
     }
 
-    var model = util.extendObject(this.props.attributes, modelAttrs);
+    var model = Util.extendObject(this.props.attributes, modelAttrs);
 
     // Create app if validate() returns no errors
     if (appValidator.validate(model) == null) {

--- a/src/js/helpers/Util.js
+++ b/src/js/helpers/Util.js
@@ -1,4 +1,4 @@
-var util = {
+var Util = {
   alert: function () {
     /*eslint-disable no-alert */
     return global.alert.apply(null, arguments);
@@ -126,4 +126,4 @@ var util = {
   }
 };
 
-module.exports = util;
+module.exports = Util;

--- a/src/js/stores/QueueStore.js
+++ b/src/js/stores/QueueStore.js
@@ -4,15 +4,15 @@ var AppDispatcher = require("../AppDispatcher");
 var QueueEvents = require("../events/QueueEvents");
 var queueScheme = require("./queueScheme");
 
-var util = require("../helpers/util");
+var Util = require("../helpers/Util");
 
 function processQueue(queue = []) {
   return queue.map(function (entry) {
-    return util.extendObject(queueScheme, entry);
+    return Util.extendObject(queueScheme, entry);
   });
 }
 
-var QueueStore = util.extendObject(EventEmitter.prototype, {
+var QueueStore = Util.extendObject(EventEmitter.prototype, {
   queue: [],
 
   getDelayByAppId: function (appId) {

--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -3,7 +3,7 @@ var expect = require("chai").expect;
 var React = require("react/addons");
 var ReactContext = require('react/lib/ReactContext');
 var TestUtils = React.addons.TestUtils;
-var util = require("../js/helpers/util");
+var Util = require("../js/helpers/Util");
 
 /**
  * This *nasty* hack is needed because we want to prevent TooltipMixin from
@@ -719,7 +719,7 @@ describe("App validator", function () {
 describe("App Page component", function () {
 
   beforeEach(function () {
-    var app = util.extendObject(appScheme, {
+    var app = Util.extendObject(appScheme, {
       id: "/test-app-1",
       healthChecks: [{path: "/", protocol: "HTTP"}],
       status: AppStatus.RUNNING,
@@ -773,7 +773,7 @@ describe("App Page component", function () {
   });
 
   it("returns the right health message for tasks with unknown health", function () {
-    var app = util.extendObject(appScheme, {
+    var app = Util.extendObject(appScheme, {
       id: "/test-app-1",
       status: AppStatus.RUNNING,
       tasks: [
@@ -791,7 +791,7 @@ describe("App Page component", function () {
   });
 
   it("returns the right health message for healthy tasks", function () {
-    var app = util.extendObject(appScheme, {
+    var app = Util.extendObject(appScheme, {
       id: "/test-app-1",
       status: AppStatus.RUNNING,
       tasks: [

--- a/src/test/util.test.js
+++ b/src/test/util.test.js
@@ -1,7 +1,7 @@
 var expect = require("chai").expect;
-var util = require("../js/helpers/util");
+var Util = require("../js/helpers/Util");
 
-describe("util", function () {
+describe("Util", function () {
 
   describe("param", function () {
 
@@ -10,29 +10,29 @@ describe("util", function () {
         hello: "world",
         foo: "bar"
       };
-      expect(util.param(obj)).to.equal("hello=world&foo=bar");
+      expect(Util.param(obj)).to.equal("hello=world&foo=bar");
     });
 
     it("handles spaces and other entities correctly", function () {
       var obj = {
         q: "is:open is:issue label:gui"
       };
-      expect(util.param(obj))
+      expect(Util.param(obj))
         .to.equal("q=is%3Aopen%20is%3Aissue%20label%3Agui");
     });
 
     it("handles bad input gracefully", function () {
       var obj = {};
-      expect(util.param(obj)).to.equal("");
+      expect(Util.param(obj)).to.equal("");
 
       obj = [1, 2, 3];
-      expect(util.param(obj)).to.equal("0=1&1=2&2=3");
+      expect(Util.param(obj)).to.equal("0=1&1=2&2=3");
 
       obj = null;
-      expect(util.param(obj)).to.equal(null);
+      expect(Util.param(obj)).to.equal(null);
 
       obj = "already=foo&also=bar";
-      expect(util.param(obj)).to.equal("already=foo&also=bar");
+      expect(Util.param(obj)).to.equal("already=foo&also=bar");
 
     });
 
@@ -44,14 +44,14 @@ describe("util", function () {
       var objA = {hello: "world", foo: "bar"};
       var objB = {hello: "there", baz: "foo"};
       var expectedResult = {hello: "there", foo: "bar", baz: "foo"};
-      var result = util.extendObject(objA, objB);
+      var result = Util.extendObject(objA, objB);
       expect(result).to.deep.equal(expectedResult);
     });
 
     it("returns a new object without modifying the source", function () {
       var objA = {hello: "world", foo: "bar"};
       var objB = {hello: "there", baz: "foo"};
-      var result = util.extendObject(objA, objB);
+      var result = Util.extendObject(objA, objB);
       expect(objA).to.deep.equal({hello: "world", foo: "bar"});
     });
 
@@ -67,13 +67,13 @@ describe("util", function () {
         flag: true
       };
 
-      var result = util.extendObject(objA, objB, objC);
+      var result = Util.extendObject(objA, objB, objC);
       expect(result).to.deep.equal(expectedResult);
     });
 
     it("always returns an object", function () {
       var expectedResult = {"0": "faz", "1": "bar"};
-      var result = util.extendObject(["foo", "bar"], ["faz"]);
+      var result = Util.extendObject(["foo", "bar"], ["faz"]);
       expect(result).to.deep.equal(expectedResult);
     });
   });
@@ -86,7 +86,7 @@ describe("util", function () {
         {name: "B", value: 2},
         {name: "C", value: 3}
       ];
-      var output = util.serializedArrayToDictionary(input);
+      var output = Util.serializedArrayToDictionary(input);
       expect(output).to.deep.equal({"A": 1, "B": 2, "C": 3});
     });
 
@@ -96,7 +96,7 @@ describe("util", function () {
         {name: "B.A", value: 2},
         {name: "B.B", value: 3}
       ];
-      var output = util.serializedArrayToDictionary(input);
+      var output = Util.serializedArrayToDictionary(input);
       expect(output).to.deep.equal({"A": 1, "B": {"A": 2, "B": 3}});
     });
 
@@ -105,7 +105,7 @@ describe("util", function () {
         {name: "A", value: 1},
         {name: "A", value: 2}
       ];
-      var output = util.serializedArrayToDictionary(input);
+      var output = Util.serializedArrayToDictionary(input);
       expect(output).to.deep.equal({"A": 2});
     });
 
@@ -113,13 +113,13 @@ describe("util", function () {
       var input = [
         {name: "A.B.C.D.E", value: 1}
       ];
-      var output = util.serializedArrayToDictionary(input);
+      var output = Util.serializedArrayToDictionary(input);
       expect(output).to.deep.equal({"A": {"B": {"C": {"D": {"E": 1}}}}});
     });
 
     it("handles empty arrays correctly", function () {
       var input = [];
-      var output = util.serializedArrayToDictionary(input);
+      var output = Util.serializedArrayToDictionary(input);
       expect(output).to.deep.equal({});
     });
 
@@ -128,7 +128,7 @@ describe("util", function () {
         {name: "A[0]", value: 1},
         {name: "A[1]", value: 2}
       ];
-      var output = util.serializedArrayToDictionary(input);
+      var output = Util.serializedArrayToDictionary(input);
       expect(output).to.deep.equal({"A": [1, 2]});
     });
 
@@ -137,7 +137,7 @@ describe("util", function () {
         {name: "A[0].A", value: 1},
         {name: "A[1].B", value: 2}
       ];
-      var output = util.serializedArrayToDictionary(input);
+      var output = Util.serializedArrayToDictionary(input);
       expect(output).to.deep.equal({"A": [{"A": 1}, {"B": 2}]});
     });
 
@@ -148,7 +148,7 @@ describe("util", function () {
         {name: "A[1].A", value: 3},
         {name: "A[1].B", value: 4}
       ];
-      var output = util.serializedArrayToDictionary(input);
+      var output = Util.serializedArrayToDictionary(input);
       expect(output).to.deep.equal({"A": [{"A": 1, "B": 2}, {"A": 3, "B": 4}]});
     });
 
@@ -156,7 +156,7 @@ describe("util", function () {
       var input = [
         {name: "A[0].B[0].C", value: 1}
       ];
-      var output = util.serializedArrayToDictionary(input);
+      var output = Util.serializedArrayToDictionary(input);
       expect(output).to.deep.equal({"A": [{"B": [{"C": 1}]}]});
     });
 
@@ -166,7 +166,7 @@ describe("util", function () {
         var input = [
           {name: ".A.B", value: 1}
         ];
-        var output = util.serializedArrayToDictionary(input);
+        var output = Util.serializedArrayToDictionary(input);
         expect(output).to.deep.equal({"A": {"B": 1}});
       });
 
@@ -174,7 +174,7 @@ describe("util", function () {
         var input = [
           {name: "A.B.", value: 1}
         ];
-        var output = util.serializedArrayToDictionary(input);
+        var output = Util.serializedArrayToDictionary(input);
         expect(output).to.deep.equal({"A": {"B": 1}});
       });
 
@@ -182,7 +182,7 @@ describe("util", function () {
         var input = [
           {name: "A..B", value: 1}
         ];
-        var output = util.serializedArrayToDictionary(input);
+        var output = Util.serializedArrayToDictionary(input);
         expect(output).to.deep.equal({"A": {"B": 1}});
       });
 
@@ -191,7 +191,7 @@ describe("util", function () {
           {name: "A[].B", value: 1},
           {name: "A[].B", value: 2}
         ];
-        var output = util.serializedArrayToDictionary(input);
+        var output = Util.serializedArrayToDictionary(input);
         expect(output).to.deep.equal({"A": [{"B": 1}, {"B": 2}]});
       });
 


### PR DESCRIPTION
According to this convention:
https://github.com/airbnb/javascript#22.8

___export___ a singleton / function _library_ / bare object

This explains why our constants are in PascalCase. They are _exported_ objects.

An exported _function_, like the qajaxWrapper, should be in camelCase indeed, so here is no action necessary
https://github.com/airbnb/javascript#22.7

Thanx to @philipnrmn to read further on 22. ;)