### PR TITLE
Refactor to use React.findDOMNode

### DIFF
--- a/src/js/components/modals/AlertModalComponent.jsx
+++ b/src/js/components/modals/AlertModalComponent.jsx
@@ -12,7 +12,7 @@ var AlertModalComponent = React.createClass({
   },
 
   componentDidMount: function () {
-    this.refs.button.getDOMNode().focus();
+    React.findDOMNode(this.refs.button).focus();
   },
 
   getDefaultProps: function () {

--- a/src/js/components/modals/PromptModalComponent.jsx
+++ b/src/js/components/modals/PromptModalComponent.jsx
@@ -23,8 +23,8 @@ var PromptModalComponent = React.createClass({
   },
 
   componentDidMount: function () {
-    this.refs.textinput.getDOMNode().focus();
-    this.refs.textinput.getDOMNode().select();
+    React.findDOMNode(this.refs.textinput).focus();
+    React.findDOMNode(this.refs.textinput).select();
   },
 
   handleDestroy: function () {
@@ -32,7 +32,7 @@ var PromptModalComponent = React.createClass({
   },
 
   handleConfirm: function () {
-    this.props.onConfirm(this.refs.textinput.getDOMNode().value);
+    this.props.onConfirm(React.findDOMNode(this.refs.textinput).value);
   },
 
   onKeyUp: function (event) {


### PR DESCRIPTION
We can leverage React's findDOMNode function to access elements via refs
as described here:
https://facebook.github.io/react/docs/working-with-the-browser.html#refs-and-finddomnode