### PR TITLE
Feature: Introduce help modal with keyboard shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Unversioned
+### Added
+- \#2031 - Make keyboard shortcuts discoverable
+
 ### Fixed
 - \#2422 - Handle apps error response attribute on HTTP 422
 

--- a/src/js/components/Marathon.jsx
+++ b/src/js/components/Marathon.jsx
@@ -11,6 +11,7 @@ var AppModalComponent = require("../components/modals/AppModalComponent");
 var DialogsComponent = require("../components/DialogsComponent");
 var EditAppModalComponent =
   require("../components/modals/EditAppModalComponent");
+var HelpModalComponent = require("../components/modals/HelpModalComponent");
 var NavTabsComponent = require("../components/NavTabsComponent");
 
 var AppsActions = require("../actions/AppsActions");
@@ -72,6 +73,10 @@ var Marathon = React.createClass({
       router.transitionTo(router.getCurrentPathname(), {}, {modal: "about"});
     });
 
+    Mousetrap.bind("shift+?", function () {
+      router.transitionTo(router.getCurrentPathname(), {}, {modal: "help"});
+    });
+
     this.startPolling();
   },
 
@@ -91,6 +96,8 @@ var Marathon = React.createClass({
       modal = this.getNewAppModal();
     } else if (modalQuery === "about") {
       modal = this.getAboutModal();
+    } else if (modalQuery === "help") {
+      modal = this.getHelpModal();
     } else if (modalQuery != null && modalQuery.indexOf("edit-app--") > -1) {
       let [, appId, appVersion] = modalQuery.split("--");
       modal = this.getEditAppModal(decodeURIComponent(appId), appVersion);
@@ -185,6 +192,13 @@ var Marathon = React.createClass({
   getAboutModal: function () {
     return (
       <AboutModalComponent
+        onDestroy={this.handleModalDestroy} />
+    );
+  },
+
+  getHelpModal: function () {
+    return (
+      <HelpModalComponent
         onDestroy={this.handleModalDestroy} />
     );
   },

--- a/src/js/components/Marathon.jsx
+++ b/src/js/components/Marathon.jsx
@@ -73,7 +73,7 @@ var Marathon = React.createClass({
       router.transitionTo(router.getCurrentPathname(), {}, {modal: "about"});
     });
 
-    Mousetrap.bind("shift+?", function () {
+    Mousetrap.bind("?", function () {
       router.transitionTo(router.getCurrentPathname(), {}, {modal: "help"});
     });
 

--- a/src/js/components/modals/HelpModalComponent.jsx
+++ b/src/js/components/modals/HelpModalComponent.jsx
@@ -39,7 +39,7 @@ var HelpModalComponent = React.createClass({
             <dd>Go to UI Version dialog</dd>
             <dt>shift + ,</dt>
             <dd>Go to About modal</dd>
-            <dt>shift + ?</dt>
+            <dt>?</dt>
             <dd>Go to Help modal</dd>
           </dl>
         </div>

--- a/src/js/components/modals/HelpModalComponent.jsx
+++ b/src/js/components/modals/HelpModalComponent.jsx
@@ -1,0 +1,51 @@
+var React = require("react/addons");
+
+var ModalComponent = require("../ModalComponent");
+
+var HelpModalComponent = React.createClass({
+  displayName: "HelpModalComponent",
+
+  propTypes: {
+    onDestroy: React.PropTypes.func.isRequired
+  },
+
+  destroy: function () {
+    // This will also call `this.props.onDestroy` since it is passed as the
+    // callback for the modal's `onDestroy` prop.
+    this.refs.modalComponent.destroy();
+  },
+
+  render: function () {
+    return (
+      <ModalComponent
+          onDestroy={this.props.onDestroy}
+          ref="modalComponent">
+        <div className="modal-header">
+          <button type="button" className="close"
+            aria-hidden="true" onClick={this.destroy}>&times;</button>
+          <h3 className="modal-title">Keyboard shortcuts</h3>
+        </div>
+        <div className="modal-body">
+          <dl className="dl-horizontal dl-horizontal-lg">
+            <dt>esc</dt>
+            <dd>Close any open modal or dialog</dd>
+            <dt>c</dt>
+            <dd>Create New Application</dd>
+            <dt>g a</dt>
+            <dd>Go to Applications list</dd>
+            <dt>g d</dt>
+            <dd>Go to Deployments list</dd>
+            <dt>g v</dt>
+            <dd>Go to UI Version dialog</dd>
+            <dt>shift + ,</dt>
+            <dd>Go to About modal</dd>
+            <dt>shift + ?</dt>
+            <dd>Go to Help modal</dd>
+          </dl>
+        </div>
+      </ModalComponent>
+    );
+  }
+});
+
+module.exports = HelpModalComponent;


### PR DESCRIPTION
This fixes https://github.com/mesosphere/marathon/issues/2031

This modal is accessible by pressing ```shift+?```.

![help](https://cloud.githubusercontent.com/assets/859154/10455364/299cbdfe-71bb-11e5-8b82-55e01a6c68a5.png)
(I've removed the 's' in 'closes' after the screenshot)