### PR TITLE
Feature: UI Version in modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
     above the API version field. Second way is pressing "g v" on the keyboard.
 
 ### Changed
-- #124 - Expose all /v2 App attributes in UI
+- \#124 - Expose all /v2 App attributes in UI
   * The optional settings inside the new application modal dialog are now
     grouped together
   * It is now possible to specify Docker container settings
@@ -30,7 +30,7 @@
     be generated on-the-fly.
 
 ### Fixed
-- #548 - UI showing empty list after scaling when on page > 1
+- \#548 - UI showing empty list after scaling when on page > 1
   * The task list shows the last available page
     if tasks count decreases after scaling.
 - \#1872 - Kill & Scale should be available for more than one task
@@ -39,7 +39,7 @@
 
 ## 0.10.0 - 2015-07-10
 ### Added
-- #1754 - UI: Allow administratively zeroing / resetting the taskLaunchDelay
+- \#1754 - UI: Allow administratively zeroing / resetting the taskLaunchDelay
   * The App list now displays two additional possible statuses: "Delayed" and
     "Waiting". The "Delayed" status also displays a tooltip showing
     the remaining time until the next launch attempt.
@@ -67,8 +67,8 @@
   Ajax-wrapper.
 
 ### Fixed
-- #1660 - Allow app creation with 0 instances
-- #1236 - Disfunctional refresh button in app configuration
+- \#1660 - Allow app creation with 0 instances
+- \#1236 - Disfunctional refresh button in app configuration
 
 ## 0.9.0 - 2015-06-17
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
     called "Last task failure" on the app page.
 - \#1937 - Display version string also in local time
 - \#1058 - Add sorting to the health column in the app list
+- \#1993 - Show Marathon UI version in about modal
+  * The Marathon UI version will be shown on mouse hovering
+    above the API version field. Second way is pressing "g v" on the keyboard.
 
 ### Changed
 - #124 - Expose all /v2 App attributes in UI

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,6 +47,11 @@ var webpackConfig = {
         test: /\.(js|jsx)$/,
         loader: "babel-loader",
         exclude: /node_modules/
+      },
+      {
+        test: /\.json$/,
+        loader: "json-loader",
+        exclude: /node_modules/
       }
     ],
     postLoaders: [

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "marathon-ui",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "npm-shrinkwrap-version": "5.4.0",
   "node-version": "v0.12.4",
   "dependencies": {
@@ -5695,6 +5695,10 @@
           }
         }
       }
+    },
+    "json-loader": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.2.tgz"
     },
     "lazy.js": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.5",
     "gulp-zip": "^3.0.2",
+    "json-loader": "^0.5.2",
     "mocha": "^2.1.0",
     "mocha-teamcity-reporter": "0.0.4",
     "npm-shrinkwrap": "^5.4.0",

--- a/src/js/components/Marathon.jsx
+++ b/src/js/components/Marathon.jsx
@@ -1,4 +1,5 @@
 var config = require("../config/config");
+var Util = require("../helpers/Util");
 
 var Link = require("react-router").Link;
 var Mousetrap = require("mousetrap");
@@ -58,6 +59,10 @@ var Marathon = React.createClass({
         router.transitionTo("deployments");
       }
     }.bind(this));
+
+    Mousetrap.bind("g v", function () {
+      Util.alert(`The UI version is ${config.version}`);
+    });
 
     Mousetrap.bind("shift+,", function () {
       router.transitionTo("about");

--- a/src/js/components/modals/AboutModalComponent.jsx
+++ b/src/js/components/modals/AboutModalComponent.jsx
@@ -63,7 +63,7 @@ var AboutModalComponent = React.createClass({
         <div className="modal-header modal-header-blend">
           <button type="button" className="close"
             aria-hidden="true" onClick={this.destroy}>&times;</button>
-          <h3 className="modal-title">
+          <h3 className="modal-title" title={`UI Version ${config.version}`}>
             <img width="160" height="27" alt="Marathon" src={logoPath} />
             <small className="text-muted" style={{"marginLeft": "1em"}}>
               Version {this.getInfo("version")}

--- a/src/js/config/config.js
+++ b/src/js/config/config.js
@@ -1,3 +1,5 @@
+var packageJSON = require("../../../package.json");
+
 var config = {
   // @@ENV gets replaced by build system
   environment: "@@ENV",
@@ -12,7 +14,10 @@ var config = {
   localTestserverURI: {
     address: "localhost",
     port: 8181
-  }
+  },
+  version: ("@@TEAMCITY_UI_VERSION".indexOf("@@TEAMCITY") === -1) ?
+    "@@TEAMCITY_UI_VERSION" :
+    `${packageJSON.version}-SNAPSHOT`
 };
 
 if (process.env.GULP_ENV === "development") {


### PR DESCRIPTION
This fixes https://github.com/mesosphere/marathon/issues/1993

If you hover over the Marathon version string in the about modal you see the UI version.
Also if you press "g v" the ui version will be displayed!

And this PR enables the ability of loading json-files via webpack require.