### PR TITLE
Feature - 1058 health sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
     if tasks count decreases after scaling.
 - \#1872 - Kill & Scale should be available for more than one task
 - \#1960 - Task detail error message doesn't show up on non existent task
+- \#1989 - HealthBar isn't working correctly on non existing health data
 
 ## 0.10.0 - 2015-07-10
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   * If there is a lastTaskFailure this information will be shown in a tab
     called "Last task failure" on the app page.
 - \#1937 - Display version string also in local time
+- \#1058 - Add sorting to the health column in the app list
 
 ### Changed
 - #124 - Expose all /v2 App attributes in UI

--- a/src/js/components/AppHealthComponent.jsx
+++ b/src/js/components/AppHealthComponent.jsx
@@ -3,9 +3,20 @@ var React = require("react/addons");
 
 var TooltipMixin = require("../mixins/TooltipMixin");
 
+var HealthStatus = require("../constants/HealthStatus");
+
 function roundWorkaround(x) {
   return Math.floor(x * 1000) / 1000;
 }
+
+var healthNameMap = {
+  [HealthStatus.HEALTHY]: "healthy",
+  [HealthStatus.UNHEALTHY]: "unhealthy",
+  [HealthStatus.UNKNOWN]: "running",
+  [HealthStatus.STAGED]: "staged",
+  [HealthStatus.OVERCAPACITY]: "over-capacity",
+  [HealthStatus.UNSCHEDULED]: "unscheduled"
+};
 
 var AppHealthComponent = React.createClass({
   displayName: "AppHealthComponent",
@@ -29,8 +40,6 @@ var AppHealthComponent = React.createClass({
   getHealthBar: function () {
     var health = this.props.model.health;
 
-    console.log(this.props.model);
-
     // normalize quantities to add up to 100%. Cut off digits at
     // third decimal to work around rounding error leading to more than 100%.
     var dataSum = health.reduce(function (a, x) {
@@ -39,6 +48,7 @@ var AppHealthComponent = React.createClass({
 
     var allZeroWidthBefore = true;
     return health.map(function (d, i) {
+      var name = healthNameMap[d.state];
       var width = roundWorkaround(d.quantity * 100 / dataSum);
       var classSet = {
         // set health-bar-inner class for bars in the stack which have a
@@ -47,7 +57,7 @@ var AppHealthComponent = React.createClass({
         "progress-bar": true
       };
       // add health bar name
-      classSet["health-bar-" + d.name] = true;
+      classSet["health-bar-" + name] = true;
 
       if (width !== 0) {
         allZeroWidthBefore = false;
@@ -61,7 +71,7 @@ var AppHealthComponent = React.createClass({
           "data-behavior": "show-tip",
           "data-tip-type-class": "default",
           "data-tip-place": "top",
-          "data-tip-content": d.name,
+          "data-tip-content": name,
           "onMouseOver": this.handleMouseOverHealthBar.bind(null, ref),
           "onMouseOut": this.handleMouseOutHealthBar.bind(null, ref)
         };

--- a/src/js/components/AppHealthComponent.jsx
+++ b/src/js/components/AppHealthComponent.jsx
@@ -26,57 +26,19 @@ var AppHealthComponent = React.createClass({
     this.tip_hideTip(el);
   },
 
-  getHealthData: function () {
-    var model = this.props.model;
-
-    var tasksWithUnknownHealth = Math.max(
-      model.tasksRunning -
-      model.tasksHealthy -
-      model.tasksUnhealthy,
-      0
-    );
-
-    var healthData = [
-      {quantity: model.tasksHealthy, name: "healthy"},
-      {quantity: model.tasksUnhealthy, name: "unhealthy"},
-      {quantity: tasksWithUnknownHealth, name: "running"},
-      {quantity: model.tasksStaged, name: "staged"}
-    ];
-
-    // cut off after `instances` many tasks...
-    var tasksSum = 0;
-    for (var i = 0; i < healthData.length; i++) {
-      var capacityLeft = Math.max(0, model.instances - tasksSum);
-      tasksSum += healthData[i].quantity;
-      healthData[i].quantity = Math.min(capacityLeft, healthData[i].quantity);
-    }
-
-    // ... show everything above that in blue
-    var overCapacity = Math.max(0, tasksSum - model.instances);
-
-    healthData.push({quantity: overCapacity, name: "over-capacity"});
-
-    // add unscheduled task, or show black if completely suspended
-    var isSuspended = model.instances === 0 && tasksSum === 0;
-    var unscheduled = Math.max(0, (model.instances - tasksSum));
-    var unscheduledOrSuspended = isSuspended ? 1 : unscheduled;
-
-    healthData.push({quantity: unscheduledOrSuspended, name: "unscheduled"});
-
-    return healthData;
-  },
-
   getHealthBar: function () {
-    var healthData = this.getHealthData();
+    var health = this.props.model.health;
+
+    console.log(this.props.model);
 
     // normalize quantities to add up to 100%. Cut off digits at
     // third decimal to work around rounding error leading to more than 100%.
-    var dataSum = healthData.reduce(function (a, x) {
+    var dataSum = health.reduce(function (a, x) {
       return a + x.quantity;
     }, 0);
 
     var allZeroWidthBefore = true;
-    return healthData.map(function (d, i) {
+    return health.map(function (d, i) {
       var width = roundWorkaround(d.quantity * 100 / dataSum);
       var classSet = {
         // set health-bar-inner class for bars in the stack which have a

--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -172,8 +172,9 @@ var AppListComponent = React.createClass({
               </span>
             </th>
             <th className="text-right">
-              <span className={headerClassSet}>
-                Health
+              <span onClick={this.sortBy.bind(null, "healthWeight")}
+                  className={headerClassSet}>
+                {this.getCaret("healthWeight")} Health
               </span>
             </th>
             <th className="text-right">

--- a/src/js/constants/HealthStatus.js
+++ b/src/js/constants/HealthStatus.js
@@ -1,7 +1,10 @@
 const HealthStatus = {
   HEALTHY: 0,
   UNHEALTHY: 1,
-  UNKNOWN: 2
+  UNKNOWN: 2,
+  STAGED: 3,
+  OVERCAPACITY: 4,
+  UNSCHEDULED: 5
 };
 
 module.exports = Object.freeze(HealthStatus);

--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -65,10 +65,10 @@ function getAppHealth(app) {
   );
 
   var healthData = [
-    {quantity: app.tasksHealthy, name: "healthy"},
-    {quantity: app.tasksUnhealthy, name: "unhealthy"},
-    {quantity: tasksWithUnknownHealth, name: "running"},
-    {quantity: app.tasksStaged, name: "staged"}
+    {quantity: app.tasksHealthy, state: HealthStatus.HEALTHY},
+    {quantity: app.tasksUnhealthy, state: HealthStatus.UNHEALTHY},
+    {quantity: tasksWithUnknownHealth, state: HealthStatus.UNKNOWN},
+    {quantity: app.tasksStaged, state: HealthStatus.STAGED}
   ];
 
   // cut off after `instances` many tasks...
@@ -82,16 +82,24 @@ function getAppHealth(app) {
   // ... show everything above that in blue
   var overCapacity = Math.max(0, tasksSum - app.instances);
 
-  healthData.push({quantity: overCapacity, name: "over-capacity"});
+  healthData.push({quantity: overCapacity, state: HealthStatus.OVERCAPACITY});
 
   // add unscheduled task, or show black if completely suspended
   var isSuspended = app.instances === 0 && tasksSum === 0;
   var unscheduled = Math.max(0, (app.instances - tasksSum));
   var unscheduledOrSuspended = isSuspended ? 1 : unscheduled;
 
-  healthData.push({quantity: unscheduledOrSuspended, name: "unscheduled"});
+  healthData.push({
+    quantity: unscheduledOrSuspended,
+    state: HealthStatus.UNSCHEDULED
+  });
 
   return healthData;
+}
+
+function getAppHealthWeight(health) {
+  return health.reduce(function (weight, state) {
+  }, 0);
 }
 
 function processApp(app) {

--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -11,14 +11,14 @@ var TaskStatus = require("../constants/TaskStatus");
 var QueueStore = require("./QueueStore");
 var QueueEvents = require("../events/QueueEvents");
 
-var healthWeights = {
+const healthWeights = Object.freeze({
   [HealthStatus.UNHEALTHY]: 32,
   [HealthStatus.OVERCAPACITY]: 16,
   [HealthStatus.STAGED]: 8,
   [HealthStatus.HEALTHY]: 4,
   [HealthStatus.UNKNOWN]: 2,
   [HealthStatus.UNSCHEDULED]: 1
-};
+});
 
 function removeApp(apps, appId) {
   return lazy(apps).reject({
@@ -82,8 +82,8 @@ function getAppHealth(app) {
 
   // cut off after `instances` many tasks...
   var tasksSum = 0;
-  for (var i = 0; i < healthData.length; i++) {
-    var capacityLeft = Math.max(0, app.instances - tasksSum);
+  for (let i = 0; i < healthData.length; i++) {
+    let capacityLeft = Math.max(0, app.instances - tasksSum);
     tasksSum += healthData[i].quantity;
     healthData[i].quantity = Math.min(capacityLeft, healthData[i].quantity);
   }

--- a/src/js/stores/appScheme.js
+++ b/src/js/stores/appScheme.js
@@ -9,6 +9,8 @@ var appScheme = {
   env: {},
   executor: "",
   healthChecks: [],
+  health: [],
+  healthWeight: 0,
   id: null,
   instances: 0,
   lastTaskFailure: null,

--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -587,12 +587,12 @@ describe("App Health component", function () {
     var model = {
       id: "app-123",
       health: [
-        { name: 'healthy', quantity: 2 },
-        { name: 'unhealthy', quantity: 2 },
-        { name: 'running', quantity: 1 },
-        { name: 'staged', quantity: 1 },
-        { name: 'over-capacity', quantity: 2 },
-        { name: 'unscheduled', quantity: 2 }
+        { state: HealthStatus.HEALTHY, quantity: 2 },
+        { state: HealthStatus.UNHEALTHY, quantity: 2 },
+        { state: HealthStatus.UNKNOWN, quantity: 1 },
+        { state: HealthStatus.STAGED, quantity: 1 },
+        { state: HealthStatus.OVERCAPACITY, quantity: 2 },
+        { state: HealthStatus.UNSCHEDULED, quantity: 2 }
       ]
     };
 
@@ -633,6 +633,36 @@ describe("App Health component", function () {
   it("health bar for unscheduled tasks has correct width", function () {
     var width = this.component.props.children[5].props.style.width;
     expect(width).to.equal("20%");
+  });
+
+  it("health bar for healthy tasks has correct content", function () {
+    var content = this.component.props.children[0].props["data-tip-content"];
+    expect(content).to.equal("healthy");
+  });
+
+  it("health bar for unhealthy tasks has correct content", function () {
+    var content = this.component.props.children[1].props["data-tip-content"];
+    expect(content).to.equal("unhealthy");
+  });
+
+  it("health bar for running tasks has correct content", function () {
+    var content = this.component.props.children[2].props["data-tip-content"];
+    expect(content).to.equal("running");
+  });
+
+  it("health bar for staged tasks has correct content", function () {
+    var content = this.component.props.children[3].props["data-tip-content"];
+    expect(content).to.equal("staged");
+  });
+
+  it("health bar for over capacity tasks has correct content", function () {
+    var content = this.component.props.children[4].props["data-tip-content"];
+    expect(content).to.equal("over-capacity");
+  });
+
+  it("health bar for unscheduled tasks has correct content", function () {
+    var content = this.component.props.children[5].props["data-tip-content"];
+    expect(content).to.equal("unscheduled");
   });
 
 });

--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -84,6 +84,48 @@ describe("Apps", function () {
       AppsActions.requestApps();
     });
 
+    describe("App", function () {
+      beforeEach(function () {
+        this.server.setup({
+          "apps": [{
+            id: "/app-1",
+            tasksHealthy: 2,
+            tasksUnhealthy: 2,
+            tasksRunning: 5,
+            tasksStaged: 2,
+            instances: 10
+          }]
+        }, 200);
+      });
+
+      it("has correct health weight", function (done) {
+        AppsStore.once(AppsEvents.CHANGE, function () {
+          expectAsync(function () {
+            expect(AppsStore.apps[0].healthWeight).to.equal(47);
+          }, done);
+        });
+
+        AppsActions.requestApps();
+      });
+
+      it("has correct health data object", function (done) {
+        AppsStore.once(AppsEvents.CHANGE, function () {
+          expectAsync(function () {
+            expect(AppsStore.apps[0].health).to.deep.equal([
+              { quantity: 2, state: HealthStatus.HEALTHY },
+              { quantity: 2, state: HealthStatus.UNHEALTHY },
+              { quantity: 1, state: HealthStatus.UNKNOWN },
+              { quantity: 2, state: HealthStatus.STAGED },
+              { quantity: 0, state: HealthStatus.OVERCAPACITY },
+              { quantity: 3, state: HealthStatus.UNSCHEDULED }
+            ]);
+          }, done);
+        });
+
+        AppsActions.requestApps();
+      });
+    });
+
   });
 
   describe("on single app request", function () {

--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -586,11 +586,14 @@ describe("App Health component", function () {
   beforeEach(function () {
     var model = {
       id: "app-123",
-      tasksRunning: 4,
-      tasksHealthy: 2,
-      tasksUnhealthy: 1,
-      tasksStaged: 1,
-      instances: 5
+      health: [
+        { name: 'healthy', quantity: 2 },
+        { name: 'unhealthy', quantity: 2 },
+        { name: 'running', quantity: 1 },
+        { name: 'staged', quantity: 1 },
+        { name: 'over-capacity', quantity: 2 },
+        { name: 'unscheduled', quantity: 2 }
+      ]
     };
 
     this.renderer = TestUtils.createRenderer();
@@ -604,7 +607,7 @@ describe("App Health component", function () {
 
   it("health bar for healthy tasks has correct width", function () {
     var width = this.component.props.children[0].props.style.width;
-    expect(width).to.equal("40%");
+    expect(width).to.equal("20%");
   });
 
   it("health bar for unhealthy tasks has correct width", function () {
@@ -614,22 +617,22 @@ describe("App Health component", function () {
 
   it("health bar for running tasks has correct width", function () {
     var width = this.component.props.children[2].props.style.width;
-    expect(width).to.equal("20%");
+    expect(width).to.equal("10%");
   });
 
   it("health bar for staged tasks has correct width", function () {
     var width = this.component.props.children[3].props.style.width;
-    expect(width).to.equal("20%");
+    expect(width).to.equal("10%");
   });
 
   it("health bar for over capacity tasks has correct width", function () {
     var width = this.component.props.children[4].props.style.width;
-    expect(width).to.equal("0%");
+    expect(width).to.equal("20%");
   });
 
   it("health bar for unscheduled tasks has correct width", function () {
     var width = this.component.props.children[5].props.style.width;
-    expect(width).to.equal("0%");
+    expect(width).to.equal("20%");
   });
 
 });


### PR DESCRIPTION
This adds sorting to the app list for the health bar, like described here:
https://github.com/mesosphere/marathon/issues/1058

And fixes a bug:
https://github.com/mesosphere/marathon/issues/1989

![health-desc](https://cloud.githubusercontent.com/assets/859154/9228739/1f2ef0fc-411a-11e5-940a-7325765f7212.png)
![health-asc](https://cloud.githubusercontent.com/assets/859154/9228742/2059079c-411a-11e5-8658-c3aadfe0fb3f.png)

Along with some refactoring and tests.

The insides of the healthData, which is used by the health bar, could be NaN at the 'quantity'-property, the healthBar went black in this case.
Now the quantity will filled correctly with 0.