### PR TITLE
Teamcity reporter

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6062,6 +6062,10 @@
         }
       }
     },
+    "mocha-teamcity-reporter": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/mocha-teamcity-reporter/-/mocha-teamcity-reporter-0.0.4.tgz"
+    },
     "moment": {
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "clean": "rm -rf dist release",
     "dist": "export GULP_ENV=\"production\" && npm run clean && npm run test && npm run build",
     "shrinkwrap": "npm-shrinkwrap --dev",
-    "test": "mocha --ui exports --reporter spec --compilers jsx:babel-core/register src/test/**/*.test.* src/test/*.test.*",
+    "test": "mocha --ui exports --reporter src/test/reporter/reporterSwitch --compilers jsx:babel-core/register src/test/**/*.test.* src/test/*.test.*",
     "serve": "export GULP_ENV=\"development\" DISABLE_SOURCE_MAP=false && gulp serve",
     "livereload": "export GULP_ENV=\"development\" DISABLE_SOURCE_MAP=false && gulp livereload",
     "package": "gulp war"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "gulp-war": "0.0.1",
     "gulp-zip": "^3.0.2",
     "mocha": "^2.1.0",
+    "mocha-teamcity-reporter": "0.0.4",
     "npm-shrinkwrap": "^5.4.0",
     "oboe": "^2.1.2",
     "sinon": "^1.12.2",

--- a/src/test/reporter/reporterSwitch.js
+++ b/src/test/reporter/reporterSwitch.js
@@ -1,0 +1,9 @@
+var reporter;
+
+if (process.env.TEAMCITY_VERSION == null) {
+  reporter = require("../../../node_modules/mocha/lib/reporters/spec");
+} else {
+  reporter = require("../../../node_modules/mocha-teamcity-reporter");
+}
+
+exports = module.exports = reporter;


### PR DESCRIPTION
If running the tests in a TeamCity environment the mocha teamcity reporter will be used instead of the default mocha spec reporter.
This is useful in our webjar packing process.