### PR TITLE
Fix - 2422 handle apps attribute on HTTP 422

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unversioned
+### Fixed
+- \#2422 - Handle apps error response attribute on HTTP 422
+
 ## 0.12.0 - 2015-10-02
 ### Added
 - \#2244 - Ability to scale an application forcefully if there is a deployment

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -112,6 +112,7 @@ const resolveFieldIdToAppKeyMap = {
  */
 const responseAttributePathToFieldIdMap = {
   "id": "appId",
+  "apps": "appId",
   "/id": "appId",
   "/acceptedResourceRoles": "acceptedResourceRoles",
   "/cmd": "cmd",


### PR DESCRIPTION
This fixes https://github.com/mesosphere/marathon/issues/2422
and https://github.com/mesosphere/marathon/issues/2420

![apps](https://cloud.githubusercontent.com/assets/859154/10458567/afc9baf2-71cb-11e5-8099-a299a8eb37bc.png)
