### PR TITLE
Fix: 2114 Disable app version apply- and edit-button on unspecified version

### DIFF
--- a/src/js/components/AppVersionComponent.jsx
+++ b/src/js/components/AppVersionComponent.jsx
@@ -1,3 +1,4 @@
+var classNames = require("classnames");
 var React = require("react/addons");
 
 var AppsActions = require("../actions/AppsActions");
@@ -50,11 +51,18 @@ var AppVersionComponent = React.createClass({
     AppsActions.applySettingsOnApp(appVersion.id, appVersion);
   },
 
+  getButtonClassSet: function () {
+    return classNames({
+      "btn btn-sm btn-default pull-right": true,
+      "disabled": this.props.appVersion.version == null
+    });
+  },
+
   getApplyButton: function () {
     if (!this.props.currentVersion) {
       return (
         <button type="submit"
-            className="btn btn-sm btn-default pull-right"
+            className={this.getButtonClassSet()}
             onClick={this.handleRollbackToAppVersion}>
           ✓ Apply
         </button>
@@ -65,7 +73,7 @@ var AppVersionComponent = React.createClass({
   getEditButton: function () {
     return (
       <button type="submit"
-          className="btn btn-sm btn-default pull-right"
+          className={this.getButtonClassSet()}
           onClick={this.handleEditAppVersion}>
         ✎ Edit
       </button>


### PR DESCRIPTION
If you apply an old version and this version becomes the fresh one, the version string could be 'unspecified'. To be honest, I am unsure why this is the case.
If the version string is unspecified the edit- and apply-buttons should be disabled.

Prevents https://github.com/mesosphere/marathon/issues/2114