### PR TITLE
Fix: 2072, 2079 - Transform attributes and allow empty values

### DIFF
--- a/src/js/components/OptionalSettingsComponent.jsx
+++ b/src/js/components/OptionalSettingsComponent.jsx
@@ -15,6 +15,13 @@ var OptionalSettingsComponent = React.createClass({
     var model = this.props.model;
     var errors = this.props.errors;
     var helpMessage = "Comma-separated list of valid constraints. Valid constraint format is \"field:operator[:value]\".";
+    var attr = {};
+
+    if (model.constraints != null) {
+      attr.constraints = model.constraints.map(function (constraint) {
+        return constraint.join(":");
+      });
+    }
 
     return (
       <div>
@@ -50,7 +57,7 @@ var OptionalSettingsComponent = React.createClass({
           attribute="constraints"
           help={helpMessage}
           label="Constraints"
-          model={model}
+          model={attr}
           errors={errors}
           validator={appValidator}>
           <input />

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -142,7 +142,9 @@ var AppModalComponent = React.createClass({
 
     // URIs should be an Array of Strings.
     if ("uris" in modelAttrs) {
-      modelAttrs.uris = modelAttrs.uris.split(",");
+      modelAttrs.uris = modelAttrs.uris.split(",").map(function (uri) {
+        return uri.trim();
+      });
     }
 
     // Constraints should be an Array of Strings.

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -145,9 +145,9 @@ var AppModalComponent = React.createClass({
       if (modelAttrs.uris === "") {
         modelAttrs.uris = [];
       } else {
-        modelAttrs.uris = modelAttrs.uris.split(",").map(function (uri) {
+        modelAttrs.uris = lazy(modelAttrs.uris.split(",")).map(function (uri) {
           return uri.trim();
-        });
+        }).compact().value();
       }
     }
 

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -153,6 +153,8 @@ var AppModalComponent = React.createClass({
           return value.trim();
         });
       });
+    } else {
+      modelAttrs.constraints = [];
     }
 
     // env should not be an array.

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -136,27 +136,33 @@ var AppModalComponent = React.createClass({
     var props = this.props;
 
     var attrArray = Util.serializeArray(event.target)
-      .filter((key) => key.value !== "");
+      .filter((key) => key.name !== "");
 
     var modelAttrs = Util.serializedArrayToDictionary(attrArray);
 
     // URIs should be an Array of Strings.
     if ("uris" in modelAttrs) {
-      modelAttrs.uris = modelAttrs.uris.split(",").map(function (uri) {
-        return uri.trim();
-      });
+      if (modelAttrs.uris === "") {
+        modelAttrs.uris = [];
+      } else {
+        modelAttrs.uris = modelAttrs.uris.split(",").map(function (uri) {
+          return uri.trim();
+        });
+      }
     }
 
     // Constraints should be an Array of Strings.
     if ("constraints" in modelAttrs) {
-      var constraintsArray = modelAttrs.constraints.split(",");
-      modelAttrs.constraints = constraintsArray.map(function (constraint) {
-        return constraint.split(":").map(function (value) {
-          return value.trim();
+      if (modelAttrs.constraints === "") {
+        modelAttrs.constraints = [];
+      } else {
+        let constraintsArray = modelAttrs.constraints.split(",");
+        modelAttrs.constraints = constraintsArray.map(function (constraint) {
+          return constraint.split(":").map(function (value) {
+            return value.trim();
+          });
         });
-      });
-    } else {
-      modelAttrs.constraints = [];
+      }
     }
 
     // env should not be an array.
@@ -169,13 +175,15 @@ var AppModalComponent = React.createClass({
 
     // Ports should always be an Array.
     if ("ports" in modelAttrs) {
-      var portStrings = modelAttrs.ports.split(",");
-      modelAttrs.ports = portStrings.map(function (p) {
-        var port = parseInt(p, 10);
-        return isNaN(port) ? p : port;
-      });
-    } else {
-      modelAttrs.ports = [];
+      if (modelAttrs.ports === "") {
+        modelAttrs.ports = [];
+      } else {
+        let portStrings = modelAttrs.ports.split(",");
+        modelAttrs.ports = portStrings.map(function (p) {
+          var port = parseInt(p, 10);
+          return isNaN(port) ? p : port;
+        });
+      }
     }
 
     // Container arrays shouldn't have null-values

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -170,7 +170,9 @@ var AppModalComponent = React.createClass({
     // env should not be an array.
     if ("env" in modelAttrs) {
       modelAttrs.env = modelAttrs.env.reduce(function (memo, item) {
-        memo[item.key] = item.value;
+        if (item.key != null && item.key !== "") {
+          memo[item.key] = item.value;
+        }
         return memo;
       }, {});
     }

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -135,6 +135,8 @@ var AppModalComponent = React.createClass({
 
     var props = this.props;
 
+    // null-values must be treated as null to let the app model untouched.
+
     var attrArray = Util.serializeArray(event.target)
       .filter((key) => key.name !== "");
 

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -172,6 +172,8 @@ var AppModalComponent = React.createClass({
         var port = parseInt(p, 10);
         return isNaN(port) ? p : port;
       });
+    } else {
+      modelAttrs.ports = [];
     }
 
     // Container arrays shouldn't have null-values

--- a/src/js/components/modals/EditAppModalComponent.jsx
+++ b/src/js/components/modals/EditAppModalComponent.jsx
@@ -8,18 +8,6 @@ var DialogActions = require("../../actions/DialogActions");
 
 var AppModalComponent = require("./AppModalComponent");
 
-function transformAppModelToFormAttributes(app) {
-  var attr = Object.assign({}, app);
-
-  if (attr.constraints != null) {
-    attr.constraints = attr.constraints.map(function (constraint) {
-      return constraint.join(":");
-    });
-  }
-
-  return attr;
-}
-
 var EditAppModalComponent = React.createClass({
   displayName: "EditAppModalComponent",
 
@@ -74,7 +62,7 @@ var EditAppModalComponent = React.createClass({
       return null;
     }
 
-    let attributes = transformAppModelToFormAttributes(
+    let attributes = Object.assign({},
       AppVersionsStore.getAppVersion(props.appId, props.appVersion)
     );
 

--- a/src/js/components/modals/EditAppModalComponent.jsx
+++ b/src/js/components/modals/EditAppModalComponent.jsx
@@ -8,6 +8,18 @@ var DialogActions = require("../../actions/DialogActions");
 
 var AppModalComponent = require("./AppModalComponent");
 
+function transformAppModelToFormAttributes(app) {
+  var attr = Object.assign({}, app);
+
+  if (attr.constraints != null) {
+    attr.constraints = attr.constraints.map(function (constraint) {
+      return constraint.join(":");
+    });
+  }
+
+  return attr;
+}
+
 var EditAppModalComponent = React.createClass({
   displayName: "EditAppModalComponent",
 
@@ -25,7 +37,7 @@ var EditAppModalComponent = React.createClass({
 
   getInitialState: function () {
     return {
-      app: null
+      attributes: null
     };
   },
 
@@ -62,8 +74,12 @@ var EditAppModalComponent = React.createClass({
       return null;
     }
 
+    let attributes = transformAppModelToFormAttributes(
+      AppVersionsStore.getAppVersion(props.appId, props.appVersion)
+    );
+
     this.setState({
-      app: AppVersionsStore.getAppVersion(props.appId, props.appVersion)
+      attributes: attributes
     });
   },
 
@@ -76,13 +92,13 @@ var EditAppModalComponent = React.createClass({
   render: function () {
     var state = this.state;
 
-    if (state.app == null) {
+    if (state.attributes == null) {
       return null;
     }
 
     return (
       <AppModalComponent
-        attributes={state.app}
+        attributes={state.attributes}
         edit={true}
         onDestroy={this.props.onDestroy} />
     );

--- a/src/js/helpers/Util.js
+++ b/src/js/helpers/Util.js
@@ -52,7 +52,7 @@ var Util = {
       if (field.type === "checkbox") {
         val = !!val;
       }
-      if (val) {
+      if (val != null) {
         serialized.push({name: field.name, value: val});
       }
     }

--- a/src/js/validators/appValidator.js
+++ b/src/js/validators/appValidator.js
@@ -73,8 +73,10 @@ var appValidator = {
       );
     }
 
-    let ports = [];
-    if (Util.isString(attrs.ports)) {
+    let ports = attrs.ports;
+    if (ports === "") {
+      ports = [];
+    } else if (Util.isString(attrs.ports)) {
       ports = attrs.ports.split(",");
     }
     if (!ports.every(function (p) {

--- a/src/js/validators/appValidator.js
+++ b/src/js/validators/appValidator.js
@@ -73,18 +73,28 @@ var appValidator = {
       );
     }
 
+    let ports = [];
     if (Util.isString(attrs.ports)) {
-      attrs.ports = attrs.ports.split(",");
+      ports = attrs.ports.split(",");
     }
-
-    if (!attrs.ports.every(function (p) {
+    if (!ports.every(function (p) {
       return !isNotPositiveNumber(p.toString().trim());
     })) {
       errors.push(
         new ValidationError("ports", "Ports must be a list of Numbers"));
     }
 
-    if (!attrs.constraints.every(isValidConstraint)) {
+    let constraints = attrs.constraints;
+    if (constraints === "") {
+      constraints = [];
+    } else if (Util.isString(attrs.constraints)) {
+      constraints = attrs.constraints.split(",").map(function (constraint) {
+        return constraint.split(":").map(function (value) {
+          return value.trim();
+        });
+      });
+    }
+    if (!constraints.every(isValidConstraint)) {
       errors.push(
         new ValidationError("constraints",
           "Invalid constraints format or operator. Supported operators are " +

--- a/src/js/validators/appValidator.js
+++ b/src/js/validators/appValidator.js
@@ -23,6 +23,9 @@ function isValidConstraint(p) {
 }
 
 function isNotPositiveNumber(value) {
+  if (value == null) {
+    return false;
+  }
   return !value.toString().match(/^[0-9\.]+$/);
 }
 
@@ -79,7 +82,7 @@ var appValidator = {
     } else if (Util.isString(attrs.ports)) {
       ports = attrs.ports.split(",");
     }
-    if (!ports.every(function (p) {
+    if (Util.isArray(ports) && !ports.every(function (p) {
       return !isNotPositiveNumber(p.toString().trim());
     })) {
       errors.push(
@@ -96,7 +99,7 @@ var appValidator = {
         });
       });
     }
-    if (!constraints.every(isValidConstraint)) {
+    if (Util.isArray(constraints) && !constraints.every(isValidConstraint)) {
       errors.push(
         new ValidationError("constraints",
           "Invalid constraints format or operator. Supported operators are " +


### PR DESCRIPTION
This fixes https://github.com/mesosphere/marathon/issues/2072
and fixes https://github.com/mesosphere/marathon/issues/2079

Fields can now be voided in the optional settings dialog.
Ports and constraints are working correctly again.
I've introduced a model-to-forms transformation function in the EditAppModalComponent.

I am unhappy about the whole app-creation-/edit-modal data handling.
We should think about a refactoring of the validation, transformation, foldable-panels handling to make it more understandable. In the moment it's very flaky and lacks of tests.