### PR TITLE
Implement app label filters

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7330,6 +7330,10 @@
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/react/-/react-0.13.3.tgz"
     },
+    "react-onclickoutside": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-0.3.1.tgz"
+    },
     "react-router": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-0.13.3.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "object-path": "^0.9.2",
     "qajax": "^1.3.0",
     "react": "^0.13.2",
+    "react-onclickoutside": "^0.3.1",
     "react-router": "^0.13.3",
     "react-tools": "^0.13.2",
     "underscore": "^1.7.0"

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1196,6 +1196,14 @@ fieldset[disabled] .btn-info.active {
         &::before {
           border: 1px solid @breadcrumb-text-color;
         }
+
+        > span {
+          display: block;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          width: @sidebar-width*0.5;
+          white-space: nowrap;
+        }
       }
     }
 

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1025,6 +1025,11 @@ fieldset[disabled] .btn-info.active {
         margin: 0 0 @base-spacing-unit 0;
         text-align: left;
         width: 100%;
+
+        > div {
+          overflow-x: hidden;
+          text-overflow: ellipsis;
+        }
       }
 
       .filters {
@@ -1163,6 +1168,14 @@ fieldset[disabled] .btn-info.active {
     color: @link-color;
     display: flex;
     justify-content: space-between;
+
+    &:active, &:focus, &:hover {
+      background-color: transparent;
+    }
+
+    &:active, &:focus {
+      border-color: @brand-primary;
+    }
   }
 
   .dropdown-menu {
@@ -1175,6 +1188,10 @@ fieldset[disabled] .btn-info.active {
 
       label {
         color: @sidebar-heading-color;
+
+        &::before {
+          border: 1px solid @breadcrumb-text-color;
+        }
       }
     }
 

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1185,6 +1185,7 @@ fieldset[disabled] .btn-info.active {
   .dropdown-menu {
     border-color: @dropdown-bg-color;
     border-radius: 2px;
+    display: block;
 
     .checkbox {
       padding: 0 @base-spacing-unit;

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1040,6 +1040,10 @@ fieldset[disabled] .btn-info.active {
         align-items: center;
         display: flex;
         justify-content: space-between;
+
+        > a {
+          padding: 0; /* "Clear" filter links */
+        }
       }
     }
   }

--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -12,6 +12,7 @@ var AppListComponent = React.createClass({
   displayName: "AppListComponent",
 
   propTypes: {
+    filterLabels: React.PropTypes.array,
     filterText: React.PropTypes.string
   },
 
@@ -79,6 +80,21 @@ var AppListComponent = React.createClass({
         .filter(function (app) {
           return app.id.indexOf(props.filterText) !== -1;
         });
+    }
+
+    if (props.filterLabels != null && props.filterLabels.length > 0) {
+      appsSequence = appsSequence.filter(function (app) {
+        let labels = app.labels;
+        if (labels == null || Object.keys(labels).length === 0) {
+          return false;
+        }
+
+        /* Use .every for an INTERSECTION instead of UNION */
+        return lazy(props.filterLabels).some(function (label) {
+          let [key, value] = lazy(label).toArray()[0];
+          return labels[key] === value;
+        });
+      });
     }
 
     return appsSequence

--- a/src/js/components/AppListLabelsFilterComponent.jsx
+++ b/src/js/components/AppListLabelsFilterComponent.jsx
@@ -1,3 +1,4 @@
+var classNames = require("classnames");
 var lazy = require("lazy.js");
 var OnClickOutsideMixin = require("react-onclickoutside");
 var React = require("react/addons");
@@ -245,14 +246,12 @@ var AppListLabelsFilterComponent = React.createClass({
       );
     });
 
+    let dropdownClassSet = classNames({
+        "hidden": !this.state.activated
+    }, "dropdown-menu list-group filters");
+
     return (
-      <ul className="dropdown-menu list-group filters"
-          style={{
-              display: this.state.activated
-                ? "block"
-                : "none"
-            }}
-          aria-labelledby="dropdownMenu1">
+      <ul className={dropdownClassSet}>
         <li className="search">
           <input type="text"
             value={state.filterText}

--- a/src/js/components/AppListLabelsFilterComponent.jsx
+++ b/src/js/components/AppListLabelsFilterComponent.jsx
@@ -1,0 +1,277 @@
+var lazy = require("lazy.js");
+var OnClickOutsideMixin = require("react-onclickoutside");
+var React = require("react/addons");
+
+var AppsStore = require("../stores/AppsStore");
+var AppsEvents = require("../events/AppsEvents");
+
+var AppListLabelsFilterComponent = React.createClass({
+  displayName: "AppListLabelsFilterComponent",
+
+  mixins: [OnClickOutsideMixin],
+
+  contextTypes: {
+    router: React.PropTypes.func
+  },
+
+  propTypes: {
+    onChange: React.PropTypes.func.isRequired
+  },
+
+  getInitialState: function () {
+    var labels = this.getAvailableLabels();
+
+    return {
+      activated: false,
+      availableLabels: labels,
+      selectedLabels: [],
+      filterText: ""
+    };
+  },
+
+  componentDidMount: function () {
+    this.updateFilterLabels();
+  },
+
+  componentWillReceiveProps: function () {
+    this.updateFilterLabels();
+  },
+
+  componentWillMount: function () {
+    AppsStore.on(AppsEvents.CHANGE, this.onAppsChange);
+  },
+
+  componentWillUnmount: function () {
+    AppsStore.removeListener(AppsEvents.CHANGE, this.onAppsChange);
+  },
+
+  getAvailableLabels: function () {
+    var apps = AppsStore.apps;
+    if (apps.length === 0) {
+      return [];
+    }
+
+    return lazy(apps)
+      .filter((app) => {
+        return app.labels != null && Object.keys(app.labels).length > 0;
+      })
+      .reduce((memo, app) => {
+        Object.keys(app.labels).forEach((key) => {
+          let label = {
+            [key]: app.labels[key]
+          };
+          if (lazy(memo).findWhere(label) == null) {
+            memo.push(label);
+          }
+        });
+        return memo;
+      }, []);
+  },
+
+  handleClickOutside: function () {
+    this.setState({
+      activated: false
+    });
+  },
+
+  onAppsChange: function () {
+    this.setState({
+      availableLabels: this.getAvailableLabels()
+    }, this.updateFilterLabels);
+  },
+
+  setQueryParam: function (filterLabels) {
+    var router = this.context.router;
+    var queryParams = router.getCurrentQuery();
+
+    if (filterLabels != null && filterLabels.length !== 0) {
+      let encodedFilterLabels = filterLabels.map((label) => {
+        let [key, value] = lazy(label).toArray()[0];
+        return encodeURIComponent(`${key}:${value}`);
+      });
+      Object.assign(queryParams, {
+        filterLabels: encodedFilterLabels
+      });
+    } else {
+      delete queryParams.filterLabels;
+    }
+
+    router.transitionTo(router.getCurrentPathname(), {}, queryParams);
+  },
+
+  updateFilterLabels: function () {
+    var router = this.context.router;
+    var state = this.state;
+    var queryParams = router.getCurrentQuery();
+    var selectedLabels = queryParams.filterLabels;
+    var stringify = JSON.stringify;
+
+    if (selectedLabels == null) {
+      selectedLabels = [];
+    } else {
+      selectedLabels = decodeURIComponent(selectedLabels)
+        .split(",")
+        .map((label) => {
+          let [key, value] = label.split(":");
+          return {
+            [key]: value
+          };
+        })
+        .filter((label) => {
+          let existingLabel = lazy(state.availableLabels).findWhere(label);
+          return existingLabel != null;
+        });
+    }
+
+    if (stringify(selectedLabels) !== stringify(state.selectedLabels)) {
+      this.setState({
+        selectedLabels: selectedLabels
+      }, this.props.onChange(selectedLabels));
+    }
+  },
+
+  handleChange: function (label, event) {
+    var state = this.state;
+    var selectedLabels = [];
+
+    if (event.target.checked === true) {
+      selectedLabels = lazy(state.selectedLabels).union(label).value();
+    } else {
+      let target = lazy(state.selectedLabels).findWhere(label);
+      if (target != null) {
+        selectedLabels = lazy(state.selectedLabels).without(target).value();
+      }
+    }
+
+    this.setQueryParam(selectedLabels);
+  },
+
+  handleFilterTextChange: function (event) {
+    var filterText = event.target.value;
+    this.setState({
+      filterText: filterText
+    });
+  },
+
+  handleKeyDown: function (event) {
+    if (event.key === "Escape") {
+      event.target.blur();
+      this.setState({
+        filterText: ""
+      });
+    }
+  },
+
+  toggleActivatedState: function () {
+    this.setState({
+      activated: !this.state.activated
+    });
+  },
+
+  getDropdownButton: function () {
+    var state = this.state;
+    if (state.availableLabels == null || state.availableLabels.length === 0) {
+      return (
+        <button className="btn btn-default dropdown-toggle" disabled>
+          No labels
+        </button>
+      );
+    }
+
+    let selectedLabelsText = state.selectedLabels.reduce((memo, label) => {
+      let [key, value] = lazy(label).toArray()[0];
+      let labelText = key;
+      if (value != null) {
+        labelText = `${key}:${value}`;
+      }
+
+      if (memo.length === 0) {
+        memo = labelText;
+        return memo;
+      }
+
+      memo = `${memo}, ${labelText}`;
+      return memo;
+    }, "");
+
+    if (selectedLabelsText === "") {
+      selectedLabelsText = "Select";
+    }
+
+    return (
+      <button className="btn btn-default dropdown-toggle"
+          type="button"
+          onClick={this.toggleActivatedState}>
+        <div>{selectedLabelsText}</div>
+        <span className="caret" />
+      </button>
+    );
+  },
+
+  getOptions: function () {
+    var state = this.state;
+    if (state.availableLabels == null || state.availableLabels.length === 0) {
+      return null;
+    }
+
+    let options = state.availableLabels.map((label, i) => {
+      let [key, value] = lazy(label).toArray()[0];
+      let optionText = key;
+      let filterText = state.filterText;
+
+      if (value != null && value !== "") {
+        optionText = `${key}:${value}`;
+      }
+
+      if (filterText !== "" &&
+        optionText.search(new RegExp(filterText, "i")) === -1) {
+        return null;
+      }
+
+      let checkboxProps = {
+        type: "checkbox",
+        id: `label-${optionText}-${i}`,
+        checked: lazy(state.selectedLabels).find(label) != null
+      };
+
+      return (
+        <li className="checkbox" key={i}>
+          <input {...checkboxProps}
+            onChange={this.handleChange.bind(this, label)} />
+          <label htmlFor={`label-${optionText}-${i}`}>{optionText}</label>
+        </li>
+      );
+    });
+
+    return (
+      <ul className="dropdown-menu list-group filters"
+          style={{
+              display: this.state.activated
+                ? "block"
+                : "none"
+            }}
+          aria-labelledby="dropdownMenu1">
+        <li className="search">
+          <input type="text"
+            value={state.filterText}
+            placeholder="Filter labels"
+            onChange={this.handleFilterTextChange}
+            onKeyDown={this.handleKeyDown} />
+        </li>
+        {options}
+      </ul>
+    );
+  },
+
+  render: function () {
+    return (
+      <div className="dropdown">
+        {this.getDropdownButton()}
+        {this.getOptions()}
+      </div>
+    );
+  }
+
+});
+
+module.exports = AppListLabelsFilterComponent;

--- a/src/js/components/AppListLabelsFilterComponent.jsx
+++ b/src/js/components/AppListLabelsFilterComponent.jsx
@@ -238,7 +238,9 @@ var AppListLabelsFilterComponent = React.createClass({
         <li className="checkbox" key={i}>
           <input {...checkboxProps}
             onChange={this.handleChange.bind(this, label)} />
-          <label htmlFor={`label-${optionText}-${i}`}>{optionText}</label>
+          <label htmlFor={`label-${optionText}-${i}`} title={optionText}>
+            <span>{optionText}</span>
+          </label>
         </li>
       );
     });

--- a/src/js/components/AppListLabelsFilterComponent.jsx
+++ b/src/js/components/AppListLabelsFilterComponent.jsx
@@ -199,12 +199,12 @@ var AppListLabelsFilterComponent = React.createClass({
     }
 
     return (
-      <button className="btn btn-default dropdown-toggle"
+      <div className="btn btn-default dropdown-toggle"
           type="button"
           onClick={this.toggleActivatedState}>
         <div>{selectedLabelsText}</div>
         <span className="caret" />
-      </button>
+      </div>
     );
   },
 

--- a/src/js/components/TabPanesComponent.jsx
+++ b/src/js/components/TabPanesComponent.jsx
@@ -2,6 +2,8 @@ var Link = require("react-router").Link;
 var React = require("react/addons");
 
 var AppListFilterComponent = require("../components/AppListFilterComponent");
+var AppListLabelsFilterComponent =
+  require("../components/AppListLabelsFilterComponent");
 var AppListComponent = require("../components/AppListComponent");
 var DeploymentsListComponent =
   require("../components/DeploymentsListComponent");
@@ -19,7 +21,8 @@ var TabPanesComponent = React.createClass({
 
   getInitialState: function () {
     return {
-      filterText: ""
+      filterText: "",
+      filterLabels: []
     };
   },
 
@@ -27,7 +30,12 @@ var TabPanesComponent = React.createClass({
     this.setState({
       filterText: filterText
     });
+  },
 
+  updateFilterLabels: function (filterLabels) {
+    this.setState({
+      filterLabels: filterLabels
+    }, console.log(filterLabels));
   },
 
   getTabId: function () {
@@ -106,49 +114,8 @@ var TabPanesComponent = React.createClass({
               <div className="flex-row">
                 <h3 className="small-caps">Label</h3>
               </div>
-              <div className="dropdown">
-                <button className="btn btn-default dropdown-toggle"
-                  type="button"
-                  id="dropdownMenu1"
-                  data-toggle="dropdown"
-                  aria-haspopup="true"
-                  aria-expanded="true"
-                  onClick={() => {
-                    this.setState({
-                      expandedDropdown: !this.state.expandedDropdown
-                    });
-                  }}>
-                  Select
-                  <span className="caret"></span>
-                </button>
-                <ul className="dropdown-menu list-group filters"
-                  style={{
-                    display: this.state.expandedDropdown
-                      ? "block"
-                      : "none"
-                  }}
-                  aria-labelledby="dropdownMenu1">
-                  <li className="search">
-                    <input type="text" />
-                  </li>
-                  <li className="checkbox">
-                    <input type="checkbox" id="label-cb-1"/>
-                    <label htmlFor="label-cb-1">corgi:happy</label>
-                  </li>
-                  <li className="checkbox">
-                    <input type="checkbox" id="label-cb-2"/>
-                    <label htmlFor="label-cb-2">dachshund:psycho</label>
-                  </li>
-                  <li className="checkbox">
-                    <input type="checkbox" checked id="label-cb-3"/>
-                    <label htmlFor="label-cb-3">setter:majestic</label>
-                  </li>
-                  <li className="checkbox">
-                    <input type="checkbox" id="label-cb-4"/>
-                    <label htmlFor="label-cb-4">pitbull:overweight</label>
-                  </li>
-                </ul>
-              </div>
+              <AppListLabelsFilterComponent
+                onChange={this.updateFilterLabels} />
               <div className="flex-row">
                 <h3 className="small-caps">Resources</h3>
               </div>
@@ -195,7 +162,8 @@ var TabPanesComponent = React.createClass({
                   </div>
                 </div>
               </div>
-              <AppListComponent filterText={this.state.filterText} />
+              <AppListComponent filterText={this.state.filterText}
+                filterLabels={this.state.filterLabels} />
             </main>
           </div>
         </TabPaneComponent>

--- a/src/js/components/TabPanesComponent.jsx
+++ b/src/js/components/TabPanesComponent.jsx
@@ -35,7 +35,7 @@ var TabPanesComponent = React.createClass({
   updateFilterLabels: function (filterLabels) {
     this.setState({
       filterLabels: filterLabels
-    }, console.log(filterLabels));
+    });
   },
 
   getTabId: function () {


### PR DESCRIPTION
This PR implements the App Labels dropdown filtering interaction.

Make sure you `npm install` as this adds a new dependency. 

ACs:

- [x] the dropdown shows all available labels
- [x] the labels in the dropdown are filterable (via the input field)
- [x] when a label is applied, the app list shows matching applications
- [x] selecting multiple labels functions as a UNION (instead of INTERSECTION)
- [x] the selection is bookmarkable and should persist upon page reload 
- [x] the labels don't break in case of extra-long strings
- [x] the dropdown works on Chrome, Safari, Firefox

10MB worth of GIF awesomeness for your :eyes: 

![labels](https://cloud.githubusercontent.com/assets/1078545/10334375/110b08f2-6cea-11e5-8995-10d754dd68ca.gif)



