### PR TITLE
Fix - Show error on non existing task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
   * The task list shows the last available page
     if tasks count decreases after scaling.
 - \#1872 - Kill & Scale should be available for more than one task
+- \#1960 - Task detail error message doesn't show up on non existent task
 
 ## 0.10.0 - 2015-07-10
 ### Added

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -340,14 +340,11 @@ var AppPageComponent = React.createClass({
     var state = this.state;
     var model = state.app;
 
-    var task = AppsStore.getTask(this.state.appId, state.activeTaskId);
-
-    if (task == null) {
-      return null;
-    }
+    var task = AppsStore.getTask(state.appId, state.activeTaskId);
 
     return (
       <TaskDetailComponent
+        appId={state.appId}
         fetchState={state.fetchState}
         taskHealthMessage={this.getTaskHealthMessage(state.activeTaskId)}
         hasHealth={model.healthChecks > 0}

--- a/src/js/components/TaskDetailComponent.jsx
+++ b/src/js/components/TaskDetailComponent.jsx
@@ -1,4 +1,5 @@
 var classNames = require("classnames");
+var Link = require("react-router").Link;
 var React = require("react/addons");
 
 var States = require("../constants/States");
@@ -11,82 +12,109 @@ var TaskDetailComponent = React.createClass({
   displayName: "TaskDetailComponent",
 
   propTypes: {
+    appId: React.PropTypes.string.isRequired,
     fetchState: React.PropTypes.number.isRequired,
     hasHealth: React.PropTypes.bool,
-    task: React.PropTypes.object.isRequired,
+    task: React.PropTypes.object,
     taskHealthMessage: React.PropTypes.string
   },
 
-  render: function () {
-    var task = this.props.task;
-    var hasHealth = !!this.props.hasHealth;
-    var hasError =
-      this.props.fetchState === States.STATE_ERROR ||
-      task == null;
-    var taskHealth = task.healthStatus;
-    var healthClassSet;
-    var timeNodes;
-    var timeFields;
-    var appUri = "#apps/" + encodeURIComponent(this.props.task.appId);
-
+  getErrorMessage: function (hasError) {
     if (!hasError) {
-      healthClassSet = classNames({
-        "text-unhealthy": taskHealth === HealthStatus.UNHEALTHY,
-        "text-muted": taskHealth === HealthStatus.UNKNOWN
-      });
-
-      timeNodes = [
-        {
-          label: "Staged at",
-          time: task.stagedAt
-        }, {
-          label: "Started at",
-          time: task.startedAt
-        }
-      ];
-      timeFields = timeNodes.map(function (timeNode, index) {
-        return (
-          <TimeFieldComponent
-            key={index}
-            label={timeNode.label}
-            time={timeNode.time} />
-        );
-      });
+      return null;
     }
+
+    return (
+      <p className="text-center text-danger">
+        Error fetching task details.
+        Go to <Link to="app" params={{appId: encodeURIComponent(this.props.appId)}}>Task List</Link> to see the full list.
+      </p>
+    );
+  },
+
+  getTaskHealthComponent: function () {
+    var props = this.props;
+    var task = props.task;
+
+    if (task == null || !props.hasHealth) {
+      return null;
+    }
+
+    return <TaskHealthComponent task={task} />;
+  },
+
+  getTaskDetails: function () {
+    var props = this.props;
+    var task = props.task;
+
+    if (task == null) {
+      return null;
+    }
+
+    var taskHealth = task.healthStatus;
+    var healthClassSet = classNames({
+      "text-unhealthy": taskHealth === HealthStatus.UNHEALTHY,
+      "text-muted": taskHealth === HealthStatus.UNKNOWN
+    });
+
+    var timeNodes = [
+      {
+        label: "Staged at",
+        time: task.stagedAt
+      }, {
+        label: "Started at",
+        time: task.startedAt
+      }
+    ];
+
+    var timeFields = timeNodes.map(function (timeNode, index) {
+      return (
+        <TimeFieldComponent
+          key={index}
+          label={timeNode.label}
+          time={timeNode.time} />
+      );
+    });
+
+    return (
+      <div>
+        <dl className="dl-horizontal">
+          <dt>Host</dt>
+          <dd>{task.host}</dd>
+          <dt>Ports</dt>
+          <dd>[{task.ports.toString()}]</dd>
+          <dt>Status</dt>
+          <dd>{task.status}</dd>
+          {timeFields}
+          <dt>Version</dt>
+          <dd>
+            <time dateTime={task.version}>
+              {new Date(task.version).toLocaleString()}
+            </time>
+          </dd>
+          <dt>Health</dt>
+          <dd className={healthClassSet}>{props.taskHealthMessage}</dd>
+          <dt>Mesos details</dt>
+          <dd><TaskMesosUrlComponent task={task}/></dd>
+        </dl>
+        {this.getTaskHealthComponent()}
+      </div>
+    );
+  },
+
+  render: function () {
+    var props = this.props;
+    var task = props.task;
+
+    var hasError =
+      props.fetchState === States.STATE_ERROR ||
+      task == null;
 
     return (
       <div className="page-body page-body-no-top">
         <h5>Task Details</h5>
-        {hasError ?
-          <p className="text-center text-danger">
-            Error fetching task details.
-            Go to <a href={appUri}>Task List</a> to see the full list.
-          </p> :
-          null}
-        {<div>
-          <dl className="dl-horizontal">
-            <dt>Host</dt>
-            <dd>{task.host}</dd>
-            <dt>Ports</dt>
-            <dd>[{task.ports.toString()}]</dd>
-            <dt>Status</dt>
-            <dd>{task.status}</dd>
-            {timeFields}
-            <dt>Version</dt>
-            <dd>
-              <time dateTime={task.version}>
-                {new Date(task.version).toLocaleString()}
-              </time>
-            </dd>
-            <dt>Health</dt>
-            <dd className={healthClassSet}>{this.props.taskHealthMessage}</dd>
-            <dt>Mesos Details</dt>
-            <dd><TaskMesosUrlComponent task={task}/></dd>
-          </dl>
-          {hasHealth ?
-            <TaskHealthComponent task={task} /> :
-            null}
-        </div>}
+        {this.getErrorMessage(hasError)}
+        {this.getTaskDetails()}
       </div>
     );
   }


### PR DESCRIPTION
This reenables the tasks detail pages error message, alongside with some little refactoring of the task details code.
This functionality was broken before.

https://github.com/mesosphere/marathon/issues/1960