### PR TITLE
App form error message are only accessible by accesors now

### DIFF
--- a/src/js/components/ContainerSettingsComponent.jsx
+++ b/src/js/components/ContainerSettingsComponent.jsx
@@ -142,7 +142,7 @@ var ContainerSettingsComponent = React.createClass({
         return (
           <div className="help-block">
             <strong>
-              {AppFormErrorMessages.getMessage(fieldId, errorIndex)}
+              {AppFormErrorMessages.getFieldMessage(fieldId, errorIndex)}
             </strong>
           </div>
         );

--- a/src/js/components/OptionalEnviromentComponent.jsx
+++ b/src/js/components/OptionalEnviromentComponent.jsx
@@ -103,7 +103,7 @@ var OptionalEnvironmentComponent = React.createClass({
         return (
           <div className="help-block">
             <strong>
-              {AppFormErrorMessages.getMessage("env", errorIndex)}
+              {AppFormErrorMessages.getFieldMessage("env", errorIndex)}
             </strong>
           </div>
         );

--- a/src/js/components/OptionalLabelsComponent.jsx
+++ b/src/js/components/OptionalLabelsComponent.jsx
@@ -103,7 +103,7 @@ var OptionalLabelsComponent = React.createClass({
         return (
           <div className="help-block">
             <strong>
-              {AppFormErrorMessages.getMessage("labels", errorIndex)}
+              {AppFormErrorMessages.getFieldMessage("labels", errorIndex)}
             </strong>
           </div>
         );

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -104,7 +104,7 @@ var AppModalComponent = React.createClass({
     } else if (status === 409) {
       this.setState({
         responseErrorMessages: {
-          general: AppFormErrorMessages.getGeneralError("appLocked")
+          general: AppFormErrorMessages.getGeneralMessage("appLocked")
         },
         force: true
       });

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -103,8 +103,10 @@ var AppModalComponent = React.createClass({
       this.onCreateApp();
     } else if (status === 409) {
       this.setState({
-        responseErrorMessages: {general: AppFormErrorMessages.appLocked[0]},
-          force: true
+        responseErrorMessages: {
+          general: AppFormErrorMessages.getGeneralError("appLocked")
+        },
+        force: true
       });
     } else {
       this.setState({
@@ -149,7 +151,7 @@ var AppModalComponent = React.createClass({
     var state = this.state;
     var errorIndex = state.errorIndices[fieldId];
     if (errorIndex != null && !Util.isArray(errorIndex)) {
-      return AppFormErrorMessages.getMessage(fieldId, errorIndex);
+      return AppFormErrorMessages.getFieldMessage(fieldId, errorIndex);
     }
     if (state.responseErrorMessages[fieldId] != null) {
       return state.responseErrorMessages[fieldId];

--- a/src/js/constants/AppFormErrorMessages.js
+++ b/src/js/constants/AppFormErrorMessages.js
@@ -70,7 +70,7 @@ const AppFormErrorMessages = {
     return "Undefined error";
   },
 
-  getGeneralError: function (key) {
+  getGeneralMessage: function (key) {
     if (generalErrors[key] != null) {
       return generalErrors[key];
     }

--- a/src/js/constants/AppFormErrorMessages.js
+++ b/src/js/constants/AppFormErrorMessages.js
@@ -1,6 +1,6 @@
 const ValidConstraints = require("./ValidConstraints");
 
-const AppFormErrorMessages = {
+const applicationFieldValidationErrors = Object.freeze({
   appId: [
     "ID must not be empty",
     "Path must not contain whitespace",
@@ -40,32 +40,46 @@ const AppFormErrorMessages = {
     "Timeout must be a non-negative number",
     "Maximal Consecutive Failures must be a non-negative number"
   ],
-  general: [
-    "App creation unsuccessful. Check your app settings and try again.",
-    "Unknown server error, could not create or apply app.",
-    "Error:",
-    "App creation unsuccessful. Unauthorized access."
-  ],
   instances: ["Instances must be a non-negative Number"],
   labels: ["Key cannot be blank"],
   mem: ["Memory must be a non-negative Number"],
-  ports: ["Ports must be a comma-separated list of numbers"],
-  appLocked: ["Error: App is currently locked by one or more deployments. " +
+  ports: ["Ports must be a comma-separated list of numbers"]
+});
+
+const generalErrors = Object.freeze({
+  appCreation:
+    "App creation unsuccessful. Check your app settings and try again.",
+  appLocked: "App is currently locked by one or more deployments. " +
     "Pressing the button again will forcefully change and deploy " +
-    "the new configuration."],
+    "the new configuration.",
+  unknownServerError: "Unknown server error, could not create or apply app.",
+  unauthorizedAccess: "App creation unsuccessful. Unauthorized access.",
+  errorPrefix: "Error:"
+});
 
-  // Those are mappings to server side error messages
-  "error.path.missing": ["Please provide a path"],
+const serverResponseMappings = Object.freeze({
+  "error.path.missing": "Please provide a path"
+});
 
-  getMessage: function (fieldId, index = 0) {
-    if (this[fieldId] != null && this[fieldId][index] != null) {
-      return this[fieldId][index];
+const AppFormErrorMessages = {
+  getFieldMessage: function (fieldId, index = 0) {
+    if (applicationFieldValidationErrors[fieldId] != null &&
+        applicationFieldValidationErrors[fieldId][index] != null) {
+      return applicationFieldValidationErrors[fieldId][index];
+    }
+    return "Undefined error";
+  },
+
+  getGeneralError: function (key) {
+    if (generalErrors[key] != null) {
+      return generalErrors[key];
     }
     return "General error";
   },
+
   lookupServerResponseMessage: function (serverMessage) {
-    if (this[serverMessage] != null && this[serverMessage][0] != null) {
-      return this[serverMessage][0];
+    if (serverResponseMappings[serverMessage] != null) {
+      return serverResponseMappings[serverMessage];
     }
     return serverMessage;
   }

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -282,7 +282,7 @@ function deleteField(fields, fieldId, index) {
 function processResponseErrors(responseErrors, response, statusCode) {
   if (statusCode >= 500) {
     responseErrors.general =
-      AppFormErrorMessages.getGeneralError("unknownServerError");
+      AppFormErrorMessages.getGeneralMessage("unknownServerError");
 
   } else if (statusCode === 422 && response != null &&
       Util.isArray(response.errors)) {
@@ -301,14 +301,14 @@ function processResponseErrors(responseErrors, response, statusCode) {
       response.message != null) {
 
     responseErrors.general =
-      AppFormErrorMessages.getGeneralError("errorPrefix") + " " +
+      AppFormErrorMessages.getGeneralMessage("errorPrefix") + " " +
       response.message;
 
   } else if (statusCode === 401 && response != null &&
       response.message != null) {
 
     responseErrors.general =
-      AppFormErrorMessages.getGeneralError("unauthorizedAccess");
+      AppFormErrorMessages.getGeneralMessage("unauthorizedAccess");
 
   } else if (statusCode === 400 && response != null &&
       Util.isArray(response.details)) {
@@ -326,7 +326,7 @@ function processResponseErrors(responseErrors, response, statusCode) {
 
   } else if (statusCode >= 300) {
     responseErrors.general =
-      AppFormErrorMessages.getGeneralError("appCreation");
+      AppFormErrorMessages.getGeneralMessage("appCreation");
   }
 }
 

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -281,7 +281,8 @@ function deleteField(fields, fieldId, index) {
 
 function processResponseErrors(responseErrors, response, statusCode) {
   if (statusCode >= 500) {
-    responseErrors.general = AppFormErrorMessages.general[1];
+    responseErrors.general =
+      AppFormErrorMessages.getGeneralError("unknownServerError");
 
   } else if (statusCode === 422 && response != null &&
       Util.isArray(response.errors)) {
@@ -300,12 +301,14 @@ function processResponseErrors(responseErrors, response, statusCode) {
       response.message != null) {
 
     responseErrors.general =
-      `${AppFormErrorMessages.general[2]} ${response.message}`;
+      AppFormErrorMessages.getGeneralError("errorPrefix") + " " +
+      response.message;
 
   } else if (statusCode === 401 && response != null &&
       response.message != null) {
 
-    responseErrors.general = AppFormErrorMessages.general[3];
+    responseErrors.general =
+      AppFormErrorMessages.getGeneralError("unauthorizedAccess");
 
   } else if (statusCode === 400 && response != null &&
       Util.isArray(response.details)) {
@@ -322,7 +325,8 @@ function processResponseErrors(responseErrors, response, statusCode) {
     });
 
   } else if (statusCode >= 300) {
-    responseErrors.general = AppFormErrorMessages.general[0];
+    responseErrors.general =
+      AppFormErrorMessages.getGeneralError("appCreation");
   }
 }
 

--- a/src/test/appForm.test.js
+++ b/src/test/appForm.test.js
@@ -745,10 +745,13 @@ describe("App Form", function () {
           "message": "bad error"
         }, 409);
 
+        var expectedMessage =
+          `${AppFormErrorMessages.getGeneralError("errorPrefix")} bad error`;
+
         AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
           expectAsync(function () {
             expect(AppFormStore.responseErrors.general)
-              .to.equal(`${AppFormErrorMessages.general[2]} bad error`);
+              .to.equal(expectedMessage);
           }, done);
         });
 
@@ -784,7 +787,7 @@ describe("App Form", function () {
         AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
           expectAsync(function () {
             expect(AppFormStore.responseErrors.general)
-              .to.equal(AppFormErrorMessages.general[0]);
+              .to.equal(AppFormErrorMessages.getGeneralError("appCreation"));
           }, done);
         });
 
@@ -799,7 +802,9 @@ describe("App Form", function () {
         AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
           expectAsync(function () {
             expect(AppFormStore.responseErrors.general)
-              .to.equal(AppFormErrorMessages.general[1]);
+              .to.equal(
+                AppFormErrorMessages.getGeneralError("unknownServerError")
+              );
           }, done);
         });
 
@@ -825,6 +830,33 @@ describe("App Form", function () {
 
     });
 
+  });
+
+});
+
+describe("App Form Error Messages", function () {
+
+  describe("#getFieldMessage", function () {
+    it("returns correct message on given fieldId and index", function () {
+      expect(AppFormErrorMessages.getFieldMessage("containerVolumes", 2))
+        .to.be.equal("Mode must not be empty");
+    });
+  });
+
+  describe("#getGeneralError", function () {
+    it("returns correct message on given key", function () {
+      expect(AppFormErrorMessages.getGeneralError("unknownServerError"))
+        .to.be.equal("Unknown server error, could not create or apply app.");
+    });
+  });
+
+  describe("#lookupServerResponseMessage", function () {
+    it("returns correct message on given server message", function () {
+      expect(
+        AppFormErrorMessages.lookupServerResponseMessage("error.path.missing")
+      )
+        .to.be.equal("Please provide a path");
+    });
   });
 
 });

--- a/src/test/appForm.test.js
+++ b/src/test/appForm.test.js
@@ -746,7 +746,7 @@ describe("App Form", function () {
         }, 409);
 
         var expectedMessage =
-          `${AppFormErrorMessages.getGeneralError("errorPrefix")} bad error`;
+          `${AppFormErrorMessages.getGeneralMessage("errorPrefix")} bad error`;
 
         AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
           expectAsync(function () {
@@ -787,7 +787,7 @@ describe("App Form", function () {
         AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
           expectAsync(function () {
             expect(AppFormStore.responseErrors.general)
-              .to.equal(AppFormErrorMessages.getGeneralError("appCreation"));
+              .to.equal(AppFormErrorMessages.getGeneralMessage("appCreation"));
           }, done);
         });
 
@@ -803,7 +803,7 @@ describe("App Form", function () {
           expectAsync(function () {
             expect(AppFormStore.responseErrors.general)
               .to.equal(
-                AppFormErrorMessages.getGeneralError("unknownServerError")
+                AppFormErrorMessages.getGeneralMessage("unknownServerError")
               );
           }, done);
         });
@@ -843,9 +843,9 @@ describe("App Form Error Messages", function () {
     });
   });
 
-  describe("#getGeneralError", function () {
+  describe("#getGeneralMessage", function () {
     it("returns correct message on given key", function () {
-      expect(AppFormErrorMessages.getGeneralError("unknownServerError"))
+      expect(AppFormErrorMessages.getGeneralMessage("unknownServerError"))
         .to.be.equal("Unknown server error, could not create or apply app.");
     });
   });


### PR DESCRIPTION
I've split ne message object into 3 private ones.
They are now accessible by 3 getter-functions:
Also general errors are now accessible by a key-name and not an index.

```
getFieldMessage(fieldId, index)
```
```
getGeneralError(key)
```
```
lookupServerResponseMessage(serverMessage)
```

Maybe FYI @Raffo :)