### PR TITLE
Fixes #2266 | Remove double slash in link to Mesos

### DIFF
--- a/src/js/components/TaskMesosUrlComponent.jsx
+++ b/src/js/components/TaskMesosUrlComponent.jsx
@@ -44,16 +44,16 @@ var TaskMesosUrlComponent = React.createClass({
         if (masterUrl == null || task.slaveId == null) {
           return null;
         }
-        var url = [
+        masterUrl = masterUrl.replace(/\/?$/, "/");
+        return [
           masterUrl,
-          "/#/slaves/",
+          "#/slaves/",
           task.slaveId,
           "/frameworks/",
           frameworkId,
           "/executors/",
           task.id || task.taskId
         ].join("");
-        return url;
       }
     }
   },

--- a/src/test/tasks.test.js
+++ b/src/test/tasks.test.js
@@ -385,4 +385,14 @@ describe("Task Mesos Url component", function () {
 "http://leader1.dcos.io:5050/#/slaves/20150720-125149-3839899402-5050-\
 16758-S1/frameworks/framework1/executors/task-123");
   });
+  it("has the correct mesos task url when mesosUrl has trailing slash", function () {
+    InfoStore.info.marathon_config.mesos_leader_ui_url = "http://leader1.dcos.io:5050/";
+    this.renderer = TestUtils.createRenderer();
+    this.renderer.render(<TaskMesosUrlComponent task={this.model}/>);
+    this.component = this.renderer.getRenderOutput();
+    var url = this.component.props.href;
+    expect(url).to.equal(
+"http://leader1.dcos.io:5050/#/slaves/20150720-125149-3839899402-5050-\
+16758-S1/frameworks/framework1/executors/task-123");
+  });
 });


### PR DESCRIPTION
Fixes #2266 - add missing `/` in Mesos URL or leave it untouched if there is one