### PR TITLE
Fix key binding for newapp.

### DIFF
--- a/src/js/components/Marathon.jsx
+++ b/src/js/components/Marathon.jsx
@@ -45,7 +45,7 @@ var Marathon = React.createClass({
     }.bind(this));
 
     Mousetrap.bind("c", function () {
-      router.transitionTo("newapp");
+      router.transitionTo("apps", null, {modal: "newapp"});
     }, "keyup");
 
     Mousetrap.bind("g a", function () {


### PR DESCRIPTION
Is there a better way to open a modal than actually transitioning to a
new route?