### PR TITLE
Revert "Disable remove on last child in duplicable list"

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -882,13 +882,6 @@ fieldset[disabled] .btn-info.active {
       font-size: 2.6em;
     }
   }
-  &:only-child {
-    .controls .remove {
-      opacity: 0.4;
-      // disable row clearance on last remaining row
-      pointer-events: none;
-    }
-  }
 }
 
 .pane-header {


### PR DESCRIPTION
This is reverts the disabled state on the remove button in the last child of a duplicable list, for reasons discussed in #163 

New issue to discuss how to handle this better: mesosphere/marathon#2120.