### PR TITLE
Rhabarber/get app type in apps store

### DIFF
--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -3,7 +3,6 @@ var lazy = require("lazy.js");
 var React = require("react/addons");
 
 var Messages = require("../constants/Messages");
-var AppTypes = require("../constants/AppTypes");
 var States = require("../constants/States");
 var AppComponent = require("../components/AppComponent");
 
@@ -126,17 +125,9 @@ var AppListComponent = React.createClass({
 
     if (props.filterTypes != null && props.filterTypes.length > 0) {
       appsSequence = appsSequence.filter(function (app) {
-        let appTypeIndex = 0;
-        if (app.container != null && app.container.type != null) {
-          appTypeIndex = AppTypes.indexOf(app.container.type);
-          if (appTypeIndex === -1) {
-            return false;
-          }
-        }
-
         /* Use .every for an INTERSECTION instead of UNION */
         return lazy(props.filterTypes).some(function (type) {
-          return AppTypes[appTypeIndex] === type;
+          return app.type === type;
         });
       });
     }

--- a/src/js/components/AppListTypeFilterComponent.jsx
+++ b/src/js/components/AppListTypeFilterComponent.jsx
@@ -4,7 +4,6 @@ var AppTypes = require("../constants/AppTypes");
 
 var AppListTypeFilterComponent = React.createClass({
   displayName: "AppListTypeFilterComponent",
-  types: [],
 
   contextTypes: {
     router: React.PropTypes.func
@@ -18,12 +17,6 @@ var AppListTypeFilterComponent = React.createClass({
     return {
       selectedTypes: []
     };
-  },
-
-  componentWillMount: function () {
-    this.types = Object.keys(AppTypes).map((key) => {
-      return AppTypes[key];
-    });
   },
 
   componentDidMount: function () {
@@ -74,7 +67,6 @@ var AppListTypeFilterComponent = React.createClass({
   updateFilterType: function () {
     var router = this.context.router;
     var state = this.state;
-    var types = this.types;
     var queryParams = router.getCurrentQuery();
     var selectedTypes = queryParams.filterType;
     var stringify = JSON.stringify;
@@ -85,8 +77,7 @@ var AppListTypeFilterComponent = React.createClass({
       selectedTypes = decodeURIComponent(selectedTypes)
         .split(",")
         .filter((type) => {
-          let existingType = types.indexOf(type);
-          return existingType !== -1;
+          return Object.values(AppTypes).indexOf(type) !== -1;
         });
     }
 
@@ -99,8 +90,7 @@ var AppListTypeFilterComponent = React.createClass({
 
   getTypeNodes: function () {
     var state = this.state;
-    var types = this.types;
-    return types.map((type, i) => {
+    return Object.values(AppTypes).map((type, i) => {
       let checkboxProps = {
         type: "checkbox",
         id: `type-${type}-${i}`,

--- a/src/js/components/AppListTypeFilterComponent.jsx
+++ b/src/js/components/AppListTypeFilterComponent.jsx
@@ -4,6 +4,7 @@ var AppTypes = require("../constants/AppTypes");
 
 var AppListTypeFilterComponent = React.createClass({
   displayName: "AppListTypeFilterComponent",
+  types: [],
 
   contextTypes: {
     router: React.PropTypes.func
@@ -17,6 +18,12 @@ var AppListTypeFilterComponent = React.createClass({
     return {
       selectedTypes: []
     };
+  },
+
+  componentWillMount: function () {
+    this.types = Object.keys(AppTypes).map((key) => {
+      return AppTypes[key];
+    });
   },
 
   componentDidMount: function () {
@@ -67,6 +74,7 @@ var AppListTypeFilterComponent = React.createClass({
   updateFilterType: function () {
     var router = this.context.router;
     var state = this.state;
+    var types = this.types;
     var queryParams = router.getCurrentQuery();
     var selectedTypes = queryParams.filterType;
     var stringify = JSON.stringify;
@@ -77,7 +85,7 @@ var AppListTypeFilterComponent = React.createClass({
       selectedTypes = decodeURIComponent(selectedTypes)
         .split(",")
         .filter((type) => {
-          let existingType = AppTypes.indexOf(type);
+          let existingType = types.indexOf(type);
           return existingType !== -1;
         });
     }
@@ -91,7 +99,8 @@ var AppListTypeFilterComponent = React.createClass({
 
   getTypeNodes: function () {
     var state = this.state;
-    return AppTypes.map((type, i) => {
+    var types = this.types;
+    return types.map((type, i) => {
       let checkboxProps = {
         type: "checkbox",
         id: `type-${type}-${i}`,

--- a/src/js/constants/AppTypes.js
+++ b/src/js/constants/AppTypes.js
@@ -1,8 +1,6 @@
-var ContainerConstants = require("../constants/ContainerConstants");
-
-const AppTypes = ["DEFAULT"].concat(
-  Object.keys(ContainerConstants.TYPE)
-    .map((typeKey) => ContainerConstants.TYPE[typeKey])
-  );
+const AppTypes = {
+  DEFAULT: "DEFAULT",
+  DOCKER: "DOCKER"
+};
 
 module.exports = Object.freeze(AppTypes);

--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -4,6 +4,7 @@ var lazy = require("lazy.js");
 var AppDispatcher = require("../AppDispatcher");
 var AppsEvents = require("../events/AppsEvents");
 var appScheme = require("../stores/schemes/appScheme");
+var AppTypes = require("../constants/AppTypes");
 var AppStatus = require("../constants/AppStatus");
 var HealthStatus = require("../constants/HealthStatus");
 var TasksEvents = require("../events/TasksEvents");
@@ -115,6 +116,14 @@ function getAppHealthWeight(health) {
   }, 0);
 }
 
+function getAppType(app) {
+  var appTypeIndex = 0;
+  if (app.container != null && app.container.type != null) {
+    appTypeIndex = AppTypes.indexOf(app.container.type) || appTypeIndex;
+  }
+  return AppTypes[appTypeIndex];
+}
+
 function calculateTotalResources(app) {
   app.totalMem = app.mem * app.instances;
   app.totalCpus = parseFloat((app.cpus * app.instances).toPrecision(4));
@@ -131,7 +140,7 @@ function processApp(app) {
   } else if (app.instances === 0 && app.tasksRunning === 0) {
     app.status = AppStatus.SUSPENDED;
   }
-
+  app.type = getAppType(app);
   app.health = getAppHealth(app);
   app.healthWeight = getAppHealthWeight(app.health);
 

--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -5,6 +5,7 @@ var AppDispatcher = require("../AppDispatcher");
 var AppsEvents = require("../events/AppsEvents");
 var appScheme = require("../stores/schemes/appScheme");
 var AppTypes = require("../constants/AppTypes");
+var ContainerConstants = require("../constants/ContainerConstants");
 var AppStatus = require("../constants/AppStatus");
 var HealthStatus = require("../constants/HealthStatus");
 var TasksEvents = require("../events/TasksEvents");
@@ -117,11 +118,11 @@ function getAppHealthWeight(health) {
 }
 
 function getAppType(app) {
-  var appTypeIndex = 0;
-  if (app.container != null && app.container.type != null) {
-    appTypeIndex = AppTypes.indexOf(app.container.type) || appTypeIndex;
+  if (app.container != null &&
+      app.container.type === ContainerConstants.TYPE.DOCKER) {
+    return AppTypes.DOCKER;
   }
-  return AppTypes[appTypeIndex];
+  return AppTypes.DEFAULT;
 }
 
 function calculateTotalResources(app) {

--- a/src/js/stores/schemes/appScheme.js
+++ b/src/js/stores/schemes/appScheme.js
@@ -1,5 +1,6 @@
 var Util = require("../../helpers/Util");
 
+var AppTypes = require("../../constants/AppTypes");
 var AppStatus = require("../../constants/AppStatus");
 
 const appScheme = {
@@ -27,7 +28,8 @@ const appScheme = {
   user: null,
   tasks: [],
   tasksRunning: 0,
-  taskStats: {}
+  taskStats: {},
+  type: AppTypes[0]
 };
 
 module.exports = Util.deepFreeze(appScheme);

--- a/src/js/stores/schemes/appScheme.js
+++ b/src/js/stores/schemes/appScheme.js
@@ -29,7 +29,7 @@ const appScheme = {
   tasks: [],
   tasksRunning: 0,
   taskStats: {},
-  type: AppTypes[0]
+  type: AppTypes.DEFAULT
 };
 
 module.exports = Util.deepFreeze(appScheme);

--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -115,6 +115,17 @@ describe("Apps", function () {
         this.server.setup({
           "apps": [{
             id: "/app-1",
+            container: {
+              type: "DOCKER"
+            },
+            tasksHealthy: 2,
+            tasksUnhealthy: 2,
+            tasksRunning: 5,
+            tasksStaged: 2,
+            instances: 10
+          },
+          {
+            id: "/app-2",
             tasksHealthy: 2,
             tasksUnhealthy: 2,
             tasksRunning: 5,
@@ -128,6 +139,17 @@ describe("Apps", function () {
         AppsStore.once(AppsEvents.CHANGE, function () {
           expectAsync(function () {
             expect(AppsStore.apps[0].healthWeight).to.equal(47);
+          }, done);
+        });
+
+        AppsActions.requestApps();
+      });
+
+      it("has the correct app type", function (done) {
+        AppsStore.once(AppsEvents.CHANGE, function () {
+          expectAsync(function () {
+            expect(AppsStore.apps[0].type).to.equal("DOCKER");
+            expect(AppsStore.apps[1].type).to.equal("DEFAULT");
           }, done);
         });
 


### PR DESCRIPTION
Add a ``type`` property to the app scheme and set the app type in the ``AppStore processApp()`` method as proposed in #286.

AC
* [x] Add ``type`` property to the app scheme
* [x] Set app store in the ``AppStore processApp()`` method
* [x] Use the new ``app.type`` property instead of type matching
* [x] Use an ``Object`` instead of an ``Array`` for the app type constants

