### PR TITLE
Remove HTML5 required attribute on inputs

### DIFF
--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -216,7 +216,7 @@ var AppModalComponent = React.createClass({
                 value={state.fields.appId}
                 label="ID"
                 onChange={this.handleFieldUpdate}>
-              <input autoFocus required />
+              <input autoFocus />
             </FormGroupComponent>
             <div className="row">
               <div className="col-sm-3">
@@ -226,7 +226,7 @@ var AppModalComponent = React.createClass({
                     label="CPUs"
                     value={state.fields.cpus}
                     onChange={this.handleFieldUpdate}>
-                  <input min="0" step="any" type="number" required />
+                  <input min="0" step="any" type="number" />
                 </FormGroupComponent>
               </div>
               <div className="col-sm-3">
@@ -236,7 +236,7 @@ var AppModalComponent = React.createClass({
                     errorMessage={this.getErrorMessage("mem")}
                     value={state.fields.mem}
                     onChange={this.handleFieldUpdate}>
-                  <input min="0" step="any" type="number" required />
+                  <input min="0" step="any" type="number" />
                 </FormGroupComponent>
               </div>
               <div className="col-sm-3">
@@ -246,7 +246,7 @@ var AppModalComponent = React.createClass({
                     errorMessage={this.getErrorMessage("disk")}
                     value={state.fields.disk}
                     onChange={this.handleFieldUpdate}>
-                  <input min="0" step="any" type="number" required />
+                  <input min="0" step="any" type="number"/>
                 </FormGroupComponent>
               </div>
               <div className="col-sm-3">
@@ -256,7 +256,7 @@ var AppModalComponent = React.createClass({
                     errorMessage={this.getErrorMessage("instances")}
                     value={state.fields.instances}
                     onChange={this.handleFieldUpdate}>
-                  <input min="0" step="1" type="number" required />
+                  <input min="0" step="1" type="number" />
                 </FormGroupComponent>
               </div>
             </div>

--- a/src/js/constants/AppFormErrorMessages.js
+++ b/src/js/constants/AppFormErrorMessages.js
@@ -35,11 +35,21 @@ const AppFormErrorMessages = {
   instances: ["Instances must be a non-negative Number"],
   mem: ["Memory must be a non-negative Number"],
   ports: ["Ports must be a comma-separated list of numbers"],
+
+  // Those are mappings to server side error messages
+  "error.path.missing": ["Please provide a path"],
+
   getMessage: function (fieldId, index = 0) {
     if (this[fieldId] != null && this[fieldId][index] != null) {
       return this[fieldId][index];
     }
     return "General error";
+  },
+  lookupServerResponseMessage: function (serverMessage) {
+    if (this[serverMessage] != null && this[serverMessage][0] != null) {
+      return this[serverMessage][0];
+    }
+    return serverMessage;
   }
 };
 

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -254,7 +254,8 @@ function processResponseErrors(responseErrors, response, statusCode) {
         : "general";
       var fieldId = resolveResponseAttributePathToFieldId(attributePath) ||
         attributePath;
-      responseErrors[fieldId] = error.error;
+      responseErrors[fieldId] =
+        AppFormErrorMessages.lookupServerResponseMessage(error.error);
     });
 
   } else if (statusCode === 409 && response != null &&
@@ -272,7 +273,9 @@ function processResponseErrors(responseErrors, response, statusCode) {
         : "general";
       var fieldId = resolveResponseAttributePathToFieldId(attributePath) ||
         attributePath;
-      responseErrors[fieldId] = detail.errors.join(", ");
+      responseErrors[fieldId] = detail.errors.map((error) => {
+        return AppFormErrorMessages.lookupServerResponseMessage(error);
+      }).join(", ");
     });
 
   } else if (statusCode >= 300) {

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -93,6 +93,7 @@ const resolveFieldIdToAppKeyMap = {
  */
 const responseAttributePathToFieldIdMap = {
   "id": "appId",
+  "/id": "appId",
   "/cmd": "cmd",
   "/constraints": "constraints",
   "/container/docker/image": "dockerImage",


### PR DESCRIPTION
We are showing the server response now on an empty app id field.
![error](https://cloud.githubusercontent.com/assets/859154/9962863/5381068a-5e28-11e5-811e-4f50bcee58ac.png)
Huh!

This fixes https://github.com/mesosphere/marathon/issues/2275