### PR TITLE
DON'T merge: Proposal for #2106 - Refactor to ES6 classes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,13 +1,14 @@
 {
   "ecmaFeatures": {
-    "jsx": true,
     "arrowFunctions": true,
     "blockBindings": true,
-    "destructuring": true,
-    "objectLiteralComputedProperties": true,
-    "templateStrings": true,
+    "classes": true,
     "defaultParams": true,
-    "restParams": true
+    "destructuring": true,
+    "jsx": true,
+    "objectLiteralComputedProperties": true,
+    "restParams": true,
+    "templateStrings": true
   },
 
   "env": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,6 @@
 {
+  "parser": "babel-eslint",
+
   "ecmaFeatures": {
     "arrowFunctions": true,
     "blockBindings": true,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,7 +46,10 @@ var webpackConfig = {
       {
         test: /\.(js|jsx)$/,
         loader: "babel-loader",
-        exclude: /node_modules/
+        exclude: /node_modules/,
+        query: {
+          stage: 0
+        }
       },
       {
         test: /\.json$/,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -866,6 +866,124 @@
         }
       }
     },
+    "babel-eslint": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-4.1.1.tgz",
+      "dependencies": {
+        "acorn-to-esprima": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/acorn-to-esprima/-/acorn-to-esprima-1.0.2.tgz"
+        },
+        "lodash.assign": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+          "dependencies": {
+            "lodash._baseassign": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                }
+              }
+            },
+            "lodash._createassigner": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+              "dependencies": {
+                "lodash._bindcallback": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                }
+              }
+            },
+            "lodash.keys": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+              "dependencies": {
+                "lodash._getnative": {
+                  "version": "3.9.1",
+                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                },
+                "lodash.isarguments": {
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                }
+              }
+            }
+          }
+        },
+        "lodash.pick": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-3.1.0.tgz",
+          "dependencies": {
+            "lodash._baseflatten": {
+              "version": "3.1.4",
+              "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+              "dependencies": {
+                "lodash.isarguments": {
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                }
+              }
+            },
+            "lodash._bindcallback": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+            },
+            "lodash._pickbyarray": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz"
+            },
+            "lodash._pickbycallback": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+              "dependencies": {
+                "lodash._basefor": {
+                  "version": "3.0.2",
+                  "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
+                },
+                "lodash.keysin": {
+                  "version": "3.0.8",
+                  "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.4",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash.restparam": {
+              "version": "3.6.1",
+              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+            }
+          }
+        }
+      }
+    },
     "babel-loader": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-5.3.2.tgz",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -341,23 +341,9 @@
       }
     },
     "babel-core": {
-      "version": "5.6.15",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.6.15.tgz",
+      "version": "5.8.23",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.23.tgz",
       "dependencies": {
-        "acorn-jsx": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-1.0.3.tgz",
-          "dependencies": {
-            "acorn": {
-              "version": "1.2.2",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
-            }
-          }
-        },
-        "ast-types": {
-          "version": "0.7.8",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz"
-        },
         "babel-plugin-constant-folding": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
@@ -375,8 +361,8 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
         },
         "babel-plugin-jscript": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.1.tgz"
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
         },
         "babel-plugin-member-expression-literals": {
           "version": "1.0.1",
@@ -387,8 +373,8 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
         },
         "babel-plugin-proto-to-assign": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.3.tgz"
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
         },
         "babel-plugin-react-constant-elements": {
           "version": "1.0.3",
@@ -424,45 +410,49 @@
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
         },
+        "babylon": {
+          "version": "5.8.23",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.23.tgz"
+        },
+        "bluebird": {
+          "version": "2.9.34",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
+        },
         "chalk": {
-          "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.0.1",
-              "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
               "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
-              "version": "1.0.3",
-              "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "1.1.1",
-                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                },
-                "get-stdin": {
-                  "version": "4.0.1",
-                  "resolved": "http://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
-              "version": "2.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "1.1.1",
-                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
@@ -471,8 +461,8 @@
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
         },
         "core-js": {
-          "version": "0.9.18",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-0.9.18.tgz"
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.1.3.tgz"
         },
         "debug": {
           "version": "2.2.0",
@@ -493,14 +483,10 @@
               "resolved": "http://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "minimist": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
             }
           }
-        },
-        "estraverse": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.0.tgz"
         },
         "esutils": {
           "version": "2.0.2",
@@ -529,8 +515,8 @@
           }
         },
         "is-integer": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.4.tgz",
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
           "dependencies": {
             "is-finite": {
               "version": "1.0.1",
@@ -541,32 +527,16 @@
                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                 }
               }
-            },
-            "is-nan": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.1.0.tgz",
-              "dependencies": {
-                "define-properties": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.0.2.tgz",
-                  "dependencies": {
-                    "foreach": {
-                      "version": "2.0.5",
-                      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
-                    },
-                    "object-keys": {
-                      "version": "1.0.4",
-                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.4.tgz"
-                    }
-                  }
-                }
-              }
             }
           }
         },
         "js-tokens": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
+        },
+        "json5": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
         },
         "line-numbers": {
           "version": "0.2.0",
@@ -579,12 +549,12 @@
           }
         },
         "lodash": {
-          "version": "3.9.3",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "minimatch": {
-          "version": "2.0.8",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.0",
@@ -635,8 +605,8 @@
           "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
         },
         "regenerator": {
-          "version": "0.8.31",
-          "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.31.tgz",
+          "version": "0.8.35",
+          "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.35.tgz",
           "dependencies": {
             "commoner": {
               "version": "0.10.3",
@@ -669,8 +639,8 @@
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
                       "dependencies": {
                         "lru-cache": {
-                          "version": "2.6.4",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                          "version": "2.6.5",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.1",
@@ -695,8 +665,8 @@
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
                 },
                 "iconv-lite": {
-                  "version": "0.4.10",
-                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.10.tgz"
+                  "version": "0.4.11",
+                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz"
                 },
                 "install": {
                   "version": "0.1.8",
@@ -771,22 +741,22 @@
               }
             },
             "esprima-fb": {
-              "version": "13001.1.0-dev-harmony-fb",
-              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1.0-dev-harmony-fb.tgz"
+              "version": "15001.1.0-dev-harmony-fb",
+              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz"
             },
             "recast": {
-              "version": "0.10.13",
-              "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.13.tgz",
+              "version": "0.10.24",
+              "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.24.tgz",
               "dependencies": {
-                "esprima-fb": {
-                  "version": "14001.1.0-dev-harmony-fb",
-                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-14001.1.0-dev-harmony-fb.tgz"
+                "ast-types": {
+                  "version": "0.8.5",
+                  "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.5.tgz"
                 }
               }
             },
             "through": {
-              "version": "2.3.7",
-              "resolved": "http://registry.npmjs.org/through/-/through-2.3.7.tgz"
+              "version": "2.3.8",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             }
           }
         },
@@ -795,12 +765,16 @@
           "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.2.0.tgz",
           "dependencies": {
             "recast": {
-              "version": "0.10.13",
-              "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.13.tgz",
+              "version": "0.10.32",
+              "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.32.tgz",
               "dependencies": {
+                "ast-types": {
+                  "version": "0.8.11",
+                  "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.11.tgz"
+                },
                 "esprima-fb": {
-                  "version": "14001.1.0-dev-harmony-fb",
-                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-14001.1.0-dev-harmony-fb.tgz"
+                  "version": "15001.1001.0-dev-harmony-fb",
+                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
                 }
               }
             },
@@ -813,8 +787,8 @@
               "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
             },
             "regjsparser": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.4.tgz",
+              "version": "0.1.5",
+              "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
               "dependencies": {
                 "jsesc": {
                   "version": "0.5.0",
@@ -853,12 +827,12 @@
           "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
         },
         "source-map": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "dependencies": {
             "amdefine": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
             }
           }
         },
@@ -871,34 +845,34 @@
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "dependencies": {
                 "amdefine": {
-                  "version": "0.1.1",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
             }
           }
-        },
-        "strip-json-comments": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
         },
         "to-fast-properties": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
         },
         "trim-right": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.0.tgz"
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+        },
+        "try-resolve": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
         }
       }
     },
     "babel-loader": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-5.2.2.tgz",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-5.3.2.tgz",
       "dependencies": {
         "loader-utils": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.10.tgz",
+          "version": "0.2.11",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.11.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "babel-core": "^5.8.23",
+    "babel-eslint": "^4.1.1",
     "babel-loader": "^5.3.2",
     "browser-sync": "^2.7.12",
     "chai": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "underscore": "^1.7.0"
   },
   "devDependencies": {
-    "babel-core": "^5.5.8",
-    "babel-loader": "^5.1.4",
+    "babel-core": "^5.8.23",
+    "babel-loader": "^5.3.2",
     "browser-sync": "^2.7.12",
     "chai": "^3.0.0",
     "chalk": "^0.5.1",

--- a/src/js/components/ModalComponent.jsx
+++ b/src/js/components/ModalComponent.jsx
@@ -6,51 +6,39 @@ function modalSizeClassName(size) {
   return (size == null) ? "" : "modal-" + size;
 }
 
-var ModalComponent = React.createClass({
-  displayName: "ModalComponent",
-  propTypes: {
-    centered: React.PropTypes.bool,
-    children: React.PropTypes.node,
-    dismissOnClickOutside: React.PropTypes.bool,
-    onDestroy: React.PropTypes.func,
-    size: React.PropTypes.string
-  },
+class ModalComponent extends React.Component {
+  constructor(props) {
+    super(props);
 
-  componentDidMount: function () {
-    this.timeout = setTimeout(this.transitionIn, 10);
-  },
-
-  destroy: function () {
-    this.props.onDestroy();
-  },
-
-  getDefaultProps: function () {
-    return {
-      dismissOnClickOutside: true,
-      onDestroy: Util.noop,
-      size: null
-    };
-  },
-
-  getInitialState: function () {
-    return {
+    this.state = {
       isIn: false
     };
-  },
 
-  onClick: function (event) {
+    this.onClick = this.onClick.bind(this);
+    this.transitionIn = this.transitionIn.bind(this);
+  }
+
+  componentDidMount() {
+    this.timeout = setTimeout(this.transitionIn, 10);
+  }
+
+  onClick(event) {
     if (this.props.dismissOnClickOutside &&
       (Util.hasClass(event.target, "modal") ||
       Util.hasClass(event.target, "modal-dialog"))) {
       this.destroy();
     }
-  },
+  }
 
-  transitionIn: function () {
+  destroy() {
+    this.props.onDestroy();
+  }
+
+  transitionIn() {
     this.setState({isIn: true});
-  },
+  }
 
-  render: function () {
+  render() {
     var modalDialogClassName =
       "modal-dialog " + modalSizeClassName(this.props.size);
 
@@ -82,6 +70,22 @@ var ModalComponent = React.createClass({
       </div>
     );
   }
-});
+}
+
+ModalComponent.propTypes = {
+  centered: React.PropTypes.bool,
+  children: React.PropTypes.node,
+  dismissOnClickOutside: React.PropTypes.bool,
+  onDestroy: React.PropTypes.func,
+  size: React.PropTypes.string
+};
+
+ModalComponent.defaultProps = {
+  dismissOnClickOutside: true,
+  onDestroy: Util.noop,
+  size: null
+};
+
+ModalComponent.displayName = "ModalComponent";
 
 module.exports = ModalComponent;

--- a/src/js/components/ModalComponent.jsx
+++ b/src/js/components/ModalComponent.jsx
@@ -7,22 +7,39 @@ function modalSizeClassName(size) {
 }
 
 class ModalComponent extends React.Component {
+  static displayName = "ModalComponent";
+
+  static propTypes = {
+    centered: React.PropTypes.bool,
+    children: React.PropTypes.node,
+    dismissOnClickOutside: React.PropTypes.bool,
+    onDestroy: React.PropTypes.func,
+    size: React.PropTypes.string
+  };
+
+  static defaultProps = {
+    dismissOnClickOutside: true,
+    onDestroy: Util.noop,
+    size: null
+  };
+
   constructor(props) {
     super(props);
 
     this.state = {
       isIn: false
     };
-
-    this.onClick = this.onClick.bind(this);
-    this.transitionIn = this.transitionIn.bind(this);
   }
 
   componentDidMount() {
     this.timeout = setTimeout(this.transitionIn, 10);
   }
 
-  onClick(event) {
+  destroy() {
+    this.props.onDestroy();
+  }
+
+  onClick = (event) => {
     if (this.props.dismissOnClickOutside &&
       (Util.hasClass(event.target, "modal") ||
       Util.hasClass(event.target, "modal-dialog"))) {
@@ -30,11 +47,7 @@ class ModalComponent extends React.Component {
     }
   }
 
-  destroy() {
-    this.props.onDestroy();
-  }
-
-  transitionIn() {
+  transitionIn = () => {
     this.setState({isIn: true});
   }
 
@@ -71,21 +84,5 @@ class ModalComponent extends React.Component {
     );
   }
 }
-
-ModalComponent.propTypes = {
-  centered: React.PropTypes.bool,
-  children: React.PropTypes.node,
-  dismissOnClickOutside: React.PropTypes.bool,
-  onDestroy: React.PropTypes.func,
-  size: React.PropTypes.string
-};
-
-ModalComponent.defaultProps = {
-  dismissOnClickOutside: true,
-  onDestroy: Util.noop,
-  size: null
-};
-
-ModalComponent.displayName = "ModalComponent";
 
 module.exports = ModalComponent;


### PR DESCRIPTION
Hey there @philipnrmn @pierlo-upitup .

I've prepared 2 proposal here for using ES6(7)-classes with React.

The first one is this commit https://github.com/mesosphere/marathon-ui/commit/462277aca62f1fa3534f62824e7172d7b8e0ca7c .

It uses straight ES6 classes, which is safe to use.
But it looks bad and uncommon to me, because of two things:
1. 
The ReactClass-properties must be defined on the existing class object, what looks like this:
```javascript
ModalComponent extends React.Component {
  constructor() {
    this.state = {
      ...
    }
  }
  ....
  render() {
  ...
  }
}

ModalComponent.propTypes = {
  size: React.PropTypes.string,
  ....
};

ModalComponent.defaultProps = {
  size: "m",
  ....
};

module.exports = ModalComponent;
```
This looks bad, especially the props are suddenly at the bottom of the definition and not at the top anymore.

2.
Passed functions like click-handlers aren't autobinded to the class, so ```this``` has a different scope.
To enforce this semi-manually, you have to do this in the constructor:
```javascript
ModalComponent extends React.Component {
  constructor() {
    this.onClick = this.onClick.bind(this);
  }
```
Buh! :(

There is a way to avoid this! Use ES7 (ES6+) classProperties and auto-binding.
https://gist.github.com/jeffmo/054df782c05639da2adb
We can write this now in a much nicer way, look at this commit https://github.com/mesosphere/marathon-ui/commit/07117f9049529ae6987588b5fb82d56c96229b7e .
```javascript
class ModalComponent extends React.Component {
  static propTypes = {
    size: React.PropTypes.string
  };

  static defaultProps = {
    size: "m"
  };

  onClick = (event) => {
    // I have the class-this at every time
  }
}
```

But! For this we have to enable experimental ES7-features in Babel, where the specs could change in the future. 
Buh again! :(

So, I don't like the first ES6-way, looks nasty. 
I like the ES7-way, but if we are cautious, we should _not_ use these new features yet.

Let's think again and maybe shift this refactoring?

Related to this issue:
https://github.com/mesosphere/marathon/issues/2106