### PR TITLE
Implemented marathon #2298, forcing deployments from edit dialog.

### DIFF
--- a/src/js/actions/AppsActions.js
+++ b/src/js/actions/AppsActions.js
@@ -132,7 +132,8 @@ var AppsActions = {
         });
       });
   },
-  applySettingsOnApp: function (appId, settings, isEditing = false) {
+  applySettingsOnApp: function (appId, settings, isEditing = false,
+      force = false) {
     // Version key is not allowed and not needed on settings object
     var clonedSettings = Object.assign({}, settings);
     delete clonedSettings.version;
@@ -143,10 +144,15 @@ var AppsActions = {
       appId: appId
     });
 
+    var url = `${config.apiURL}v2/apps/${appId}`;
+    if (force) {
+      url = url + "?force=true";
+    }
+
     this.request({
       method: "PUT",
       data: clonedSettings,
-      url: `${config.apiURL}v2/apps/${appId}`
+      url: url
     })
       .success(function (app) {
         AppDispatcher.dispatch({

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -101,8 +101,7 @@ var AppModalComponent = React.createClass({
       this.onCreateApp();
     } else if (status === 409) {
       this.setState({
-        responseErrorMessages: {general: `Failed to change and deploy the new
-          configuration. Press the button again to force the operation.`},
+        responseErrorMessages: {general: AppFormErrorMessages.appLocked[0]},
           force: true
       });
     } else {

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -49,7 +49,8 @@ var AppModalComponent = React.createClass({
     return {
       fields: AppFormStore.fields,
       errorIndices: {},
-      responseErrorMessages: {}
+      responseErrorMessages: {},
+      force: false
     };
   },
 
@@ -98,7 +99,12 @@ var AppModalComponent = React.createClass({
     // All status below 300 are actually not an error
     if (status < 300) {
       this.onCreateApp();
-
+    } else if (status === 409) {
+      this.setState({
+        responseErrorMessages: {general: `Failed to change and deploy the new
+          configuration. Press the button again to force the operation.`},
+          force: true
+      });
     } else {
       this.setState({
         responseErrorMessages: AppFormStore.responseErrors
@@ -131,7 +137,7 @@ var AppModalComponent = React.createClass({
       let app = AppFormStore.app;
 
       if (this.props.app != null) {
-        AppsActions.applySettingsOnApp(app.id, app, true);
+        AppsActions.applySettingsOnApp(app.id, app, true, this.state.force);
       } else {
         AppsActions.createApp(app);
       }

--- a/src/js/constants/AppFormErrorMessages.js
+++ b/src/js/constants/AppFormErrorMessages.js
@@ -40,6 +40,9 @@ const AppFormErrorMessages = {
   labels: ["Key cannot be blank"],
   mem: ["Memory must be a non-negative Number"],
   ports: ["Ports must be a comma-separated list of numbers"],
+  appLocked: ["Error: App is currently locked by one or more deployments. " +
+    "Pressing the button again will forcefully change and deploy " +
+    "the new configuration."],
 
   // Those are mappings to server side error messages
   "error.path.missing": ["Please provide a path"],


### PR DESCRIPTION
This is a first implementation of https://github.com/mesosphere/marathon/issues/2298 which is an attempt to make the edit configuration dialog consistent with the rest of the application in case of 409 (deployment stuck, but force possible). Please contribute how to make this better. 