### PR TITLE
Last failed task tab in app view.

### DIFF
--- a/src/js/components/AppLastTaskFailureComponent.jsx
+++ b/src/js/components/AppLastTaskFailureComponent.jsx
@@ -1,0 +1,88 @@
+var React = require("react/addons");
+
+var AppsStore = require("../stores/AppsStore");
+var AppsActions = require("../actions/AppsActions");
+var AppsEvents = require("../events/AppsEvents");
+var TaskMesosUrlComponent = require("../components/TaskMesosUrlComponent");
+
+var AppLastTaskFailureComponent = React.createClass({
+  displayName: "AppLastTaskFailureComponent",
+
+  propTypes: {
+    appId: React.PropTypes.string.isRequired
+  },
+
+  getInitialState: function () {
+    return {
+      app: AppsStore.getCurrentApp(this.props.appId)
+    };
+  },
+
+  componentWillMount: function () {
+    AppsStore.on(AppsEvents.CHANGE, this.onAppsChange);
+  },
+
+  componentWillUnmount: function () {
+    AppsStore.removeListener(AppsEvents.CHANGE, this.onAppsChange);
+  },
+
+  handleRefresh: function () {
+    AppsActions.requestApp(this.props.appId);
+  },
+
+  onAppsChange: function () {
+    this.setState({
+      app: AppsStore.getCurrentApp(this.props.appId)
+    });
+  },
+
+  render: function () {
+    var app = this.state.app;
+    var lastTaskFailure = app.lastTaskFailure;
+    if (lastTaskFailure != null) {
+      return (
+        <div>
+          <h5>
+            Last Task Failure
+            <button className="btn btn-sm btn-info pull-right"
+              onClick={this.handleRefresh}>
+              ↻ Refresh
+            </button>
+          </h5>
+          <div>
+              <dl className="dl-horizontal">
+                  <dt>Task id</dt>
+                  <dd>{lastTaskFailure.taskId}</dd>
+                  <dt>State</dt>
+                  <dd>{lastTaskFailure.state}</dd>
+                  <dt>Message</dt>
+                  <dd>{lastTaskFailure.message}</dd>
+                  <dt>Host</dt>
+                  <dd>{lastTaskFailure.host}</dd>
+                  <dt>Timestamp</dt>
+                  <dd>{lastTaskFailure.timestamp}</dd>
+                  <dt>Version</dt>
+                  <dd>{lastTaskFailure.version}</dd>
+                  <dt>Mesos details</dt>
+                  <dd><TaskMesosUrlComponent task={lastTaskFailure}/></dd>
+              </dl>
+          </div>
+        </div>
+      );
+    } else {
+      return (
+        <div>
+          <h5>
+            This app does not have failed task
+          </h5>
+            <button className="btn btn-sm btn-info pull-right"
+              onClick={this.handleRefresh}>
+              ↻ Refresh
+            </button>
+        </div>
+      );
+    }
+  }
+});
+
+module.exports = AppLastTaskFailureComponent;

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -7,6 +7,7 @@ var AppBreadcrumbsComponent = require("../components/AppBreadcrumbsComponent");
 var AppStatus = require("../constants/AppStatus");
 var AppStatusComponent = require("../components/AppStatusComponent");
 var AppVersionsActions = require("../actions/AppVersionsActions");
+var AppLastTaskFailureComponent = require("../components/AppLastTaskFailureComponent");
 var AppVersionListComponent = require("../components/AppVersionListComponent");
 var HealthStatus = require("../constants/HealthStatus");
 var States = require("../constants/States");
@@ -21,7 +22,8 @@ var QueueStore = require("../stores/QueueStore");
 
 var tabsTemplate = [
   {id: "apps/:appId", text: "Tasks"},
-  {id: "apps/:appId/configuration", text: "Configuration"}
+  {id: "apps/:appId/configuration", text: "Configuration"},
+  {id: "apps/:appId/last-task-failure", text: "Last task failure"}
 ];
 
 var AppPageComponent = React.createClass({
@@ -67,6 +69,8 @@ var AppPageComponent = React.createClass({
 
     if (view === "configuration") {
       activeTabId += "/configuration";
+    } else if (view === "last-task-failure") {
+      activeTabId += "/last-task-failure";
     } else if (view != null) {
       activeTaskId = view;
       activeViewIndex = 1;
@@ -348,6 +352,10 @@ var AppPageComponent = React.createClass({
         <TabPaneComponent
           id={"apps/" + encodeURIComponent(state.appId) + "/configuration"}>
           <AppVersionListComponent appId={state.appId} />
+        </TabPaneComponent>
+        <TabPaneComponent
+          id={"apps/" + encodeURIComponent(state.appId) + "/last-task-failure"}>
+          <AppLastTaskFailureComponent appId={state.appId} />
         </TabPaneComponent>
       </TogglableTabsComponent>
     );

--- a/src/js/components/TaskMesosUrlComponent.jsx
+++ b/src/js/components/TaskMesosUrlComponent.jsx
@@ -51,7 +51,7 @@ var TaskMesosUrlComponent = React.createClass({
           "/frameworks/",
           frameworkId,
           "/executors/",
-          task.id
+          task.id || task.taskId
         ].join("");
         return url;
       }

--- a/src/js/stores/appScheme.js
+++ b/src/js/stores/appScheme.js
@@ -11,6 +11,7 @@ var appScheme = {
   healthChecks: [],
   id: null,
   instances: 0,
+  lastTaskFailure: null,
   status: AppStatus.SUSPENDED,
   mem: null,
   disk: null,

--- a/src/test/appLastTaskFailure.test.js
+++ b/src/test/appLastTaskFailure.test.js
@@ -1,0 +1,93 @@
+var expect = require("chai").expect;
+var React = require("react/addons");
+var TestUtils = React.addons.TestUtils;
+
+var config = require("../js/config/config");
+var Util = require("../js/helpers/Util");
+var appScheme = require("../js/stores/appScheme");
+var InfoStore = require("../js/stores/InfoStore");
+var AppsStore = require("../js/stores/AppsStore");
+var AppLastTaskFailureComponent = require("../js/components/AppLastTaskFailureComponent");
+
+var expectAsync = require("./helpers/expectAsync");
+var HttpServer = require("./helpers/HttpServer").HttpServer;
+
+var server = new HttpServer(config.localTestserverURI);
+config.apiURL = "http://" + server.address + ":" + server.port + "/";
+
+describe("App last task failure component", function () {
+
+  afterEach(function () {
+    this.renderer.unmount();
+  });
+
+  it("should show failed task", function () {
+    this.model = {
+      appId: "/python",
+      id: "task-123",
+      slaveId: "20150720-125149-3839899402-5050-16758-S1"
+    };
+    InfoStore.info = {
+      "version": "1.2.3",
+      "frameworkId": "framework1",
+      "leader": "leader1.dcos.io",
+      "marathon_config": {
+        "marathon_field_1": "mf1",
+        "mesos_master_url": "http://leader1.dcos.io:5050"
+      }
+    };
+    this.appId = '/python';
+    var app = Util.extendObject(appScheme, {
+      id: "/python",
+      lastTaskFailure: {
+        appId: "/python",
+        host: "slave1.dcos.io",
+        message: "Slave slave1.dcos.io removed",
+        state: "TASK_LOST",
+        taskId: "python.83c0a69b-256a-11e5-aaed-fa163eaaa6b7",
+        timestamp: "2015-08-05T09:08:56.349Z",
+        version: "2015-07-06T12:37:28.774Z"
+      }
+    });
+
+    AppsStore.apps = [app];
+
+    this.renderer = TestUtils.createRenderer();
+    this.renderer.render(<AppLastTaskFailureComponent appId={this.appId} />);
+    this.component = this.renderer.getRenderOutput();
+
+    var element = this.component.props.children[1].props.children.props.children;
+
+    var taskId = element[1]._store.props.children;
+    var state = element[3]._store.props.children;
+    var message = element[5]._store.props.children;
+    var host = element[7]._store.props.children;
+    var timestamp = element[9]._store.props.children;
+    var version = element[11]._store.props.children;
+    var mesosElement= element[13]._store.props.children.type.displayName;
+
+    expect(taskId).to.equal('python.83c0a69b-256a-11e5-aaed-fa163eaaa6b7');
+    expect(state).to.equal('TASK_LOST');
+    expect(message).to.equal('Slave slave1.dcos.io removed');
+    expect(host).to.equal('slave1.dcos.io');
+    expect(timestamp).to.equal('2015-08-05T09:08:56.349Z');
+    expect(version).to.equal('2015-07-06T12:37:28.774Z');
+  });
+
+  it("should show message when app never failed", function () {
+
+    this.appId = '/python';
+    var app = Util.extendObject(appScheme, {
+      id: "/python",
+    });
+
+    AppsStore.apps = [app];
+
+    this.renderer = TestUtils.createRenderer();
+    this.renderer.render(<AppLastTaskFailureComponent appId={this.appId} />);
+    this.component = this.renderer.getRenderOutput();
+
+    var message = this.component.props.children[0]._store.props.children;
+    expect(message).to.equal('This app does not have failed task');
+  });
+});


### PR DESCRIPTION
Ability to show details of last task failure in app.
Allows to faster detection of problems with running applications in Marathon.

This PR required changes in REST API https://github.com/mesosphere/marathon/pull/1948
It helps resolve https://github.com/mesosphere/marathon/issues/968

Tab view when app have failed task:
![marathon_failed_task2](https://cloud.githubusercontent.com/assets/695791/9106509/1669d76e-3c21-11e5-8e72-f5698527c520.png)

Tab view when app doesn't have failed task:
![marathon_failed_task1](https://cloud.githubusercontent.com/assets/695791/9106514/1d234928-3c21-11e5-8dcd-f5bde0e3f3a7.png)

