### PR TITLE
Fix dropdown height

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -325,7 +325,6 @@ a,
   border-color: #5e646c;
   color: #555;
   box-shadow: inset 0 4px 4px rgba(0, 0, 0, 0.2);
-  height: auto;
 }
 
 .text-align-top {
@@ -794,6 +793,7 @@ fieldset[disabled] .btn-info.active {
     background: transparent;
     border-color: #5e646c;
     border-width: 1px 0;
+    height: auto;
   }
 
   .input-group-addon {


### PR DESCRIPTION
830aba23af87782b9900d30b9ba1d14a7155fbd4 introduced ugly styles for
dropdowns inside the modal dialog.

From:
![screen shot 2015-10-12 at 12 25 37](https://cloud.githubusercontent.com/assets/1078545/10425974/6a9b5f70-70dc-11e5-9f8b-48240802d62a.png)


To:
![screen shot 2015-10-12 at 12 25 13](https://cloud.githubusercontent.com/assets/1078545/10425977/6d51ce66-70dc-11e5-9c3d-f6e91448eefa.png)
