### PR TITLE
Feature - 2133 display health checks settings in configuration tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - \#124 - Expose environment variables in app modal dialog
 - \#2010 - Show task life time and states in debug tab
 - \#2012 - Show summary about the most recent configuration change
+- \#2133 - Display health checks settings in the application configuration tab
 
 ### Changed
 - \#124 - Expose all /v2 App attributes in UI

--- a/src/js/components/AppVersionComponent.jsx
+++ b/src/js/components/AppVersionComponent.jsx
@@ -83,9 +83,9 @@ var AppVersionComponent = React.createClass({
   render: function () {
     var appVersion = this.props.appVersion;
 
-    var constraintsNode = (appVersion.constraints.length < 1) ?
-      <UNSPECIFIED_NODE /> :
-      appVersion.constraints.map(function (c) {
+    var constraintsNode = (appVersion.constraints.length < 1)
+      ? <UNSPECIFIED_NODE />
+      : appVersion.constraints.map(function (c) {
 
         // Only include constraint parts if they are not empty Strings. For
         // example, a hostname uniqueness constraint looks like:
@@ -101,34 +101,34 @@ var AppVersionComponent = React.createClass({
         );
       });
 
-    var containerNode = (appVersion.container == null) ?
-      <UNSPECIFIED_NODE /> :
-      <dd><pre>{JSON.stringify(appVersion.container, null, 2)}</pre></dd>;
+    var containerNode = (appVersion.container == null)
+      ? <UNSPECIFIED_NODE />
+      : <dd><pre>{JSON.stringify(appVersion.container, null, 2)}</pre></dd>;
 
     var envNode = (appVersion.env == null ||
-        Object.keys(appVersion.env).length === 0) ?
-      <UNSPECIFIED_NODE /> :
+        Object.keys(appVersion.env).length === 0)
+      ? <UNSPECIFIED_NODE />
       // Print environment variables as key value pairs like "key=value"
-      Object.keys(appVersion.env).map(function (k) {
+      : Object.keys(appVersion.env).map(function (k) {
         return <dd key={k}>{k + "=" + appVersion.env[k]}</dd>;
       });
 
-    var executorNode = (appVersion.executor === "") ?
-      <UNSPECIFIED_NODE /> :
-      <dd>{appVersion.executor}</dd>;
+    var executorNode = (appVersion.executor === "")
+      ? <UNSPECIFIED_NODE />
+      : <dd>{appVersion.executor}</dd>;
 
     var healthChecksNode = (appVersion.healthChecks == null
-        || appVersion.healthChecks.length === 0) ?
-      <UNSPECIFIED_NODE /> :
-      <dd><pre>{JSON.stringify(appVersion.healthChecks, null, 2)}</pre></dd>;
+        || appVersion.healthChecks.length === 0)
+      ? <UNSPECIFIED_NODE />
+      : <dd><pre>{JSON.stringify(appVersion.healthChecks, null, 2)}</pre></dd>;
 
-    var portsNode = (appVersion.ports.length === 0) ?
-      <UNSPECIFIED_NODE /> :
-      <dd>{appVersion.ports.join(",")}</dd>;
+    var portsNode = (appVersion.ports.length === 0)
+      ? <UNSPECIFIED_NODE />
+      : <dd>{appVersion.ports.join(",")}</dd>;
 
-    var urisNode = (appVersion.uris.length === 0) ?
-      <UNSPECIFIED_NODE /> :
-      appVersion.uris.map(function (u) {
+    var urisNode = (appVersion.uris.length === 0)
+      ? <UNSPECIFIED_NODE />
+      : appVersion.uris.map(function (u) {
         return <dd key={u}>{u}</dd>;
       });
 

--- a/src/js/components/AppVersionComponent.jsx
+++ b/src/js/components/AppVersionComponent.jsx
@@ -117,6 +117,11 @@ var AppVersionComponent = React.createClass({
       <UNSPECIFIED_NODE /> :
       <dd>{appVersion.executor}</dd>;
 
+    var healthChecksNode = (appVersion.healthChecks == null
+        || appVersion.healthChecks.length === 0) ?
+      <UNSPECIFIED_NODE /> :
+      <dd><pre>{JSON.stringify(appVersion.healthChecks, null, 2)}</pre></dd>;
+
     var portsNode = (appVersion.ports.length === 0) ?
       <UNSPECIFIED_NODE /> :
       <dd>{appVersion.ports.join(",")}</dd>;
@@ -144,6 +149,8 @@ var AppVersionComponent = React.createClass({
           {envNode}
           <dt>Executor</dt>
           {executorNode}
+          <dt>Health Checks</dt>
+          {healthChecksNode}
           <dt>Instances</dt>
           {invalidateValue(appVersion.instances)}
           <dt>Memory</dt>

--- a/src/test/appVersions.test.js
+++ b/src/test/appVersions.test.js
@@ -208,7 +208,7 @@ describe("App Version List component", function () {
 describe("App Version component", function () {
 
   beforeEach(function () {
-    var model = {
+    this.model = {
       "id": "/sleep10",
       "cmd": "sleep 10",
       "args": null,
@@ -228,7 +228,16 @@ describe("App Version component", function () {
       "backoffFactor": 1.15,
       "maxLaunchDelaySeconds": 3600,
       "container": null,
-      "healthChecks": [],
+      "healthChecks": [{
+        "path": "/",
+        "protocol": "HTTP",
+        "portIndex": 0,
+        "gracePeriodSeconds": 30,
+        "intervalSeconds": 30,
+        "timeoutSeconds": 30,
+        "maxConsecutiveFailures": 3,
+        "ignoreHttp1xx": false
+      }],
       "dependencies": [],
       "upgradeStrategy": {
         "minimumHealthCapacity": 1.0,
@@ -241,7 +250,7 @@ describe("App Version component", function () {
 
     this.renderer = TestUtils.createRenderer();
     this.renderer.render(<AppVersionComponent
-      appVersion={model} />);
+      appVersion={this.model} />);
     this.component = this.renderer.getRenderOutput();
     this.table = this.component.props.children[2].props.children;
   });
@@ -274,44 +283,51 @@ describe("App Version component", function () {
     expect(this.table[11].type.displayName).to.equal("UNSPECIFIED_NODE");
   });
 
+  it("has correct health checks", function () {
+    var healthChecks = this.table[13].props.children.props.children;
+    expect(healthChecks).to.equal(
+      JSON.stringify(this.model.healthChecks, null, 2)
+    );
+  });
+
   it("has correct number of instances", function () {
-    expect(this.table[13].props.children[0]).to.equal(14);
+    expect(this.table[15].props.children[0]).to.equal(14);
   });
 
   it("has correct amount of memory", function () {
-    expect(this.table[15].props.children[0]).to.equal(16.0);
-    expect(this.table[15].props.children[2]).to.equal("MB");
-  });
-
-  it("has correct amount of disk space", function () {
-    expect(this.table[17].props.children[0]).to.equal(0.0);
+    expect(this.table[17].props.children[0]).to.equal(16.0);
     expect(this.table[17].props.children[2]).to.equal("MB");
   });
 
+  it("has correct amount of disk space", function () {
+    expect(this.table[19].props.children[0]).to.equal(0.0);
+    expect(this.table[19].props.children[2]).to.equal("MB");
+  });
+
   it("has correct ports", function () {
-    expect(this.table[19].props.children).to.equal("10000,10001");
+    expect(this.table[21].props.children).to.equal("10000,10001");
   });
 
   it("has correct backoff factor", function () {
-    expect(this.table[21].props.children[0]).to.equal(1.15);
+    expect(this.table[23].props.children[0]).to.equal(1.15);
   });
 
   it("has correct backoff", function () {
-    expect(this.table[23].props.children[0]).to.equal(1);
-    expect(this.table[23].props.children[2]).to.equal("seconds");
-  });
-
-  it("has correct max launch delay", function () {
-    expect(this.table[25].props.children[0]).to.equal(3600);
+    expect(this.table[25].props.children[0]).to.equal(1);
     expect(this.table[25].props.children[2]).to.equal("seconds");
   });
 
+  it("has correct max launch delay", function () {
+    expect(this.table[27].props.children[0]).to.equal(3600);
+    expect(this.table[27].props.children[2]).to.equal("seconds");
+  });
+
   it("has correct URIs", function () {
-    expect(this.table[27].type.displayName).to.equal("UNSPECIFIED_NODE");
+    expect(this.table[29].type.displayName).to.equal("UNSPECIFIED_NODE");
   });
 
   it("has correct version", function () {
-    expect(this.table[29].props.children[0]).to.equal("2015-06-29T12:57:02.269Z");
+    expect(this.table[31].props.children[0]).to.equal("2015-06-29T12:57:02.269Z");
   });
 
 });


### PR DESCRIPTION
This fixes https://github.com/mesosphere/marathon/issues/2133

With health checks:
![hc](https://cloud.githubusercontent.com/assets/859154/9575389/920d10e0-4fcf-11e5-9027-fc97160e5a7e.png)

Without health checks:
![hcu](https://cloud.githubusercontent.com/assets/859154/9575383/8bb63992-4fcf-11e5-9975-5843f52eee0b.png)
