### PR TITLE
Change - 2248 portmappings and tests on cmd field if container is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   * Add model to form transformers
   * Add proper per-field validation
   * Add support for server-side validation errors on individual fields
+- \#2248 - Docker: port mappings do not make sense when host network is used
 
 ### Changed
 - \#2223 - Display life time duration as other durations in UI

--- a/src/js/components/ContainerSettingsComponent.jsx
+++ b/src/js/components/ContainerSettingsComponent.jsx
@@ -241,9 +241,7 @@ var ContainerSettingsComponent = React.createClass({
     if (this.props.fields.dockerNetwork === ContainerConstants.NETWORK.HOST) {
       return (
         <div className="help-block">
-          While host networking is selected you cannot define port mappings.
-          <br />
-          Consider to modify the applications port configuration.
+         Use the ports field to assign ports in host network mode.
         </div>
       );
     }

--- a/src/js/components/ContainerSettingsComponent.jsx
+++ b/src/js/components/ContainerSettingsComponent.jsx
@@ -238,6 +238,16 @@ var ContainerSettingsComponent = React.createClass({
       return null;
     }
 
+    if (this.props.fields.dockerNetwork === ContainerConstants.NETWORK.HOST) {
+      return (
+        <div className="help-block">
+          While host networking is selected you cannot define port mappings.
+          <br />
+          Consider to modify the applications port configuration.
+        </div>
+      );
+    }
+
     var disableRemoveButton = (rows.length === 1 &&
       Util.isEmptyString(rows[0].containerPort) &&
       Util.isEmptyString(rows[0].hostPort) &&

--- a/src/js/stores/transforms/AppFormModelPostProcess.js
+++ b/src/js/stores/transforms/AppFormModelPostProcess.js
@@ -1,5 +1,7 @@
 var Util = require("../../helpers/Util");
 
+var ContainerConstants = require("../../constants/ContainerConstants");
+
 function hasOnlyEmptyValues(obj) {
   return Util.isObject(obj) &&
     Object.values(obj)
@@ -13,6 +15,15 @@ function hasOnlyEmptyValues(obj) {
 const AppFormModelPostProcess = {
   container: (app) => {
     var container = app.container;
+
+    if (container.docker != null) {
+      if (container.docker.network === ContainerConstants.NETWORK.HOST) {
+        // If host networking is set, remove all port mappings.
+        if (Util.isArray(container.docker.portMappings)) {
+          container.docker.portMappings = [];
+        }
+      }
+    }
 
     var isEmpty = (Util.isArray(container.volumes) &&
         container.volumes.length === 0 ||

--- a/src/test/appFormModelPostProcess.test.js
+++ b/src/test/appFormModelPostProcess.test.js
@@ -5,7 +5,7 @@ var AppFormModelPostProcess =
 
 describe("App Form Model Post Process", function () {
 
-  describe("processes", function () {
+  describe("container", function () {
 
     it("empty container values to empty object", function () {
       var app = {
@@ -111,6 +111,25 @@ describe("App Form Model Post Process", function () {
           }
         }
       });
+    });
+
+    it("sets an empty space on the cmd field if cmd is empty and container set",
+        function () {
+      var app = {
+        cmd: "",
+        container: {
+          volumes: [],
+          docker: {
+            image: "group/image",
+            portMappings: [],
+            parameters: []
+          }
+        }
+      };
+
+      AppFormModelPostProcess.container(app);
+
+      expect(app.cmd).to.equal(" ");
     });
 
   });

--- a/src/test/appFormModelPostProcess.test.js
+++ b/src/test/appFormModelPostProcess.test.js
@@ -41,6 +41,78 @@ describe("App Form Model Post Process", function () {
       expect(app).to.deep.equal(app);
     });
 
+    it("removes Docker port mappings on selected host networking", function () {
+      var app = {
+        container: {
+          volumes: [],
+          docker: {
+            image: "group/image",
+            network: "HOST",
+            portMappings: [{
+              containerPort: 55,
+              hostPort: 56,
+              protocol: "tcp",
+              servicePort: 57
+            }],
+            parameters: []
+          }
+        }
+      };
+
+      AppFormModelPostProcess.container(app);
+
+      expect(app).to.deep.equal({
+        container: {
+          volumes: [],
+          docker: {
+            image: "group/image",
+            network: "HOST",
+            portMappings: [],
+            parameters: []
+          }
+        }
+      });
+    });
+
+    it("does not remove Docker port mappings on bridged networking",
+        function () {
+      var app = {
+        container: {
+          volumes: [],
+          docker: {
+            image: "group/image",
+            network: "BRIDGE",
+            portMappings: [{
+              containerPort: 55,
+              hostPort: 56,
+              protocol: "tcp",
+              servicePort: 57
+            }],
+            parameters: []
+          }
+        }
+      };
+
+      AppFormModelPostProcess.container(app);
+
+      expect(app).to.deep.equal({
+        container: {
+          volumes: [],
+          docker: {
+            image: "group/image",
+            network: "BRIDGE",
+            portMappings: [{
+              containerPort: 55,
+              hostPort: 56,
+              protocol: "tcp",
+              servicePort: 57
+            }],
+            parameters: []
+          }
+        }
+      });
+    });
+
   });
 
 });


### PR DESCRIPTION
![dpm](https://cloud.githubusercontent.com/assets/859154/10042722/7f5342f0-61ed-11e5-93f2-7a332b0a53bc.png)

Already set values are preserved in the fields object, but the fields to model post processor will empty the port mappings object if host networking is set, before sending the values to the server.

This fixes https://github.com/mesosphere/marathon/issues/2248

Also this adds one missing test on the cmd field related to docker containers. It sends a single empty space character if the container is used and the command was modified to empty, like described in https://github.com/mesosphere/marathon/issues/2147.