### PR TITLE
Fix: An empty docker object triggers spuriously a default docker setting

### DIFF
--- a/src/js/stores/transforms/AppFormModelPostProcess.js
+++ b/src/js/stores/transforms/AppFormModelPostProcess.js
@@ -6,10 +6,11 @@ var HealthCheckProtocols = require("../../constants/HealthCheckProtocols");
 const healthChecksRowScheme = require("../healthChecksRowScheme");
 
 function hasOnlyEmptyValues(obj) {
-  return Util.isObject(obj) &&
+  return obj == null || Util.isObject(obj) &&
     Object.values(obj)
     .every((element) => {
       return element == null ||
+        element === false ||
         (Util.isArray(element) && element.length === 0) ||
         Util.isEmptyString(element);
     });
@@ -47,7 +48,7 @@ const AppFormModelPostProcess = {
       hasOnlyEmptyValues(container.docker);
 
     if (isEmpty) {
-      app.container = {};
+      app.container = null;
     } else {
       // Remove this hack, if there is a solution available.
       // https://github.com/mesosphere/marathon/issues/2147

--- a/src/test/appFormModelPostProcess.test.js
+++ b/src/test/appFormModelPostProcess.test.js
@@ -17,7 +17,7 @@ describe("App Form Model Post Process", function () {
 
   describe("container", function () {
 
-    it("empty container values to empty object", function () {
+    it("empty container values to null", function () {
       var app = {
         container: {
           type: "DOCKER",
@@ -31,7 +31,7 @@ describe("App Form Model Post Process", function () {
 
       AppFormModelPostProcess.container(app);
 
-      expect(app).to.deep.equal({container: {}});
+      expect(app.container).to.equal(null);
     });
 
     it("doesn't touch non-empty containers", function () {


### PR DESCRIPTION
If I send ```app.container = {}``` to the API with the intention to remove all existing containers, Marathon converts this to something unusable:
```
{
  "type": "DOCKER",
  "volumes": [],
  "docker": {
    "privileged": false,
    "parameters": [],
    "forcePullImage": false
  }
}
```
I am pretty sure this worked before. 
@kolloch Do you know if there was a change of this behavior?

For now, we have to send ```null``` to not accidentally trigger an empty docker container.
Which means we can't remove docker containers anymore.