### PR TITLE
Change - 2223 round lifetime 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - \#2284 - Expose the application dependencies field in the configuration tab
 - \#2263 - UI doesn't expose roles
 
+### Changed
+- \#2223 - Display life time duration as other durations in UI
+
 ### Fixed
 - \#2157 - Row is off-centre if upper row is empty in lists
 - \#2266 - Link "Mesos details" is broken

--- a/src/js/components/AppTaskStatsComponent.jsx
+++ b/src/js/components/AppTaskStatsComponent.jsx
@@ -1,5 +1,6 @@
 var classNames = require("classnames");
 var React = require("react/addons");
+var Moment = require("moment");
 
 var AppTaskStatsComponent = React.createClass({
   displayName: "AppTaskStatsComponent",
@@ -51,12 +52,24 @@ var AppTaskStatsComponent = React.createClass({
 
     let lifeTime = stats.lifeTime;
 
+    var averageSecondsHumanReadable =
+      Moment.duration(parseInt(lifeTime.averageSeconds), "seconds").humanize();
+
+    var medianSecondsHumanReadable =
+      Moment.duration(parseInt(lifeTime.medianSeconds), "seconds").humanize();
+
     return (
       <dl className="dl-horizontal dl-unstyled">
         <dt>Average</dt>
-        <dd>{lifeTime.averageSeconds} seconds</dd>
+        <dd>
+          {parseFloat(lifeTime.averageSeconds).toFixed(2)} seconds
+          ({averageSecondsHumanReadable})
+        </dd>
         <dt>Median</dt>
-        <dd>{lifeTime.medianSeconds} seconds</dd>
+        <dd>
+          {parseFloat(lifeTime.medianSeconds).toFixed(2)} seconds
+          ({medianSecondsHumanReadable})
+        </dd>
       </dl>
     );
   },


### PR DESCRIPTION
and make it human readable.
The seconds are rounded to a "precision" of 2.

![human](https://cloud.githubusercontent.com/assets/859154/10016263/e40f52ce-6125-11e5-85ec-09e0f3ac7414.png)

This fixes https://github.com/mesosphere/marathon/issues/2223