### PR TITLE
Feature/2039 move edit config button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
     Also the dist-folder isn't needed in the repository anymore, the files will
     be generated on-the-fly.
 - \#1251 - Show total resource usage in app list
+- \#2039 - Updated app config edit button styles
 
 ### Fixed
 - \#548 - UI showing empty list after scaling when on page > 1

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -870,6 +870,10 @@ fieldset[disabled] .btn-info.active {
   }
 }
 
+.pane-header {
+  line-height: 30px;
+}
+
 /* ==============
  * PLEASE NOTE
  * The following styles are necessary due to tooltip.js using the same

--- a/src/js/components/AppDebugInfoComponent.jsx
+++ b/src/js/components/AppDebugInfoComponent.jsx
@@ -120,7 +120,7 @@ var AppDebugInfoComponent = React.createClass({
   render: function () {
     return (
       <div>
-        <button className="btn btn-sm btn-info pull-right"
+        <button className="btn btn-sm btn-default pull-right"
           onClick={this.handleRefresh}>
           ↻ Refresh
         </button>

--- a/src/js/components/AppVersionComponent.jsx
+++ b/src/js/components/AppVersionComponent.jsx
@@ -51,10 +51,8 @@ var AppVersionComponent = React.createClass({
   },
 
   getApplyButton: function () {
-    var applyButton = null;
-
     if (!this.props.currentVersion) {
-      applyButton = (
+      return (
         <button type="submit"
             className="btn btn-sm btn-default pull-right"
             onClick={this.handleRollbackToAppVersion}>
@@ -62,8 +60,6 @@ var AppVersionComponent = React.createClass({
         </button>
       );
     }
-
-    return applyButton;
   },
 
   getEditButton: function () {

--- a/src/js/components/AppVersionComponent.jsx
+++ b/src/js/components/AppVersionComponent.jsx
@@ -56,7 +56,7 @@ var AppVersionComponent = React.createClass({
         <button type="submit"
             className="btn btn-sm btn-default pull-right"
             onClick={this.handleRollbackToAppVersion}>
-          Apply these settings
+          ✓ Apply
         </button>
       );
     }

--- a/src/js/components/AppVersionComponent.jsx
+++ b/src/js/components/AppVersionComponent.jsx
@@ -67,13 +67,15 @@ var AppVersionComponent = React.createClass({
   },
 
   getEditButton: function () {
-    return (
-      <button type="submit"
-          className="btn btn-sm btn-default pull-right"
-          onClick={this.handleEditAppVersion}>
-        Edit these settings
-      </button>
-    );
+    if (!this.props.currentVersion) {
+      return (
+        <button type="submit"
+            className="btn btn-sm btn-default pull-right"
+            onClick={this.handleEditAppVersion}>
+          Edit these settings
+        </button>
+      );
+    }
   },
 
   render: function () {

--- a/src/js/components/AppVersionComponent.jsx
+++ b/src/js/components/AppVersionComponent.jsx
@@ -63,15 +63,13 @@ var AppVersionComponent = React.createClass({
   },
 
   getEditButton: function () {
-    if (!this.props.currentVersion) {
-      return (
-        <button type="submit"
-            className="btn btn-sm btn-default pull-right"
-            onClick={this.handleEditAppVersion}>
-          Edit these settings
-        </button>
-      );
-    }
+    return (
+      <button type="submit"
+          className="btn btn-sm btn-default pull-right"
+          onClick={this.handleEditAppVersion}>
+        ✎ Edit
+      </button>
+    );
   },
 
   render: function () {

--- a/src/js/components/AppVersionComponent.jsx
+++ b/src/js/components/AppVersionComponent.jsx
@@ -123,6 +123,8 @@ var AppVersionComponent = React.createClass({
 
     return (
       <div>
+        {this.getApplyButton()}
+        {this.getEditButton()}
         <dl className={"dl-horizontal " + this.props.className}>
           <dt>Command</dt>
           {invalidateValue(appVersion.cmd)}
@@ -155,8 +157,6 @@ var AppVersionComponent = React.createClass({
           <dt>Version</dt>
           {invalidateValue(appVersion.version)}
         </dl>
-        {this.getApplyButton()}
-        {this.getEditButton()}
       </div>
     );
   }

--- a/src/js/components/AppVersionListComponent.jsx
+++ b/src/js/components/AppVersionListComponent.jsx
@@ -195,7 +195,7 @@ var AppVersionListComponent = React.createClass({
       <div>
         <h5>
           Current Version{versionDate}
-          <button className="btn btn-sm btn-info pull-right"
+          <button className="btn btn-sm btn-default pull-right"
               onClick={this.handleRefresh}>
             ↻ Refresh
           </button>

--- a/src/js/components/AppVersionListComponent.jsx
+++ b/src/js/components/AppVersionListComponent.jsx
@@ -21,10 +21,6 @@ var AppVersionListComponent = React.createClass({
     appId: React.PropTypes.string.isRequired
   },
 
-  contextTypes: {
-    router: React.PropTypes.func
-  },
-
   getInitialState: function () {
     var props = this.props;
 
@@ -92,15 +88,6 @@ var AppVersionListComponent = React.createClass({
 
   handleRefresh: function () {
     AppVersionsActions.requestAppVersions(this.props.appId);
-  },
-
-  handleEdit: function () {
-    var currentVersion = AppsStore.getCurrentApp(this.props.appId);
-    var router = this.context.router;
-
-    router.transitionTo(router.getCurrentPathname(), {}, {
-      modal: `edit-app--${currentVersion.id}--${currentVersion.version}`
-    });
   },
 
   handlePageChange: function (pageNum) {
@@ -198,10 +185,6 @@ var AppVersionListComponent = React.createClass({
           <button className="btn btn-sm btn-default pull-right"
               onClick={this.handleRefresh}>
             ↻ Refresh
-          </button>
-          <button className="btn btn-sm btn-default pull-right"
-              onClick={this.handleEdit}>
-            ✎ Edit
           </button>
         </h5>
         <AppVersionComponent

--- a/src/js/components/AppVersionListComponent.jsx
+++ b/src/js/components/AppVersionListComponent.jsx
@@ -180,7 +180,7 @@ var AppVersionListComponent = React.createClass({
 
     return (
       <div>
-        <h5>
+        <h5 className="pane-header">
           Current Version{versionDate}
           <button className="btn btn-sm btn-default pull-right"
               onClick={this.handleRefresh}>

--- a/src/js/components/AppVersionListComponent.jsx
+++ b/src/js/components/AppVersionListComponent.jsx
@@ -21,6 +21,10 @@ var AppVersionListComponent = React.createClass({
     appId: React.PropTypes.string.isRequired
   },
 
+  contextTypes: {
+    router: React.PropTypes.func
+  },
+
   getInitialState: function () {
     var props = this.props;
 
@@ -88,6 +92,15 @@ var AppVersionListComponent = React.createClass({
 
   handleRefresh: function () {
     AppVersionsActions.requestAppVersions(this.props.appId);
+  },
+
+  handleEdit: function () {
+    var currentVersion = AppsStore.getCurrentApp(this.props.appId);
+    var router = this.context.router;
+
+    router.transitionTo(router.getCurrentPathname(), {}, {
+      modal: `edit-app--${currentVersion.id}--${currentVersion.version}`
+    });
   },
 
   handlePageChange: function (pageNum) {
@@ -185,6 +198,10 @@ var AppVersionListComponent = React.createClass({
           <button className="btn btn-sm btn-info pull-right"
               onClick={this.handleRefresh}>
             ↻ Refresh
+          </button>
+          <button className="btn btn-sm btn-default pull-right"
+              onClick={this.handleEdit}>
+            ✎ Edit
           </button>
         </h5>
         <AppVersionComponent

--- a/src/test/appVersions.test.js
+++ b/src/test/appVersions.test.js
@@ -243,7 +243,7 @@ describe("App Version component", function () {
     this.renderer.render(<AppVersionComponent
       appVersion={model} />);
     this.component = this.renderer.getRenderOutput();
-    this.table = this.component.props.children[0].props.children;
+    this.table = this.component.props.children[2].props.children;
   });
 
   afterEach(function () {


### PR DESCRIPTION
Fixes mesosphere/marathon#2039

I have dodged the config/settings debate by simply using the word 'Edit'. I think this is in keeping with 'Refresh'. 

Before:
![marathon-2039-before](https://cloud.githubusercontent.com/assets/2989362/9444594/005c4842-4a88-11e5-9f45-fb82a22db4b5.png)

After:
![marathon-2039-after](https://cloud.githubusercontent.com/assets/2989362/9444598/04208e66-4a88-11e5-9ea4-0e258c86c0dd.png)
