### PR TITLE
2105 server errors

### DIFF
--- a/src/js/components/OptionalEnviromentComponent.jsx
+++ b/src/js/components/OptionalEnviromentComponent.jsx
@@ -14,6 +14,7 @@ var OptionalEnvironmentComponent = React.createClass({
 
   propTypes: {
     errorIndices: React.PropTypes.array,
+    generalError: React.PropTypes.string,
     rows: React.PropTypes.array
   },
 
@@ -106,6 +107,20 @@ var OptionalEnvironmentComponent = React.createClass({
     return null;
   },
 
+  getGeneralErrorBlock: function () {
+    var error = this.props.generalError;
+
+    if (error == null) {
+      return null;
+    }
+
+    return (
+      <p className="text-danger">
+        <strong>{error}</strong>
+      </p>
+    );
+  },
+
   getEnviromentRow: function (row, i, disableRemoveButton = false) {
     var error = this.getError(i);
 
@@ -166,6 +181,7 @@ var OptionalEnvironmentComponent = React.createClass({
         <div className="duplicable-list">
           {this.getEnviromentRows()}
         </div>
+        {this.getGeneralErrorBlock()}
       </div>
     );
   }

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -93,7 +93,7 @@ var AppModalComponent = React.createClass({
   },
 
   onCreateAppError: function (data, status) {
-    // This is actually not an error
+    // All status below 300 are actually not an error
     if (status < 300) {
       this.onCreateApp();
 

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -4,8 +4,11 @@ var objectPath = require("object-path");
 var Util = require("../helpers/Util");
 
 var AppDispatcher = require("../AppDispatcher");
+var AppFormErrorMessages = require("../validators/AppFormErrorMessages");
 var AppFormTransforms = require("./AppFormTransforms");
 var AppFormValidators = require("./AppFormValidators");
+var AppsStore = require("./AppsStore");
+var AppsEvents = require("../events/AppsEvents");
 var FormEvents = require("../events/FormEvents");
 
 const defaultFieldValues = Object.freeze({
@@ -70,11 +73,25 @@ const duplicableRowFields = [
   "containerVolumes"
 ];
 
+const responseAttributeNameToFieldIdMap = {
+  "id": "appId",
+  "/cmd": "cmd",
+  "/cpus": "cpus",
+  "/disk": "disk",
+  "/env": "env",
+  "/executor": "executor",
+  "/instances": "instances",
+  "/mem": "mem",
+  "/ports": "ports",
+  "/uris": "uris",
+  "/constraints": "constraints"
+};
+
 function getValidationErrorIndex(fieldId, value) {
   if (validationRules[fieldId] == null) {
     return -1;
   }
-  return validationRules[fieldId].findIndex((isValid) =>!isValid(value));
+  return validationRules[fieldId].findIndex((isValid) => !isValid(value));
 }
 
 function insertField(fields, fieldId, index = null, value) {
@@ -121,9 +138,49 @@ function rebuildModelFromFields(app, fields, fieldId) {
   }
 }
 
+function processResponseErrors(responseErrors, response, statusCode) {
+  if (statusCode >= 500) {
+    responseErrors.general = AppFormErrorMessages.general[1];
+
+  } else if (statusCode === 422 && response != null &&
+      Util.isArray(response.errors)) {
+
+    response.errors.forEach((error) => {
+      var fieldId = error.attribute.length
+        ? error.attribute
+        : "general";
+      fieldId = responseAttributeNameToFieldIdMap[fieldId] || fieldId;
+      responseErrors[fieldId] = error.error;
+    });
+
+  } else if (statusCode === 409 && response != null &&
+      response.message != null) {
+
+    responseErrors.general =
+      `${AppFormErrorMessages.general[2]} ${response.message}`;
+
+  } else if (statusCode === 400 && response != null &&
+      Util.isArray(response.details)) {
+
+    response.details.forEach((detail) => {
+      var fieldId = detail.path.length
+        ? detail.path
+        : "general";
+      fieldId = responseAttributeNameToFieldIdMap[fieldId] || fieldId;
+      responseErrors[fieldId] = detail.errors.join(", ");
+    });
+
+  } else if (statusCode >= 300) {
+    responseErrors.general = AppFormErrorMessages.general[0];
+  }
+}
+
 var AppFormStore = lazy(EventEmitter.prototype).extend({
   app: {},
   fields: {},
+  // If there is an app related response from the server that was unsuccessful,
+  // these error messages will be stored here by fieldId.
+  responseErrors: {},
   validationErrorIndices: {},
   initAndReset: function () {
     this.app = {};
@@ -168,6 +225,18 @@ function executeAction(action, setFieldFunction) {
     AppFormStore.emit(FormEvents.FIELD_VALIDATION_ERROR);
   }
 }
+
+function onAppsErrorResponse(response, statusCode) {
+  AppFormStore.responseErrors = {};
+  processResponseErrors(AppFormStore.responseErrors, response, statusCode);
+}
+
+AppsStore.on(AppsEvents.CREATE_APP_ERROR, function (data, status) {
+  onAppsErrorResponse(data, status);
+});
+AppsStore.on(AppsEvents.APPLY_APP_ERROR, function (data, isEditing, status) {
+  onAppsErrorResponse(data, status);
+});
 
 AppDispatcher.register(function (action) {
   switch (action.actionType) {

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -178,8 +178,6 @@ function processResponseErrors(responseErrors, response, statusCode) {
 var AppFormStore = lazy(EventEmitter.prototype).extend({
   app: {},
   fields: {},
-  // If there is an app related response from the server that was unsuccessful,
-  // these error messages will be stored here by fieldId.
   responseErrors: {},
   validationErrorIndices: {},
   initAndReset: function () {

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -237,6 +237,12 @@ AppsStore.on(AppsEvents.CREATE_APP_ERROR, function (data, status) {
 AppsStore.on(AppsEvents.APPLY_APP_ERROR, function (data, isEditing, status) {
   onAppsErrorResponse(data, status);
 });
+AppsStore.on(AppsEvents.CREATE_APP, function () {
+  AppFormStore.responseErrors = {};
+});
+AppsStore.on(AppsEvents.APPLY_APP, function () {
+  AppFormStore.responseErrors = {};
+});
 
 AppDispatcher.register(function (action) {
   switch (action.actionType) {

--- a/src/js/validators/AppFormErrorMessages.js
+++ b/src/js/validators/AppFormErrorMessages.js
@@ -27,6 +27,11 @@ const AppFormErrorMessages = {
   ],
   env: ["Key cannot be blank"],
   executor: ["Invalid executor format"],
+  general: [
+    "App creation unsuccessful. Check your app settings and try again.",
+    "Unknown server error, could not create or apply app.",
+    "Error:"
+  ],
   instances: ["Instances must be a non-negative Number"],
   mem: ["Memory must be a non-negative Number"],
   ports: ["Ports must be a comma-separated list of numbers"],

--- a/src/test/appForm.test.js
+++ b/src/test/appForm.test.js
@@ -658,7 +658,7 @@ describe("App Form", function () {
 
     describe("App form store", function () {
 
-      it("processes array of details on code 400", function (done) {
+      it("processes a 400 error response correctly", function (done) {
         this.server.setup({
           details: [{
             "path": "/instances",
@@ -680,7 +680,24 @@ describe("App Form", function () {
         });
       });
 
-      it("processes array of errors on code 422", function (done) {
+      it("processes a 409 error response message correctly", function (done) {
+        this.server.setup({
+          "message": "bad error"
+        }, 409);
+
+        AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
+          expectAsync(function () {
+            expect(AppFormStore.responseErrors.general)
+              .to.equal(`${AppFormErrorMessages.general[2]} bad error`);
+          }, done);
+        });
+
+        AppsActions.createApp({
+          "howdy": "partner"
+        });
+      });
+
+      it("processes a 422 error response correctly", function (done) {
         this.server.setup({
           errors: [{
             "attribute": "id",
@@ -700,24 +717,8 @@ describe("App Form", function () {
         });
       });
 
-      it("processes error message on code 409", function (done) {
-        this.server.setup({
-          "message": "bad error"
-        }, 409);
-
-        AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
-          expectAsync(function () {
-            expect(AppFormStore.responseErrors.general)
-              .to.equal(`${AppFormErrorMessages.general[2]} bad error`);
-          }, done);
-        });
-
-        AppsActions.createApp({
-          "howdy": "partner"
-        });
-      });
-
-      it("sets general error on codes 300 to 499", function (done) {
+      it("processes error response codes 300 to 499 correctly",
+          function (done) {
         this.server.setup("something strange", 315);
 
         AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
@@ -732,7 +733,7 @@ describe("App Form", function () {
         });
       });
 
-      it("sets unknown error on codes >= 500", function (done) {
+      it("processes error response codes >= 500 correctly", function (done) {
         this.server.setup("something strange with the server", 500);
 
         AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {


### PR DESCRIPTION
This handles server error responses, taking place after our own validation.

To test this you need to turn off validation and turn off transformators or manipulated transformators badly.

E.g.:
```javascript
function getValidationErrorIndex(fieldId, value) {
  return -1;
}
```
```javascript
function getTransformedField(fieldId, value) {
  return value;
}
```
```javascript
const AppFormTransforms = {
  cpus: (value) => "xxx",
```

There are different responses from the server.

Sometimes with helpful messages, stored in ```response.errors``` (AppFormStore.js:116):
![errors4](https://cloud.githubusercontent.com/assets/859154/9788270/be7f28ec-57c8-11e5-99f2-67fc70967b16.png)

But there are also not so helpful messages stored in ```response.details``` (AppFormStore.js:135), named: ```error.pattern```, ```error.expected.jsarray``` and so on.
It would be nice to map these to something human readable.
@aquamatthias Could somebody provide us with a list of these _placeholders_?

![errors1](https://cloud.githubusercontent.com/assets/859154/9788313/3142bdb2-57c9-11e5-8fd1-92a0a65989ef.png)
![errors3](https://cloud.githubusercontent.com/assets/859154/9788319/367bfb68-57c9-11e5-8fe7-8d7f875c4fc1.png)

And of course there are general errors too:
![errors2](https://cloud.githubusercontent.com/assets/859154/9788326/469305a0-57c9-11e5-9e6e-d6580151a344.png)

