### PR TITLE
Refactor - Rename "Last task failure"-tab to "Debug"-tab

### DIFF
--- a/src/js/components/AppDebugInfoComponent.jsx
+++ b/src/js/components/AppDebugInfoComponent.jsx
@@ -5,8 +5,8 @@ var AppsActions = require("../actions/AppsActions");
 var AppsEvents = require("../events/AppsEvents");
 var TaskMesosUrlComponent = require("../components/TaskMesosUrlComponent");
 
-var AppLastTaskFailureComponent = React.createClass({
-  displayName: "AppLastTaskFailureComponent",
+var AppDebugInfoComponent = React.createClass({
+  displayName: "AppDebugInfoComponent",
 
   propTypes: {
     appId: React.PropTypes.string.isRequired
@@ -83,4 +83,4 @@ var AppLastTaskFailureComponent = React.createClass({
   }
 });
 
-module.exports = AppLastTaskFailureComponent;
+module.exports = AppDebugInfoComponent;

--- a/src/js/components/AppDebugInfoComponent.jsx
+++ b/src/js/components/AppDebugInfoComponent.jsx
@@ -41,7 +41,7 @@ var AppDebugInfoComponent = React.createClass({
 
     if (lastTaskFailure == null) {
       return (
-        <span className="text-muted">This app does not have failed task</span>
+        <span className="text-muted">This app does not have failed tasks</span>
       );
     }
 

--- a/src/js/components/AppLastTaskFailureComponent.jsx
+++ b/src/js/components/AppLastTaskFailureComponent.jsx
@@ -36,52 +36,50 @@ var AppLastTaskFailureComponent = React.createClass({
     });
   },
 
-  render: function () {
-    var app = this.state.app;
-    var lastTaskFailure = app.lastTaskFailure;
-    if (lastTaskFailure != null) {
+  getLastTaskFailureInfo: function () {
+    var lastTaskFailure = this.state.app.lastTaskFailure;
+
+    if (lastTaskFailure == null) {
       return (
-        <div>
-          <h5>
-            Last Task Failure
-            <button className="btn btn-sm btn-info pull-right"
-              onClick={this.handleRefresh}>
-              ↻ Refresh
-            </button>
-          </h5>
-          <div>
-              <dl className="dl-horizontal">
-                  <dt>Task id</dt>
-                  <dd>{lastTaskFailure.taskId}</dd>
-                  <dt>State</dt>
-                  <dd>{lastTaskFailure.state}</dd>
-                  <dt>Message</dt>
-                  <dd>{lastTaskFailure.message}</dd>
-                  <dt>Host</dt>
-                  <dd>{lastTaskFailure.host}</dd>
-                  <dt>Timestamp</dt>
-                  <dd>{lastTaskFailure.timestamp}</dd>
-                  <dt>Version</dt>
-                  <dd>{lastTaskFailure.version}</dd>
-                  <dt>Mesos Details</dt>
-                  <dd><TaskMesosUrlComponent task={lastTaskFailure}/></dd>
-              </dl>
-          </div>
-        </div>
-      );
-    } else {
-      return (
-        <div>
-          <h5>
-            This app does not have failed task
-          </h5>
-            <button className="btn btn-sm btn-info pull-right"
-              onClick={this.handleRefresh}>
-              ↻ Refresh
-            </button>
-        </div>
+        <span className="text-muted">This app does not have failed task</span>
       );
     }
+
+    return (
+      <dl className="dl-horizontal">
+        <dt>Task id</dt>
+        <dd>{lastTaskFailure.taskId}</dd>
+        <dt>State</dt>
+        <dd>{lastTaskFailure.state}</dd>
+        <dt>Message</dt>
+        <dd>{lastTaskFailure.message}</dd>
+        <dt>Host</dt>
+        <dd>{lastTaskFailure.host}</dd>
+        <dt>Timestamp</dt>
+        <dd>{lastTaskFailure.timestamp}</dd>
+        <dt>Version</dt>
+        <dd>{lastTaskFailure.version}</dd>
+        <dt>Mesos Details</dt>
+        <dd><TaskMesosUrlComponent task={lastTaskFailure}/></dd>
+      </dl>
+    );
+  },
+
+  render: function () {
+    return (
+      <div>
+        <h5>
+          Last Task Failure
+          <button className="btn btn-sm btn-info pull-right"
+            onClick={this.handleRefresh}>
+            ↻ Refresh
+          </button>
+        </h5>
+        <div>
+          {this.getLastTaskFailureInfo()}
+        </div>
+      </div>
+    );
   }
 });
 

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -23,11 +23,7 @@ var QueueStore = require("../stores/QueueStore");
 var tabsTemplate = [
   {id: "apps/:appId", text: "Tasks"},
   {id: "apps/:appId/configuration", text: "Configuration"},
-  {
-    id: "apps/:appId/last-task-failure",
-    text: "Last Task Failure",
-    hidden: true
-  }
+  {id: "apps/:appId/debug", text: "Debug"}
 ];
 
 var AppPageComponent = React.createClass({
@@ -67,21 +63,16 @@ var AppPageComponent = React.createClass({
         activeTabId = id;
       }
 
-      if (tab.id === "apps/:appId/last-task-failure") {
-        tab.hidden = app.lastTaskFailure == null;
-      }
-
       return {
         id: id,
-        text: tab.text,
-        hidden: tab.hidden
+        text: tab.text
       };
     });
 
     if (view === "configuration") {
       activeTabId += "/configuration";
-    } else if (view === "last-task-failure") {
-      activeTabId += "/last-task-failure";
+    } else if (view === "debug") {
+      activeTabId += "/debug";
     } else if (view != null) {
       activeTaskId = view;
       activeViewIndex = 1;
@@ -146,24 +137,15 @@ var AppPageComponent = React.createClass({
   onAppChange: function () {
     var state = this.state;
     var app = AppsStore.getCurrentApp(state.appId);
-    var tabs = state.tabs;
-
-    tabs = tabs.map(function (tab) {
-      var tabId = `apps/${encodeURIComponent(state.appId)}/last-task-failure`;
-      if (tab.id === tabId) {
-        tab.hidden = app.lastTaskFailure == null;
-      }
-      return tab;
-    });
 
     this.setState({
       app: app,
       fetchState: States.STATE_SUCCESS,
-      tabs: tabs
+      tabs: state.tabs
     });
 
-    if (this.state.view === "configuration") {
-      AppVersionsActions.requestAppVersions(this.state.appId);
+    if (state.view === "configuration") {
+      AppVersionsActions.requestAppVersions(state.appId);
     }
   },
 
@@ -375,7 +357,7 @@ var AppPageComponent = React.createClass({
           <AppVersionListComponent appId={state.appId} />
         </TabPaneComponent>
         <TabPaneComponent
-          id={"apps/" + encodeURIComponent(state.appId) + "/last-task-failure"}>
+          id={"apps/" + encodeURIComponent(state.appId) + "/debug"}>
           <AppLastTaskFailureComponent appId={state.appId} />
         </TabPaneComponent>
       </TogglableTabsComponent>

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -7,7 +7,7 @@ var AppBreadcrumbsComponent = require("../components/AppBreadcrumbsComponent");
 var AppStatus = require("../constants/AppStatus");
 var AppStatusComponent = require("../components/AppStatusComponent");
 var AppVersionsActions = require("../actions/AppVersionsActions");
-var AppLastTaskFailureComponent = require("../components/AppLastTaskFailureComponent");
+var AppDebugInfoComponent = require("../components/AppDebugInfoComponent");
 var AppVersionListComponent = require("../components/AppVersionListComponent");
 var HealthStatus = require("../constants/HealthStatus");
 var States = require("../constants/States");
@@ -358,7 +358,7 @@ var AppPageComponent = React.createClass({
         </TabPaneComponent>
         <TabPaneComponent
           id={"apps/" + encodeURIComponent(state.appId) + "/debug"}>
-          <AppLastTaskFailureComponent appId={state.appId} />
+          <AppDebugInfoComponent appId={state.appId} />
         </TabPaneComponent>
       </TogglableTabsComponent>
     );

--- a/src/test/appLastTaskFailure.test.js
+++ b/src/test/appLastTaskFailure.test.js
@@ -7,7 +7,7 @@ var Util = require("../js/helpers/Util");
 var appScheme = require("../js/stores/appScheme");
 var InfoStore = require("../js/stores/InfoStore");
 var AppsStore = require("../js/stores/AppsStore");
-var AppLastTaskFailureComponent = require("../js/components/AppLastTaskFailureComponent");
+var AppDebugInfoComponent = require("../js/components/AppDebugInfoComponent");
 
 var expectAsync = require("./helpers/expectAsync");
 var HttpServer = require("./helpers/HttpServer").HttpServer;
@@ -53,7 +53,7 @@ describe("App last task failure component", function () {
     AppsStore.apps = [app];
 
     this.renderer = TestUtils.createRenderer();
-    this.renderer.render(<AppLastTaskFailureComponent appId={this.appId} />);
+    this.renderer.render(<AppDebugInfoComponent appId={this.appId} />);
     this.component = this.renderer.getRenderOutput();
 
     var element = this.component.props.children[1].props.children.props.children;
@@ -84,10 +84,11 @@ describe("App last task failure component", function () {
     AppsStore.apps = [app];
 
     this.renderer = TestUtils.createRenderer();
-    this.renderer.render(<AppLastTaskFailureComponent appId={this.appId} />);
+    this.renderer.render(<AppDebugInfoComponent appId={this.appId} />);
     this.component = this.renderer.getRenderOutput();
 
-    var message = this.component.props.children[0]._store.props.children;
+    var message = this.component.props.children[1].props.children.props.children;
+
     expect(message).to.equal('This app does not have failed task');
   });
 });

--- a/src/test/appLastTaskFailure.test.js
+++ b/src/test/appLastTaskFailure.test.js
@@ -9,7 +9,6 @@ var InfoStore = require("../js/stores/InfoStore");
 var AppsStore = require("../js/stores/AppsStore");
 var AppDebugInfoComponent = require("../js/components/AppDebugInfoComponent");
 
-var expectAsync = require("./helpers/expectAsync");
 var HttpServer = require("./helpers/HttpServer").HttpServer;
 
 var server = new HttpServer(config.localTestserverURI);
@@ -36,7 +35,7 @@ describe("App last task failure component", function () {
         "mesos_master_url": "http://leader1.dcos.io:5050"
       }
     };
-    this.appId = '/python';
+    this.appId = "/python";
     var app = Util.extendObject(appScheme, {
       id: "/python",
       lastTaskFailure: {
@@ -66,17 +65,17 @@ describe("App last task failure component", function () {
     var version = element[11]._store.props.children;
     var mesosElement= element[13]._store.props.children.type.displayName;
 
-    expect(taskId).to.equal('python.83c0a69b-256a-11e5-aaed-fa163eaaa6b7');
-    expect(state).to.equal('TASK_LOST');
-    expect(message).to.equal('Slave slave1.dcos.io removed');
-    expect(host).to.equal('slave1.dcos.io');
-    expect(timestamp).to.equal('2015-08-05T09:08:56.349Z');
-    expect(version).to.equal('2015-07-06T12:37:28.774Z');
+    expect(taskId).to.equal("python.83c0a69b-256a-11e5-aaed-fa163eaaa6b7");
+    expect(state).to.equal("TASK_LOST");
+    expect(message).to.equal("Slave slave1.dcos.io removed");
+    expect(host).to.equal("slave1.dcos.io");
+    expect(timestamp).to.equal("2015-08-05T09:08:56.349Z");
+    expect(version).to.equal("2015-07-06T12:37:28.774Z");
   });
 
   it("should show message when app never failed", function () {
 
-    this.appId = '/python';
+    this.appId = "/python";
     var app = Util.extendObject(appScheme, {
       id: "/python",
     });
@@ -89,6 +88,6 @@ describe("App last task failure component", function () {
 
     var message = this.component.props.children[1].props.children.props.children;
 
-    expect(message).to.equal('This app does not have failed task');
+    expect(message).to.equal("This app does not have failed tasks");
   });
 });


### PR DESCRIPTION
This is a preparation for https://github.com/mesosphere/marathon/issues/2010 and renames the "Last Task Failure"-tab into the "Debug"-tab, which will be always shown, because we will have more persistent data there in the next days..
It can be already merged..
![ltf1](https://cloud.githubusercontent.com/assets/859154/9333285/60e521de-45c9-11e5-8021-b55982661cbf.png)
![ltf2](https://cloud.githubusercontent.com/assets/859154/9333290/63e379bc-45c9-11e5-938b-93e6ab0ccccc.png)

