### PR TITLE
Quickfix: Task statistics empty-message if object is empty

### DIFF
--- a/src/js/components/AppTaskStatsListComponent.jsx
+++ b/src/js/components/AppTaskStatsListComponent.jsx
@@ -39,7 +39,7 @@ var AppTaskStatsListComponent = React.createClass({
     var taskStatsList = this.props.taskStatsList;
     var noTaskStatistics = null;
 
-    if (taskStatsList == null || !Object.keys(taskStatsList).length) {
+    if (taskStatsList == null || Object.keys(taskStatsList).length === 0) {
       noTaskStatistics = (
         <div className="panel panel-body panel-inverse">
           <span className="text-muted">

--- a/src/js/components/AppTaskStatsListComponent.jsx
+++ b/src/js/components/AppTaskStatsListComponent.jsx
@@ -39,7 +39,7 @@ var AppTaskStatsListComponent = React.createClass({
     var taskStatsList = this.props.taskStatsList;
     var noTaskStatistics = null;
 
-    if (taskStatsList == null) {
+    if (taskStatsList == null || !Object.keys(taskStatsList).length) {
       noTaskStatistics = (
         <div className="panel panel-body panel-inverse">
           <span className="text-muted">


### PR DESCRIPTION
"This app does not have task statistics" wasn't shown on empty object, but it should.