### PR TITLE
Fix for object-path.set() with null-values

### DIFF
--- a/src/js/helpers/Util.js
+++ b/src/js/helpers/Util.js
@@ -1,4 +1,5 @@
 var consecutiveNumber = 0;
+var objectPath = require("object-path");
 
 var Util = {
   param: function (obj) {
@@ -72,6 +73,15 @@ var Util = {
     }
 
     return paths;
+  },
+  objectPathSet: function (obj, path, value) {
+    var [initialKey] = path.split(".");
+
+    if (obj[initialKey] == null) {
+      obj[initialKey] = {};
+    }
+
+    objectPath.set(obj, path, value);
   }
 };
 

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -164,9 +164,9 @@ function rebuildModelFromFields(app, fields, fieldId) {
   if (key) {
     const transform = AppFormTransforms.FieldToModel[fieldId];
     if (transform == null) {
-      objectPath.set(app, key, fields[fieldId]);
+      Util.objectPathSet(app, key, fields[fieldId]);
     } else {
-      objectPath.set(app, key, transform(fields[fieldId]));
+      Util.objectPathSet(app, key, transform(fields[fieldId]));
     }
   }
 

--- a/src/test/util.test.js
+++ b/src/test/util.test.js
@@ -241,4 +241,22 @@ describe("Util", function () {
     });
   });
 
+  describe("objectPathSet", function () {
+    it("should work on inital null-values", function () {
+      var obj = {
+        a: null
+      };
+
+      Util.objectPathSet(obj, "a.b.c", "true");
+
+      expect(obj).to.deep.equal({
+        a: {
+          b: {
+            c: "true"
+          }
+        }
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
object-path.set() doesn't work on inital null-values