### PR TITLE
Properly initialize ``toString``

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unversioned
 ### Fixed
+- \#2421 - Error: Invalid calling object (Win 8 IE10, Win 7 IE11)
 - \#2422 - Handle apps error response attribute on HTTP 422
 
 ## 0.12.0 - 2015-10-02

--- a/src/js/helpers/Util.js
+++ b/src/js/helpers/Util.js
@@ -1,8 +1,10 @@
-var consecutiveNumber = 0;
 var objectPath = require("object-path");
+
+var consecutiveNumber = 0;
 // Use ``Object.prototype.toString``, as the *global* ``window.toString``
 // method can't be *call*ed on a different objects in IE.
 var toString = Object.prototype.toString;
+
 var Util = {
   initKeyValue: function (obj, key, value) {
     if (obj[key] === undefined) {

--- a/src/js/helpers/Util.js
+++ b/src/js/helpers/Util.js
@@ -2,7 +2,7 @@ var objectPath = require("object-path");
 
 var consecutiveNumber = 0;
 // Use ``Object.prototype.toString``, as the *global* ``window.toString``
-// method can't be *call*ed on a different objects in IE.
+// method can't be *call*ed on different objects in IE.
 var toString = Object.prototype.toString;
 
 var Util = {

--- a/src/js/helpers/Util.js
+++ b/src/js/helpers/Util.js
@@ -1,6 +1,6 @@
 var consecutiveNumber = 0;
 var objectPath = require("object-path");
-
+var toString = Object.prototype.toString;
 var Util = {
   initKeyValue: function (obj, key, value) {
     if (obj[key] === undefined) {

--- a/src/js/helpers/Util.js
+++ b/src/js/helpers/Util.js
@@ -1,5 +1,7 @@
 var consecutiveNumber = 0;
 var objectPath = require("object-path");
+// Use ``Object.prototype.toString``, as the *global* ``window.toString``
+// method can't be *call*ed on a different objects in IE.
 var toString = Object.prototype.toString;
 var Util = {
   initKeyValue: function (obj, key, value) {


### PR DESCRIPTION
Use ``Object.prototype.toString`` to fix the "Invalid calling object" errors in IE.

Closes #marathon/2421