### PR TITLE
Implement filter by Status

### DIFF
--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -13,6 +13,7 @@ var AppListComponent = React.createClass({
 
   propTypes: {
     filterLabels: React.PropTypes.array,
+    filterStatus: React.PropTypes.array,
     filterText: React.PropTypes.string
   },
 
@@ -93,6 +94,20 @@ var AppListComponent = React.createClass({
         return lazy(props.filterLabels).some(function (label) {
           let [key, value] = lazy(label).toArray()[0];
           return labels[key] === value;
+        });
+      });
+    }
+
+    if (props.filterStatus != null && props.filterStatus.length > 0) {
+      appsSequence = appsSequence.filter(function (app) {
+        if (app.status == null) {
+          return false;
+        }
+        let appStatus = app.status.toString();
+
+        /* Use .every for an INTERSECTION instead of UNION */
+        return lazy(props.filterStatus).some(function (status) {
+          return appStatus === status;
         });
       });
     }

--- a/src/js/components/AppListStatusFilterComponent.jsx
+++ b/src/js/components/AppListStatusFilterComponent.jsx
@@ -1,0 +1,135 @@
+var React = require("react/addons");
+
+var AppStatus = require("../constants/AppStatus");
+
+/* TODO extract from AppStatusComponent */
+var statusNameMapping = {
+  [AppStatus.RUNNING]: "Running",
+  [AppStatus.DEPLOYING]: "Deploying",
+  [AppStatus.SUSPENDED]: "Suspended",
+  [AppStatus.DELAYED]: "Delayed",
+  [AppStatus.WAITING]: "Waiting"
+};
+
+var AppListStatusFilterComponent = React.createClass({
+  displayName: "AppListStatusFilterComponent",
+
+  contextTypes: {
+    router: React.PropTypes.func
+  },
+
+  propTypes: {
+    onChange: React.PropTypes.func.isRequired
+  },
+
+  getInitialState: function () {
+    return {
+      selectedStatus: []
+    };
+  },
+
+  componentDidMount: function () {
+    this.updateFilterStatus();
+  },
+
+  componentWillReceiveProps: function () {
+    this.updateFilterStatus();
+  },
+
+  setQueryParam: function (filterStatus) {
+    var router = this.context.router;
+    var queryParams = router.getCurrentQuery();
+
+    if (filterStatus != null && filterStatus.length !== 0) {
+      let encodedFilterStatus = filterStatus.map((key) => {
+        return encodeURIComponent(`${key}`);
+      });
+      Object.assign(queryParams, {
+        filterStatus: encodedFilterStatus
+      });
+    } else {
+      delete queryParams.filterStatus;
+    }
+
+    router.transitionTo(router.getCurrentPathname(), {}, queryParams);
+  },
+
+  handleChange: function (statusKey, event) {
+    var state = this.state;
+    var selectedStatus = [];
+    var status = statusKey.toString();
+
+    if (event.target.checked === true) {
+      selectedStatus = React.addons.update(state.selectedStatus, {
+        $push: [status]
+      });
+    } else {
+      let index = state.selectedStatus.indexOf(status);
+      if (index !== -1) {
+        selectedStatus = React.addons.update(state.selectedStatus, {
+          $splice: [[index, 1]]
+        });
+      }
+    }
+
+    this.setQueryParam(selectedStatus);
+  },
+
+  updateFilterStatus: function () {
+    var router = this.context.router;
+    var state = this.state;
+    var queryParams = router.getCurrentQuery();
+    var selectedStatus = queryParams.filterStatus;
+    var stringify = JSON.stringify;
+
+    if (selectedStatus == null) {
+      selectedStatus = [];
+    } else {
+      selectedStatus = decodeURIComponent(selectedStatus)
+        .split(",")
+        .filter((statusKey) => {
+          let status = statusKey.toString();
+          let existingStatus = Object.keys(statusNameMapping).indexOf(status);
+          return existingStatus !== -1;
+        });
+    }
+
+    if (stringify(selectedStatus) !== stringify(state.selectedStatus)) {
+      this.setState({
+          selectedStatus: selectedStatus
+      }, this.props.onChange(selectedStatus));
+    }
+  },
+
+  getStatusNodes: function () {
+    var state = this.state;
+    return Object.keys(statusNameMapping).map((key, i) => {
+      let optionText = statusNameMapping[key];
+
+      let checkboxProps = {
+        type: "checkbox",
+        id: `status-${key}-${i}`,
+        checked: state.selectedStatus.indexOf(key) !== -1
+      };
+
+      return (
+        <li className="checkbox" key={i}>
+          <input {...checkboxProps}
+            onChange={this.handleChange.bind(this, key)} />
+          <label htmlFor={`status-${key}-${i}`}>{optionText}</label>
+        </li>
+      );
+    });
+  },
+
+  render: function () {
+    return (
+      <ul className="list-group checked-list-box filters">
+        {this.getStatusNodes()}
+      </ul>
+    );
+  }
+
+});
+
+module.exports = AppListStatusFilterComponent;

--- a/src/js/components/TabPanesComponent.jsx
+++ b/src/js/components/TabPanesComponent.jsx
@@ -76,7 +76,7 @@ var TabPanesComponent = React.createClass({
               </Link>
               <div className="flex-row">
                 <h3 className="small-caps">Status</h3>
-                <a href="#">Clear</a>
+                <a href="#" className="hidden">Clear</a>
               </div>
               <AppListStatusFilterComponent
                 onChange={this.updateFilterStatus} />

--- a/src/js/components/TabPanesComponent.jsx
+++ b/src/js/components/TabPanesComponent.jsx
@@ -4,6 +4,8 @@ var React = require("react/addons");
 var AppListFilterComponent = require("../components/AppListFilterComponent");
 var AppListLabelsFilterComponent =
   require("../components/AppListLabelsFilterComponent");
+var AppListStatusFilterComponent =
+  require("../components/AppListStatusFilterComponent");
 var AppListComponent = require("../components/AppListComponent");
 var DeploymentsListComponent =
   require("../components/DeploymentsListComponent");
@@ -22,7 +24,8 @@ var TabPanesComponent = React.createClass({
   getInitialState: function () {
     return {
       filterText: "",
-      filterLabels: []
+      filterLabels: [],
+      filterStatus: []
     };
   },
 
@@ -35,6 +38,12 @@ var TabPanesComponent = React.createClass({
   updateFilterLabels: function (filterLabels) {
     this.setState({
       filterLabels: filterLabels
+    });
+  },
+
+  updateFilterStatus: function (filterStatus) {
+    this.setState({
+      filterStatus: filterStatus
     });
   },
 
@@ -69,28 +78,8 @@ var TabPanesComponent = React.createClass({
                 <h3 className="small-caps">Status</h3>
                 <a href="#">Clear</a>
               </div>
-              <ul className="list-group checked-list-box filters">
-                <li className="checkbox">
-                  <input type="checkbox" id="filter-cb-1"/>
-                  <label htmlFor="filter-cb-1">Running</label>
-                </li>
-                <li className="checkbox">
-                  <input type="checkbox" checked id="filter-cb-2"/>
-                  <label htmlFor="filter-cb-2">Deploying</label>
-                </li>
-                <li className="checkbox">
-                  <input type="checkbox" id="filter-cb-3"/>
-                  <label htmlFor="filter-cb-3">Inactive</label>
-                </li>
-                <li className="checkbox">
-                  <input type="checkbox" id="filter-cb-4"/>
-                  <label htmlFor="filter-cb-4">Waiting</label>
-                </li>
-                <li className="checkbox">
-                  <input type="checkbox" id="filter-cb-5"/>
-                  <label htmlFor="filter-cb-5">Delayed</label>
-                </li>
-              </ul>
+              <AppListStatusFilterComponent
+                onChange={this.updateFilterStatus} />
               <div className="flex-row">
                 <h3 className="small-caps">Application Type</h3>
               </div>
@@ -163,7 +152,8 @@ var TabPanesComponent = React.createClass({
                 </div>
               </div>
               <AppListComponent filterText={this.state.filterText}
-                filterLabels={this.state.filterLabels} />
+                filterLabels={this.state.filterLabels}
+                filterStatus={this.state.filterStatus} />
             </main>
           </div>
         </TabPaneComponent>


### PR DESCRIPTION
This makes it possible to filter apps by their status.

*Heads up*: I couldn't really decide between the wording `stati` (latin plural of `status`, I believe), `statuses` and `status` (all correct, I suppose) so I went for the latter. Let me know if you have a preference.

ACs:

- [x] the list shows all available status
- [x] when a status is applied, the app list shows matching applications
- [x] selecting multiple status functions as a UNION (instead of INTERSECTION)
- [x] the selection is bookmarkable and should persist upon page reload 
- [x] it does not interfere with other filters

`/giphy filterbystatus`
![status](https://cloud.githubusercontent.com/assets/1078545/10343771/d650f5a6-6d1f-11e5-96ab-0a20fb8da960.gif)


@orlandohohmeier merging this or https://github.com/mesosphere/marathon-ui/pull/283 first should make no difference. A rebase is 100% required in both cases. I'll take care of it!

PS as written at `src/js/components/AppListStatusFilterComponent.jsx:5` we should most definitely refactor this bit of knowledge into an own module, or possibly we can rewrite our `AppStatus.js` to export multiple objects, so we can fetch them via the `import {status, statusNaming} from "AppStatus.js"` in both component. 

Skipping that part for now.

PPS: it's not visible in the GIF, but the "Clear" link in the sidebar is hidden. We need to rewrite this with a Flux architecture to make that work nicely. Skippin'

PPPS: It will probably make sense to refactor this into a more generic "filter" component so we can re-use the business logic with application Type, etc. Also skippin'.