### PR TITLE
Fix - Env row shouldn't have an empty pair

### DIFF
--- a/src/js/stores/transforms/AppFormFieldToModelTransforms.js
+++ b/src/js/stores/transforms/AppFormFieldToModelTransforms.js
@@ -66,7 +66,9 @@ const AppFormFieldToModelTransforms = {
   dockerPrivileged: (isChecked) => !!isChecked,
   env: (rows) => {
     return rows.reduce((memo, row) => {
-      memo[row.key] = row.value;
+      if (!Util.isEmptyString(row.key) || !Util.isEmptyString(row.value)) {
+        memo[row.key] = row.value;
+      }
       return memo;
     }, {});
   },

--- a/src/test/appFormTransforms.test.js
+++ b/src/test/appFormTransforms.test.js
@@ -192,6 +192,13 @@ describe("App Form Field to Model Transform", function () {
       });
     });
 
+    it("env ignores empty key-values", function () {
+      expect(AppFormTransforms.FieldToModel.env([
+        {key: "", value: "", consecutiveKey: 0},
+        {key: "key2", value: "value2", consecutiveKey: 1}
+      ])).to.deep.equal({key2: "value2"});
+    });
+
     it("instances to integer", function () {
       expect(AppFormTransforms.FieldToModel.instances("2")).to.equal(2);
       expect(AppFormTransforms.FieldToModel.instances("4.5")).to.equal(4);


### PR DESCRIPTION
```{key: "", value: "", consecutiveKey: 0}``` shouldn't be transformed to the model.