### PR TITLE
Adjust colspan to center all message rows

### DIFF
--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -268,17 +268,17 @@ var AppListComponent = React.createClass({
             </td>
           </tr>
           <tr className={errorClassSet}>
-            <td className="text-center text-danger" colSpan="6">
+            <td className="text-center text-danger" colSpan="7">
               {`Error fetching apps. ${Messages.RETRY_REFRESH}`}
             </td>
           </tr>
           <tr className={unauthorizedClassSet}>
-            <td className="text-center text-danger" colSpan="6">
+            <td className="text-center text-danger" colSpan="7">
               {`Error fetching apps. ${Messages.UNAUTHORIZED}`}
             </td>
           </tr>
           <tr className={forbiddenClassSet}>
-            <td className="text-center text-danger" colSpan="6">
+            <td className="text-center text-danger" colSpan="7">
               {`Error fetching apps. ${Messages.FORBIDDEN}`}
             </td>
           </tr>


### PR DESCRIPTION
This fixes the `colspan` values for all of the "message" rows in the list overview.

From:

![screen shot 2015-10-12 at 12 02 05](https://cloud.githubusercontent.com/assets/1078545/10425622/48e516c6-70d9-11e5-8f20-0741290d16a2.png)


To:

![screen shot 2015-10-12 at 12 01 41](https://cloud.githubusercontent.com/assets/1078545/10425623/4bb8b5f6-70d9-11e5-8952-aa16c96b1ce4.png)

