### PR TITLE
Expose labels and dependencies on app configuration page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ### Added
 - \#2244 - Ability to scale an application forcefully if there is a deployment
   running
+- \#2283 - Expose the application labels field in the configuration tab
+- \#2284 - Expose the application dependencies field in the configuration tab
 
 ### Fixed
 - \#2157 - Row is off-centre if upper row is empty in lists

--- a/src/js/components/AppVersionComponent.jsx
+++ b/src/js/components/AppVersionComponent.jsx
@@ -1,4 +1,5 @@
 var classNames = require("classnames");
+var Link = require("react-router").Link;
 var React = require("react/addons");
 
 var AppsActions = require("../actions/AppsActions");
@@ -134,6 +135,16 @@ var AppVersionComponent = React.createClass({
       ? <UnspecifiedNodeComponent />
       : <dd><pre>{JSON.stringify(appVersion.container, null, 2)}</pre></dd>;
 
+    var dependenciesNode = (appVersion.dependencies.length === 0)
+      ? <UnspecifiedNodeComponent />
+      : appVersion.dependencies.map(function (d) {
+        return (
+          <dd key={d}>
+            <Link to="app" params={{appId: encodeURIComponent(d)}}>{d}</Link>
+          </dd>
+        );
+      });
+
     var envNode = (appVersion.env == null ||
         Object.keys(appVersion.env).length === 0)
       ? <UnspecifiedNodeComponent />
@@ -170,6 +181,8 @@ var AppVersionComponent = React.createClass({
           {invalidateValue(appVersion.cmd)}
           <dt>Constraints</dt>
           {constraintsNode}
+          <dt>Dependencies</dt>
+          {dependenciesNode}
           <dt>Container</dt>
           {containerNode}
           <dt>CPUs</dt>

--- a/src/js/components/AppVersionComponent.jsx
+++ b/src/js/components/AppVersionComponent.jsx
@@ -162,6 +162,14 @@ var AppVersionComponent = React.createClass({
       ? <UnspecifiedNodeComponent />
       : <dd><pre>{JSON.stringify(appVersion.healthChecks, null, 2)}</pre></dd>;
 
+    var labelsNode = (appVersion.labels == null ||
+        Object.keys(appVersion.labels).length === 0)
+      ? <UnspecifiedNodeComponent />
+      // Print labels as key value pairs like "key=value"
+      : Object.keys(appVersion.labels).map(function (k) {
+        return <dd key={k}>{k + "=" + appVersion.labels[k]}</dd>;
+      });
+
     var portsNode = (appVersion.ports.length === 0)
       ? <UnspecifiedNodeComponent />
       : <dd>{appVersion.ports.join(",")}</dd>;
@@ -183,6 +191,8 @@ var AppVersionComponent = React.createClass({
           {constraintsNode}
           <dt>Dependencies</dt>
           {dependenciesNode}
+          <dt>Labels</dt>
+          {labelsNode}
           <dt>Container</dt>
           {containerNode}
           <dt>CPUs</dt>

--- a/src/js/stores/appScheme.js
+++ b/src/js/stores/appScheme.js
@@ -5,6 +5,7 @@ var appScheme = {
   constraints: [],
   container: null,
   cpus: null,
+  dependencies: [],
   deployments: [],
   env: {},
   executor: "",

--- a/src/js/stores/appScheme.js
+++ b/src/js/stores/appScheme.js
@@ -14,6 +14,7 @@ var appScheme = {
   healthWeight: 0,
   id: null,
   instances: 0,
+  labels: {},
   lastTaskFailure: null,
   status: AppStatus.SUSPENDED,
   mem: null,

--- a/src/test/appVersions.test.js
+++ b/src/test/appVersions.test.js
@@ -267,67 +267,75 @@ describe("App Version component", function () {
     expect(this.table[3].type.displayName).to.equal("UnspecifiedNodeComponent");
   });
 
-  it("has correct container", function () {
+  it("has correct dependencies", function () {
     expect(this.table[5].type.displayName).to.equal("UnspecifiedNodeComponent");
   });
 
-  it("has correct cpus", function () {
-    expect(this.table[7].props.children[0]).to.equal(0.1);
+  it("has correct labels", function () {
+    expect(this.table[7].type.displayName).to.equal("UnspecifiedNodeComponent");
   });
 
-  it("has correct environment", function () {
+  it("has correct container", function () {
     expect(this.table[9].type.displayName).to.equal("UnspecifiedNodeComponent");
   });
 
+  it("has correct cpus", function () {
+    expect(this.table[11].props.children[0]).to.equal(0.1);
+  });
+
+  it("has correct environment", function () {
+    expect(this.table[13].type.displayName).to.equal("UnspecifiedNodeComponent");
+  });
+
   it("has correct executor", function () {
-    expect(this.table[11].type.displayName).to.equal("UnspecifiedNodeComponent");
+    expect(this.table[15].type.displayName).to.equal("UnspecifiedNodeComponent");
   });
 
   it("has correct health checks", function () {
-    var healthChecks = this.table[13].props.children.props.children;
+    var healthChecks = this.table[17].props.children.props.children;
     expect(healthChecks).to.equal(
       JSON.stringify(this.model.healthChecks, null, 2)
     );
   });
 
   it("has correct number of instances", function () {
-    expect(this.table[15].props.children[0]).to.equal(14);
+    expect(this.table[19].props.children[0]).to.equal(14);
   });
 
   it("has correct amount of memory", function () {
-    expect(this.table[17].props.children[0]).to.equal(16.0);
-    expect(this.table[17].props.children[2]).to.equal("MB");
+    expect(this.table[21].props.children[0]).to.equal(16.0);
+    expect(this.table[21].props.children[2]).to.equal("MB");
   });
 
   it("has correct amount of disk space", function () {
-    expect(this.table[19].props.children[0]).to.equal(0.0);
-    expect(this.table[19].props.children[2]).to.equal("MB");
+    expect(this.table[23].props.children[0]).to.equal(0.0);
+    expect(this.table[23].props.children[2]).to.equal("MB");
   });
 
   it("has correct ports", function () {
-    expect(this.table[21].props.children).to.equal("10000,10001");
+    expect(this.table[25].props.children).to.equal("10000,10001");
   });
 
   it("has correct backoff factor", function () {
-    expect(this.table[23].props.children[0]).to.equal(1.15);
+    expect(this.table[27].props.children[0]).to.equal(1.15);
   });
 
   it("has correct backoff", function () {
-    expect(this.table[25].props.children[0]).to.equal(1);
-    expect(this.table[25].props.children[2]).to.equal("seconds");
+    expect(this.table[29].props.children[0]).to.equal(1);
+    expect(this.table[29].props.children[2]).to.equal("seconds");
   });
 
   it("has correct max launch delay", function () {
-    expect(this.table[27].props.children[0]).to.equal(3600);
-    expect(this.table[27].props.children[2]).to.equal("seconds");
+    expect(this.table[31].props.children[0]).to.equal(3600);
+    expect(this.table[31].props.children[2]).to.equal("seconds");
   });
 
   it("has correct URIs", function () {
-    expect(this.table[29].type.displayName).to.equal("UnspecifiedNodeComponent");
+    expect(this.table[33].type.displayName).to.equal("UnspecifiedNodeComponent");
   });
 
   it("has correct version", function () {
-    expect(this.table[31].props.children[0]).to.equal("2015-06-29T12:57:02.269Z");
+    expect(this.table[35].props.children[0]).to.equal("2015-06-29T12:57:02.269Z");
   });
 
 });


### PR DESCRIPTION
Those were missing.
![labels](https://cloud.githubusercontent.com/assets/859154/9976280/53d58392-5edf-11e5-9c32-4562d27abc24.png)

This fixes https://github.com/mesosphere/marathon/issues/2283
This fixes https://github.com/mesosphere/marathon/issues/2284
