### PR TITLE
Fix - 2252 debug tab tasks count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 - \#2157 - Row is off-centre if upper row is empty in lists
 - \#2266 - Link "Mesos details" is broken
+- \#2252 - Wrong task number in Debug Tab
 
 ## 0.11.0 - 2015-09-02
 ### Added

--- a/src/js/components/AppTaskStatsComponent.jsx
+++ b/src/js/components/AppTaskStatsComponent.jsx
@@ -85,7 +85,10 @@ var AppTaskStatsComponent = React.createClass({
     }
 
     return Object.keys(stats.counts).reduce(function (memo, key) {
-      return memo + stats.counts[key];
+      if (key === "running" || key === "staged") {
+        return memo + stats.counts[key];
+      }
+      return memo;
     }, 0);
   },
 


### PR DESCRIPTION
This fixes https://github.com/mesosphere/marathon/issues/2252

We could consider to do a 0.11.1 bugfix release for the UI from this?
I am not sure, because this bug doesn't break functionality, it's just misleading information.