### PR TITLE
Remove unnecessary padding

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -855,6 +855,9 @@ fieldset[disabled] .btn-info.active {
       }
     }
   }
+  .row.reduced-padding .panel-body {
+    padding-bottom: 0;
+  }
 }
 
 .duplicable-row {


### PR DESCRIPTION
This removes the bottom padding for the health check rows, the only ones with `.row.reduced-padding`.

![screen shot 2015-09-29 at 09 48 15](https://cloud.githubusercontent.com/assets/1078545/10158005/3dba9766-668f-11e5-8b69-709cf6ba6821.png)

