### PR TITLE
Feature - Handle 403 explicitly

### DIFF
--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -51,10 +51,19 @@ var AppListComponent = React.createClass({
   },
 
   onAppsRequestError: function (message, statusCode) {
+    var fetchState = States.STATE_ERROR;
+
+    switch (statusCode) {
+      case 401:
+        fetchState = States.STATE_UNAUTHORIZED;
+        break;
+      case 403:
+        fetchState = States.STATE_FORBIDDEN;
+        break;
+    }
+
     this.setState({
-      fetchState: statusCode !== 401
-        ? States.STATE_ERROR
-        : States.STATE_UNAUTHORIZED
+      fetchState: fetchState
     });
   },
 
@@ -115,7 +124,8 @@ var AppListComponent = React.createClass({
 
     var noAppsClassSet = classNames({
       "hidden": pageIsLoading || pageHasApps ||
-        state.fetchState === States.STATE_UNAUTHORIZED
+        state.fetchState === States.STATE_UNAUTHORIZED ||
+        state.fetchState === States.STATE_FORBIDDEN
     });
 
     var noRunningAppsClassSet = classNames({
@@ -128,6 +138,10 @@ var AppListComponent = React.createClass({
 
     var unauthorizedClassSet = classNames({
       "hidden": state.fetchState !== States.STATE_UNAUTHORIZED
+    });
+
+    var forbiddenClassSet = classNames({
+      "hidden": state.fetchState !== States.STATE_FORBIDDEN
     });
 
     var headerClassSet = classNames({
@@ -214,6 +228,11 @@ var AppListComponent = React.createClass({
           <tr className={unauthorizedClassSet}>
             <td className="text-center text-danger" colSpan="6">
               Error fetching apps. Unauthorized access.
+            </td>
+          </tr>
+          <tr className={forbiddenClassSet}>
+            <td className="text-center text-danger" colSpan="6">
+              Error fetching apps. Access forbidden.
             </td>
           </tr>
           {appNodes}

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -153,10 +153,19 @@ var AppPageComponent = React.createClass({
   },
 
   onAppRequestError: function (message, statusCode) {
+    var fetchState = States.STATE_ERROR;
+
+    switch (statusCode) {
+      case 401:
+        fetchState = States.STATE_UNAUTHORIZED;
+        break;
+      case 403:
+        fetchState = States.STATE_FORBIDDEN;
+        break;
+    }
+
     this.setState({
-      fetchState: statusCode !== 401
-        ? States.STATE_ERROR
-        : States.STATE_UNAUTHORIZED
+      fetchState: fetchState
     });
   },
 
@@ -172,6 +181,8 @@ var AppPageComponent = React.createClass({
       });
     } else if (statusCode === 401) {
       DialogActions.alert(`Not scaling: ${Messages.UNAUTHORIZED}`);
+    } else if (statusCode === 403) {
+      DialogActions.alert(`Not scaling: ${Messages.FORBIDDEN}`);
     } else {
       DialogActions.alert(`Not scaling:
           ${errorMessage.message || errorMessage}`);
@@ -181,6 +192,8 @@ var AppPageComponent = React.createClass({
   onRestartAppError: function (errorMessage, statusCode) {
     if (statusCode === 401) {
       DialogActions.alert(`Error restarting app: ${Messages.UNAUTHORIZED}`);
+    } else if (statusCode === 403) {
+      DialogActions.alert(`Error restarting app: ${Messages.FORBIDDEN}`);
     } else {
       DialogActions.alert(
         `Error restarting app: ${errorMessage.message || errorMessage}`
@@ -191,6 +204,8 @@ var AppPageComponent = React.createClass({
   onDeleteAppError: function (errorMessage, statusCode) {
     if (statusCode === 401) {
       DialogActions.alert(`Error destroying app: ${Messages.UNAUTHORIZED}`);
+    } else if (statusCode === 403) {
+      DialogActions.alert(`Error destroying app: ${Messages.FORBIDDEN}`);
     } else {
       DialogActions.alert(
         `Error destroying app: ${errorMessage.message || errorMessage}`
@@ -210,6 +225,9 @@ var AppPageComponent = React.createClass({
     if (statusCode === 401) {
       DialogActions.alert(`Error resetting delay on app:
         ${Messages.UNAUTHORIZED}`);
+    } else if (statusCode === 403) {
+      DialogActions.alert(`Error resetting delay on app:
+        ${Messages.FORBIDDEN}`);
     } else {
       DialogActions.alert(
         `Error resetting delay on app: ${errorMessage.message || errorMessage}`

--- a/src/js/components/DeploymentsListComponent.jsx
+++ b/src/js/components/DeploymentsListComponent.jsx
@@ -47,10 +47,19 @@ var DeploymentListComponent = React.createClass({
   },
 
   onRequestError: function (message, statusCode) {
+    var fetchState = States.STATE_ERROR;
+
+    switch (statusCode) {
+      case 401:
+        fetchState = States.STATE_UNAUTHORIZED;
+        break;
+      case 403:
+        fetchState = States.STATE_FORBIDDEN;
+        break;
+    }
+
     this.setState({
-      fetchState: statusCode !== 401
-        ? States.STATE_ERROR
-        : States.STATE_UNAUTHORIZED
+      fetchState: fetchState
     });
   },
 
@@ -122,9 +131,14 @@ var DeploymentListComponent = React.createClass({
       "hidden": state.fetchState !== States.STATE_UNAUTHORIZED
     });
 
+    var forbiddenClassSet = classNames({
+      "hidden": state.fetchState !== States.STATE_FORBIDDEN
+    });
+
     var noDeploymentsClassSet = classNames({
       "hidden": pageIsLoading || state.deployments.length !== 0 ||
-        state.fetchState === States.STATE_UNAUTHORIZED
+        state.fetchState === States.STATE_UNAUTHORIZED ||
+        state.fetchState === States.STATE_FORBIDDEN
     });
 
     var errorMessageClassSet = classNames({
@@ -194,6 +208,11 @@ var DeploymentListComponent = React.createClass({
           <tr className={unauthorizedClassSet}>
             <td className="text-center text-danger" colSpan="6">
               Error fetching deployments. Unauthorized access.
+            </td>
+          </tr>
+          <tr className={forbiddenClassSet}>
+            <td className="text-center text-danger" colSpan="6">
+              Error fetching deployments. Access forbidden.
             </td>
           </tr>
           {this.getDeploymentNodes()}

--- a/src/js/components/TaskListComponent.jsx
+++ b/src/js/components/TaskListComponent.jsx
@@ -96,6 +96,7 @@ var TaskListComponent = React.createClass({
     var hasHealth = !!props.hasHealth;
     var hasError = props.fetchState === States.STATE_ERROR;
     var isUnauthorized = props.fetchState === States.STATE_UNAUTHORIZED;
+    var isForbidden = props.fetchState === States.STATE_FORBIDDEN;
 
     var headerClassSet = classNames({
       "clickable": true,
@@ -107,7 +108,7 @@ var TaskListComponent = React.createClass({
     });
 
     var noTasksClassSet = classNames({
-      "hidden": tasksLength !== 0 || hasError || isUnauthorized
+      "hidden": tasksLength !== 0 || hasError || isUnauthorized || isForbidden
     });
 
     var errorClassSet = classNames({
@@ -118,6 +119,11 @@ var TaskListComponent = React.createClass({
     var unauthorizedClassSet = classNames({
       "fluid-container": true,
       "hidden": !isUnauthorized
+    });
+
+    var forbiddenClassSet = classNames({
+      "fluid-container": true,
+      "hidden": !isForbidden
     });
 
     var hasHealthClassSet = classNames({
@@ -135,6 +141,11 @@ var TaskListComponent = React.createClass({
         <div className={unauthorizedClassSet}>
           <p className="text-center text-danger">
             Error fetching tasks. Unauthorized access.
+          </p>
+        </div>
+        <div className={forbiddenClassSet}>
+          <p className="text-center text-danger">
+            Error fetching tasks. Access forbidden.
           </p>
         </div>
         <table className="table table-unstyled">

--- a/src/js/constants/AppFormErrorMessages.js
+++ b/src/js/constants/AppFormErrorMessages.js
@@ -56,6 +56,7 @@ const generalErrors = Util.deepFreeze({
     "the new configuration.",
   unknownServerError: "Unknown server error, could not create or apply app.",
   unauthorizedAccess: "App creation unsuccessful. Unauthorized access.",
+  forbiddenAccess: "App creation unsuccessful. Access forbidden.",
   errorPrefix: "Error:"
 });
 

--- a/src/js/constants/Messages.js
+++ b/src/js/constants/Messages.js
@@ -1,5 +1,6 @@
 const Messages = {
-  UNAUTHORIZED: "Unauthorized access. Could not execute operation."
+  UNAUTHORIZED: "Unauthorized access. Could not execute operation.",
+  FORBIDDEN: "Access forbidden. Could not execute operation."
 };
 
 module.exports = Object.freeze(Messages);

--- a/src/js/constants/States.js
+++ b/src/js/constants/States.js
@@ -2,7 +2,8 @@ const States = {
   STATE_LOADING: 0,
   STATE_ERROR: 1,
   STATE_SUCCESS: 2,
-  STATE_UNAUTHORIZED: 3
+  STATE_UNAUTHORIZED: 3,
+  STATE_FORBIDDEN: 4
 };
 
 module.exports = Object.freeze(States);

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -304,6 +304,12 @@ function processResponseErrors(responseErrors, response, statusCode) {
       AppFormErrorMessages.getGeneralMessage("errorPrefix") + " " +
       response.message;
 
+  } else if (statusCode === 403 && response != null &&
+      response.message != null) {
+
+    responseErrors.general =
+      AppFormErrorMessages.getGeneralMessage("forbiddenAccess");
+
   } else if (statusCode === 401 && response != null &&
       response.message != null) {
 

--- a/src/test/tasks.test.js
+++ b/src/test/tasks.test.js
@@ -344,7 +344,7 @@ describe("Task List component", function () {
 
   it("has correct TaskListItemComponents keys", function () {
     var tasklistitems =
-      this.component.props.children[2].props.children[1].props.children[2];
+      this.component.props.children[3].props.children[1].props.children[2];
 
     expect(tasklistitems[0].key).to.equal("task-1");
     expect(tasklistitems[1].key).to.equal("task-2");


### PR DESCRIPTION
This handles the HTTP 403 response explicitly, besides the 401.
This is related to https://github.com/mesosphere/marathon/issues/2194 and needs no further changelog entry.