### PR TITLE
Quickfix - arrow functions have the wrong scope

### DIFF
--- a/src/js/helpers/qajaxWrapper.js
+++ b/src/js/helpers/qajaxWrapper.js
@@ -10,8 +10,8 @@ var qajaxWrapper = function (options) {
   if (!options.concurrent) {
     if (uniqueCalls.indexOf(options.url) > -1) {
       return {
-        error: () => { return this; },
-        success: () => { return this; }
+        error: function () { return this; },
+        success: function () { return this; }
       };
     }
     uniqueCalls.push(options.url);


### PR DESCRIPTION
I want to return the scope of the object and not of the overlaying function.
This broke the function chaining possibility.