### PR TITLE
Fix: 2094 Enable the ability to clear environment variables 

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -880,13 +880,6 @@ fieldset[disabled] .btn-info.active {
       font-size: 2.6em;
     }
   }
-  &:only-child {
-    .controls .remove {
-      opacity: 0.4;
-      // disable row clearance on last remaining row
-      pointer-events: none;
-    }
-  }
 }
 
 .pane-header {

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -170,7 +170,9 @@ var AppModalComponent = React.createClass({
     // env should not be an array.
     if ("env" in modelAttrs) {
       modelAttrs.env = modelAttrs.env.reduce(function (memo, item) {
-        memo[item.key] = item.value;
+        if (item.key != null && item.key !== "") {
+          memo[item.key] = item.value;
+        }
         return memo;
       }, {});
     }

--- a/src/js/validators/appValidator.js
+++ b/src/js/validators/appValidator.js
@@ -23,6 +23,9 @@ function isValidConstraint(p) {
 }
 
 function isNotPositiveNumber(value) {
+  if (value == null) {
+    return false;
+  }
   return !value.toString().match(/^[0-9\.]+$/);
 }
 
@@ -79,7 +82,7 @@ var appValidator = {
     } else if (Util.isString(attrs.ports)) {
       ports = attrs.ports.split(",");
     }
-    if (!ports.every(function (p) {
+    if (Util.isArray(ports) && !ports.every(function (p) {
       return !isNotPositiveNumber(p.toString().trim());
     })) {
       errors.push(
@@ -96,7 +99,7 @@ var appValidator = {
         });
       });
     }
-    if (!constraints.every(isValidConstraint)) {
+    if (Util.isArray(constraints) && !constraints.every(isValidConstraint)) {
       errors.push(
         new ValidationError("constraints",
           "Invalid constraints format or operator. Supported operators are " +


### PR DESCRIPTION
I should be able to clear the a row by pressing on the "-"-button, if there is only 1 row left, because I maybe want to remove my env vars completely. Of course the row line stays, but empty.

Before:
![row1](https://cloud.githubusercontent.com/assets/859154/9542701/6dc9125a-4d73-11e5-901d-bdfe39326e65.png)
After pressing on each "-":
![row2](https://cloud.githubusercontent.com/assets/859154/9542705/7695d788-4d73-11e5-8ba9-80ec0fe0d4d6.png)

Fixes https://github.com/mesosphere/marathon/issues/2094


