### PR TITLE
Last task failure tab additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - \#1756 - Create a "Not found page"
 - \#878 - Jump to Mesos sandbox from UI
   * You can go directly to the Mesos tasks sandbox from the tasks detail page.
+- \#968 - Expose a way to identify "fragile" marathon apps in the web UI
+  * If there is a lastTaskFailure this information will be shown in a tab
+    called "Last task failure" on the app page.
 
 ### Changed
 - #124 - Expose all /v2 App attributes in UI

--- a/src/js/components/AppLastTaskFailureComponent.jsx
+++ b/src/js/components/AppLastTaskFailureComponent.jsx
@@ -63,7 +63,7 @@ var AppLastTaskFailureComponent = React.createClass({
                   <dd>{lastTaskFailure.timestamp}</dd>
                   <dt>Version</dt>
                   <dd>{lastTaskFailure.version}</dd>
-                  <dt>Mesos details</dt>
+                  <dt>Mesos Details</dt>
                   <dd><TaskMesosUrlComponent task={lastTaskFailure}/></dd>
               </dl>
           </div>

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -68,11 +68,7 @@ var AppPageComponent = React.createClass({
       }
 
       if (tab.id === "apps/:appId/last-task-failure") {
-        if (app.lastTaskFailure == null) {
-          tab.hidden = true;
-        } else {
-          tab.hidden = false;
-        }
+        tab.hidden = app.lastTaskFailure == null;
       }
 
       return {
@@ -155,13 +151,8 @@ var AppPageComponent = React.createClass({
     tabs = tabs.map(function (tab) {
       var tabId = `apps/${encodeURIComponent(state.appId)}/last-task-failure`;
       if (tab.id === tabId) {
-        if (app.lastTaskFailure == null) {
-          tab.hidden = true;
-        } else {
-          tab.hidden = false;
-        }
+        tab.hidden = app.lastTaskFailure == null;
       }
-
       return tab;
     });
 

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -23,7 +23,11 @@ var QueueStore = require("../stores/QueueStore");
 var tabsTemplate = [
   {id: "apps/:appId", text: "Tasks"},
   {id: "apps/:appId/configuration", text: "Configuration"},
-  {id: "apps/:appId/last-task-failure", text: "Last task failure"}
+  {
+    id: "apps/:appId/last-task-failure",
+    text: "Last task failure",
+    hidden: true
+  }
 ];
 
 var AppPageComponent = React.createClass({
@@ -55,15 +59,26 @@ var AppPageComponent = React.createClass({
     var activeViewIndex = 0;
     var activeTaskId = null;
 
+    var app = AppsStore.getCurrentApp(appId);
+
     var tabs = tabsTemplate.map(function (tab) {
       var id = tab.id.replace(":appId", encodeURIComponent(appId));
       if (activeTabId == null) {
         activeTabId = id;
       }
 
+      if (tab.id === "apps/:appId/last-task-failure") {
+        if (app.lastTaskFailure == null) {
+          tab.hidden = true;
+        } else {
+          tab.hidden = false;
+        }
+      }
+
       return {
         id: id,
-        text: tab.text
+        text: tab.text,
+        hidden: tab.hidden
       };
     });
 
@@ -80,7 +95,7 @@ var AppPageComponent = React.createClass({
       activeTabId: activeTabId,
       activeTaskId: activeTaskId,
       activeViewIndex: activeViewIndex,
-      app: AppsStore.getCurrentApp(appId),
+      app: app,
       appId: appId,
       view: decodeURIComponent(params.view),
       tabs: tabs
@@ -133,9 +148,27 @@ var AppPageComponent = React.createClass({
   },
 
   onAppChange: function () {
+    var state = this.state;
+    var app = AppsStore.getCurrentApp(state.appId);
+    var tabs = state.tabs;
+
+    tabs = tabs.map(function (tab) {
+      var tabId = `apps/${encodeURIComponent(state.appId)}/last-task-failure`;
+      if (tab.id === tabId) {
+        if (app.lastTaskFailure == null) {
+          tab.hidden = true;
+        } else {
+          tab.hidden = false;
+        }
+      }
+
+      return tab;
+    });
+
     this.setState({
-      app: AppsStore.getCurrentApp(this.state.appId),
-      fetchState: States.STATE_SUCCESS
+      app: app,
+      fetchState: States.STATE_SUCCESS,
+      tabs: tabs
     });
 
     if (this.state.view === "configuration") {

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -25,7 +25,7 @@ var tabsTemplate = [
   {id: "apps/:appId/configuration", text: "Configuration"},
   {
     id: "apps/:appId/last-task-failure",
-    text: "Last task failure",
+    text: "Last Task Failure",
     hidden: true
   }
 ];

--- a/src/js/components/NavTabsComponent.jsx
+++ b/src/js/components/NavTabsComponent.jsx
@@ -50,6 +50,10 @@ var NavTabsComponent = React.createClass({
     var activeTabId = this.props.activeTabId;
 
     var tabs = this.props.tabs.map(function (tab) {
+      if (tab.hidden === true) {
+        return null;
+      }
+
       var tabClassSet = classNames({
         "active": tab.id === activeTabId
       });

--- a/src/js/components/TaskDetailComponent.jsx
+++ b/src/js/components/TaskDetailComponent.jsx
@@ -80,7 +80,7 @@ var TaskDetailComponent = React.createClass({
             </dd>
             <dt>Health</dt>
             <dd className={healthClassSet}>{this.props.taskHealthMessage}</dd>
-            <dt>Mesos details</dt>
+            <dt>Mesos Details</dt>
             <dd><TaskMesosUrlComponent task={task}/></dd>
           </dl>
           {hasHealth ?


### PR DESCRIPTION
Preceding PR from @quamilek which adds a "Last task failure"-tab:
https://github.com/mesosphere/marathon-ui/pull/122

This adds the appropriate line to the CHANGELOG.
And the tab will only shows up if there is a lastTaskFailure.
Regarded issue:
https://github.com/mesosphere/marathon/issues/968
Regarded duplicate issue:
https://github.com/mesosphere/marathon/issues/1179
