### PR TITLE
Implement filter by App Type

### DIFF
--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -2,6 +2,7 @@ var classNames = require("classnames");
 var lazy = require("lazy.js");
 var React = require("react/addons");
 
+var AppTypes = require("../constants/AppTypes");
 var States = require("../constants/States");
 var AppComponent = require("../components/AppComponent");
 
@@ -14,7 +15,8 @@ var AppListComponent = React.createClass({
   propTypes: {
     filterLabels: React.PropTypes.array,
     filterStatus: React.PropTypes.array,
-    filterText: React.PropTypes.string
+    filterText: React.PropTypes.string,
+    filterType: React.PropTypes.array
   },
 
   getInitialState: function () {
@@ -108,6 +110,23 @@ var AppListComponent = React.createClass({
         /* Use .every for an INTERSECTION instead of UNION */
         return lazy(props.filterStatus).some(function (status) {
           return appStatus === status;
+        });
+      });
+    }
+
+    if (props.filterTypes != null && props.filterTypes.length > 0) {
+      appsSequence = appsSequence.filter(function (app) {
+        let appTypeIndex = 0;
+        if (app.container != null && app.container.type != null) {
+          appTypeIndex = AppTypes.indexOf(app.container.type);
+          if (appTypeIndex === -1) {
+            return false;
+          }
+        }
+
+        /* Use .every for an INTERSECTION instead of UNION */
+        return lazy(props.filterTypes).some(function (type) {
+          return AppTypes[appTypeIndex] === type;
         });
       });
     }

--- a/src/js/components/AppListTypeFilterComponent.jsx
+++ b/src/js/components/AppListTypeFilterComponent.jsx
@@ -2,11 +2,6 @@ var React = require("react/addons");
 
 var AppTypes = require("../constants/AppTypes");
 
-const appTypesNameMapping = {
-  "DEFAULT": "Default",
-  "DOCKER": "Docker"
-};
-
 var AppListTypeFilterComponent = React.createClass({
   displayName: "AppListTypeFilterComponent",
 
@@ -107,9 +102,7 @@ var AppListTypeFilterComponent = React.createClass({
         <li className="checkbox" key={i}>
           <input {...checkboxProps}
             onChange={this.handleChange.bind(this, type)} />
-          <label htmlFor={`type-${type}-${i}`}>
-            {appTypesNameMapping[type]}
-          </label>
+          <label htmlFor={`type-${type}-${i}`}>{type}</label>
         </li>
       );
     });

--- a/src/js/components/AppListTypeFilterComponent.jsx
+++ b/src/js/components/AppListTypeFilterComponent.jsx
@@ -1,0 +1,128 @@
+var React = require("react/addons");
+
+var AppTypes = require("../constants/AppTypes");
+
+const appTypesNameMapping = {
+  "DEFAULT": "Default",
+  "DOCKER": "Docker"
+};
+
+var AppListTypeFilterComponent = React.createClass({
+  displayName: "AppListTypeFilterComponent",
+
+  contextTypes: {
+    router: React.PropTypes.func
+  },
+
+  propTypes: {
+    onChange: React.PropTypes.func.isRequired
+  },
+
+  getInitialState: function () {
+    return {
+      selectedTypes: []
+    };
+  },
+
+  componentDidMount: function () {
+    this.updateFilterType();
+  },
+
+  componentWillReceiveProps: function () {
+    this.updateFilterType();
+  },
+
+  setQueryParam: function (filterType) {
+    var router = this.context.router;
+    var queryParams = router.getCurrentQuery();
+
+    if (filterType != null && filterType.length !== 0) {
+      let encodedFilterType = filterType.map((key) => {
+        return encodeURIComponent(`${key}`);
+      });
+      Object.assign(queryParams, {
+        filterType: encodedFilterType
+      });
+    } else {
+      delete queryParams.filterType;
+    }
+
+    router.transitionTo(router.getCurrentPathname(), {}, queryParams);
+  },
+
+  handleChange: function (type, event) {
+    var state = this.state;
+    var selectedTypes = [];
+
+    if (event.target.checked === true) {
+      selectedTypes = React.addons.update(state.selectedTypes, {
+        $push: [type]
+      });
+    } else {
+      let index = state.selectedTypes.indexOf(type);
+      if (index !== -1) {
+        selectedTypes = React.addons.update(state.selectedTypes, {
+          $splice: [[index, 1]]
+        });
+      }
+    }
+    this.setQueryParam(selectedTypes);
+  },
+
+  updateFilterType: function () {
+    var router = this.context.router;
+    var state = this.state;
+    var queryParams = router.getCurrentQuery();
+    var selectedTypes = queryParams.filterType;
+    var stringify = JSON.stringify;
+
+    if (selectedTypes == null) {
+      selectedTypes = [];
+    } else {
+      selectedTypes = decodeURIComponent(selectedTypes)
+        .split(",")
+        .filter((type) => {
+          let existingType = AppTypes.indexOf(type);
+          return existingType !== -1;
+        });
+    }
+
+    if (stringify(selectedTypes) !== stringify(state.selectedTypes)) {
+      this.setState({
+        selectedTypes: selectedTypes
+      }, this.props.onChange(selectedTypes));
+    }
+  },
+
+  getTypeNodes: function () {
+    var state = this.state;
+    return AppTypes.map((type, i) => {
+      let checkboxProps = {
+        type: "checkbox",
+        id: `type-${type}-${i}`,
+        checked: state.selectedTypes.indexOf(type) !== -1
+      };
+
+      return (
+        <li className="checkbox" key={i}>
+          <input {...checkboxProps}
+            onChange={this.handleChange.bind(this, type)} />
+          <label htmlFor={`type-${type}-${i}`}>
+            {appTypesNameMapping[type]}
+          </label>
+        </li>
+      );
+    });
+  },
+
+  render: function () {
+    return (
+      <ul className="list-group checked-list-box filters">
+        {this.getTypeNodes()}
+      </ul>
+    );
+  }
+
+});
+
+module.exports = AppListTypeFilterComponent;

--- a/src/js/components/TabPanesComponent.jsx
+++ b/src/js/components/TabPanesComponent.jsx
@@ -6,6 +6,8 @@ var AppListLabelsFilterComponent =
   require("../components/AppListLabelsFilterComponent");
 var AppListStatusFilterComponent =
   require("../components/AppListStatusFilterComponent");
+var AppListTypeFilterComponent =
+  require("../components/AppListTypeFilterComponent");
 var AppListComponent = require("../components/AppListComponent");
 var DeploymentsListComponent =
   require("../components/DeploymentsListComponent");
@@ -25,7 +27,8 @@ var TabPanesComponent = React.createClass({
     return {
       filterText: "",
       filterLabels: [],
-      filterStatus: []
+      filterStatus: [],
+      filterTypes: []
     };
   },
 
@@ -44,6 +47,12 @@ var TabPanesComponent = React.createClass({
   updateFilterStatus: function (filterStatus) {
     this.setState({
       filterStatus: filterStatus
+    });
+  },
+
+  updateFilterTypes: function (filterTypes) {
+    this.setState({
+      filterTypes: filterTypes
     });
   },
 
@@ -83,23 +92,7 @@ var TabPanesComponent = React.createClass({
               <div className="flex-row">
                 <h3 className="small-caps">Application Type</h3>
               </div>
-              <ul className="list-group checked-list-box filters">
-                <li className="checkbox">
-                  <input type="checkbox" id="filter-cb-6"/>
-                  <label htmlFor="filter-cb-6">Docker</label>
-                </li>
-                <li className="checkbox">
-                  <input type="checkbox" checked id="filter-cb-7"/>
-                  <label htmlFor="filter-cb-7">Rocket</label>
-                </li>
-                <li className="checkbox">
-                  <input type="checkbox" id="filter-cb-8"/>
-                  <label htmlFor="filter-cb-8">Cgroup</label>
-                </li>
-                <li className="flex-row show-more">
-                  <a href="#">Show more</a>
-                </li>
-              </ul>
+              <AppListTypeFilterComponent onChange={this.updateFilterTypes} />
               <div className="flex-row">
                 <h3 className="small-caps">Label</h3>
               </div>
@@ -153,6 +146,7 @@ var TabPanesComponent = React.createClass({
               </div>
               <AppListComponent filterText={this.state.filterText}
                 filterLabels={this.state.filterLabels}
+                filterTypes={this.state.filterTypes}
                 filterStatus={this.state.filterStatus} />
             </main>
           </div>

--- a/src/js/constants/AppTypes.js
+++ b/src/js/constants/AppTypes.js
@@ -5,4 +5,4 @@ const AppTypes = ["DEFAULT"].concat(
     .map((typeKey) => ContainerConstants.TYPE[typeKey])
   );
 
-module.exports = AppTypes;
+module.exports = Object.freeze(AppTypes);

--- a/src/js/constants/AppTypes.js
+++ b/src/js/constants/AppTypes.js
@@ -1,0 +1,8 @@
+var ContainerConstants = require("../constants/ContainerConstants");
+
+const AppTypes = ["DEFAULT"].concat(
+  Object.keys(ContainerConstants.TYPE)
+    .map((typeKey) => ContainerConstants.TYPE[typeKey])
+  );
+
+module.exports = AppTypes;


### PR DESCRIPTION
This makes it possible to filter apps by their type (for now only "default" and "docker").

ACs:

- [x] the list shows all available types
- [x] when a type is applied, the app list shows matching applications
- [x] selecting multiple types functions as a UNION (instead of INTERSECTION)
- [x] the selection is bookmarkable and should persist upon page reload 
- [x] it does not interfere with other filters

Proof:

![filter-type](https://cloud.githubusercontent.com/assets/1078545/10365796/2b958f26-6dc6-11e5-97c3-7875d405ca44.gif)

Once more, summoning @aldipower and @philipnrmn as I think in general we should discuss a Flux approach to filtering, just so we don't forget ;)

