### PR TITLE
Implement Application List view

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -288,16 +288,6 @@ a,
         text-overflow: ellipsis;
         max-width: @app-list-name-width;
         white-space: nowrap;
-
-        // App/directory icons
-        &:before {
-          color: @link-color;
-          cursor: default;
-          font-family: "Ionicons";
-          height: @base-spacing-unit*2;
-          margin: 0 @base-spacing-unit 0 0;
-          width: @base-spacing-unit*2;
-        }
       }
 
       .labels {
@@ -332,14 +322,6 @@ a,
     .label-loop(@i - 1);
   }
   .label-loop(10);
-
-  .group .name > span:before {
-    content: "\f38a";
-  }
-  .app .name > span:before {
-    // 'android-expand' makes a good placeholder
-    content: "\f386";
-  }
 
 }
 

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -260,6 +260,11 @@ a,
 
   }
 
+  & tr td:first-child,
+  & tr th:first-child
+  {
+    padding-left: @base-spacing-unit*2;
+  }
   /* Cells */
   & > thead > tr > th,
   & > tbody > tr > th,
@@ -283,6 +288,16 @@ a,
         text-overflow: ellipsis;
         max-width: @app-list-name-width;
         white-space: nowrap;
+
+        // App/directory icons
+        &:before {
+          color: @link-color;
+          cursor: default;
+          font-family: "Ionicons";
+          height: @base-spacing-unit*2;
+          margin: 0 @base-spacing-unit 0 0;
+          width: @base-spacing-unit*2;
+        }
       }
 
       .labels {
@@ -317,6 +332,14 @@ a,
     .label-loop(@i - 1);
   }
   .label-loop(10);
+
+  .group .name > span:before {
+    content: "\f38a";
+  }
+  .app .name > span:before {
+    // 'android-expand' makes a good placeholder
+    content: "\f386";
+  }
 
 }
 
@@ -1075,12 +1098,11 @@ fieldset[disabled] .btn-info.active {
 
     main {
       flex: 1;
-      padding-left: @base-spacing-unit*2;
 
       .contextual-bar {
         align-items: center;
         display: flex;
-        padding: @base-spacing-unit*2 0;
+        padding: @base-spacing-unit*2;
 
         .app-list-controls {
           align-items: center;

--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -113,7 +113,7 @@ var AppListComponent = React.createClass({
     });
   },
 
-  getAppsInContext: function () {
+  getAppsInGroup: function () {
     var apps = this.state.apps;
     var currentGroup = this.props.currentGroup;
 
@@ -148,7 +148,7 @@ var AppListComponent = React.createClass({
     var sortKey = state.sortKey;
     var props = this.props;
 
-    var appsSequence = lazy(this.getAppsInContext());
+    var appsSequence = lazy(this.getAppsInGroup());
 
     if (props.filterText != null && props.filterText !== "") {
       appsSequence = appsSequence

--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -33,7 +33,12 @@ function updateGroup(group, app) {
 var AppListComponent = React.createClass({
   displayName: "AppListComponent",
 
+  contextTypes: {
+    router: React.PropTypes.func
+  },
+
   propTypes: {
+    currentGroup: React.PropTypes.string.isRequired,
     filterLabels: React.PropTypes.array,
     filterStatus: React.PropTypes.array,
     filterText: React.PropTypes.string,
@@ -57,7 +62,6 @@ var AppListComponent = React.createClass({
 
     return {
       apps: apps,
-      currentGroup: "/",
       fetchState: fetchState,
       sortKey: "id",
       sortDescending: false
@@ -111,10 +115,7 @@ var AppListComponent = React.createClass({
 
   getAppsInContext: function () {
     var apps = this.state.apps;
-    var currentGroup = this.state.currentGroup;
-    if (!currentGroup.endsWith("/")) {
-      currentGroup += "/";
-    }
+    var currentGroup = this.props.currentGroup;
 
     return lazy(apps)
       .filter((app) => app.id.startsWith(currentGroup))
@@ -192,14 +193,16 @@ var AppListComponent = React.createClass({
     }
 
     return appsSequence
-      .sortBy(function (app) {
+      .sortBy((app) => {
         return app[sortKey];
       }, state.sortDescending)
-      .map(function (app) {
+      .map((app) => {
         switch (props.viewType) {
           case "List":
             return (
-              <AppListItemComponent key={app.id} model={app} />
+              <AppListItemComponent key={app.id}
+                model={app}
+                currentGroup={props.currentGroup} />
             );
           default:
             return null;

--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -11,7 +11,7 @@ var AppsEvents = require("../events/AppsEvents");
 
 var AppListViewTypes = require("../constants/AppListViewTypes");
 
-function createGroup(groupId, app) {
+function initGroupNode(groupId, app) {
   return {
     id: groupId,
     instances: app.instances,
@@ -22,7 +22,7 @@ function createGroup(groupId, app) {
   };
 }
 
-function updateGroup(group, app) {
+function updateGroupNode(group, app) {
   group.instances += app.instances;
   group.tasksRunning += app.tasksRunning;
   group.totalCpus += app.totalCpus;
@@ -113,7 +113,7 @@ var AppListComponent = React.createClass({
     });
   },
 
-  getAppsInGroup: function () {
+  getGroupedNodes: function () {
     var apps = this.state.apps;
     var currentGroup = this.props.currentGroup;
 
@@ -133,10 +133,10 @@ var AppListComponent = React.createClass({
           });
 
           if (group == null) {
-            group = createGroup(groupId, app);
-            memo.unshift(group);
+            group = initGroupNode(groupId, app);
+            memo.push(group);
           } else {
-            updateGroup(group, app);
+            updateGroupNode(group, app);
           }
         }
         return memo;
@@ -148,7 +148,7 @@ var AppListComponent = React.createClass({
     var sortKey = state.sortKey;
     var props = this.props;
 
-    var appsSequence = lazy(this.getAppsInGroup());
+    var appsSequence = lazy(this.getGroupedNodes());
 
     if (props.filterText != null && props.filterText !== "") {
       appsSequence = appsSequence

--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -9,6 +9,8 @@ var AppListItemComponent = require("./AppListItemComponent");
 var AppsStore = require("../stores/AppsStore");
 var AppsEvents = require("../events/AppsEvents");
 
+var ViewTypes = require("../constants/AppListViewTypes");
+
 function createGroup(groupId, app) {
   return {
     id: groupId,
@@ -35,7 +37,14 @@ var AppListComponent = React.createClass({
     filterLabels: React.PropTypes.array,
     filterStatus: React.PropTypes.array,
     filterText: React.PropTypes.string,
-    filterType: React.PropTypes.array
+    filterType: React.PropTypes.array,
+    viewType: React.PropTypes.oneOf(ViewTypes)
+  },
+
+  getDefaultProps: function () {
+    return {
+      viewType: ViewTypes[0]
+    };
   },
 
   getInitialState: function () {
@@ -187,9 +196,14 @@ var AppListComponent = React.createClass({
         return app[sortKey];
       }, state.sortDescending)
       .map(function (app) {
+        switch (props.viewType) {
+          case "List":
             return (
               <AppListItemComponent key={app.id} model={app} />
             );
+          default:
+            return null;
+        }
       })
       .value();
   },

--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -9,7 +9,7 @@ var AppListItemComponent = require("./AppListItemComponent");
 var AppsStore = require("../stores/AppsStore");
 var AppsEvents = require("../events/AppsEvents");
 
-var ViewTypes = require("../constants/AppListViewTypes");
+var AppListViewTypes = require("../constants/AppListViewTypes");
 
 function createGroup(groupId, app) {
   return {
@@ -43,12 +43,12 @@ var AppListComponent = React.createClass({
     filterStatus: React.PropTypes.array,
     filterText: React.PropTypes.string,
     filterType: React.PropTypes.array,
-    viewType: React.PropTypes.oneOf(ViewTypes)
+    viewType: React.PropTypes.oneOf(Object.values(AppListViewTypes))
   },
 
   getDefaultProps: function () {
     return {
-      viewType: ViewTypes[0]
+      viewType: AppListViewTypes.LIST
     };
   },
 
@@ -198,7 +198,7 @@ var AppListComponent = React.createClass({
       }, state.sortDescending)
       .map((app) => {
         switch (props.viewType) {
-          case "List":
+          case AppListViewTypes.LIST:
             return (
               <AppListItemComponent key={app.id}
                 model={app}

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -1,3 +1,4 @@
+var classNames = require("classnames");
 var React = require("react/addons");
 
 var AppHealthComponent = require("../components/AppHealthComponent");
@@ -59,6 +60,10 @@ var AppListItemComponent = React.createClass({
 
   getHealthBar: function () {
     var model = this.props.model;
+    if (model.isGroup) {
+      return null;
+    }
+
     return (
       <td className="text-right health-bar-column">
         <AppHealthComponent model={model} />
@@ -68,6 +73,10 @@ var AppListItemComponent = React.createClass({
 
   getStatus: function () {
     var model = this.props.model;
+    if (model.isGroup) {
+      return null;
+    }
+
     return (
       <td className="text-right status">
         <AppStatusComponent model={model} />
@@ -77,18 +86,12 @@ var AppListItemComponent = React.createClass({
 
   render: function () {
     var model = this.props.model;
-    var status = null;
-    var healthBar = null;
-    var colSpan = 3;
-    var className = "group";
+    var className = classNames({
+      "group": model.isGroup,
+      "app": !model.isGroup
+    });
+    var colSpan = model.isGroup ? 3 : 1;
     var name = ViewHelper.getRelativePath(model.id, this.props.currentGroup);
-
-    if (!model.isGroup) {
-      className = "app";
-      status = this.getStatus();
-      healthBar = this.getHealthBar();
-      colSpan = 1;
-    }
 
     return (
       // Set `title` on cells that potentially overflow so hovering on the
@@ -106,13 +109,13 @@ var AppListItemComponent = React.createClass({
             {`${ViewHelper.convertMegabytesToString(model.totalMem)}`}
           </span>
         </td>
-        {status}
+        {this.getStatus()}
         <td className="text-right running tasks" colSpan={colSpan}>
           <span>
             {model.tasksRunning}
           </span> of {model.instances}
         </td>
-        {healthBar}
+        {this.getHealthBar()}
         <td className="text-right actions">&hellip;</td>
       </tr>
     );

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -49,12 +49,11 @@ var AppListItemComponent = React.createClass({
 
   onClick: function () {
     var model = this.props.model;
+    var router = this.context.router;
     if (model.isGroup) {
-      this.context.router
-        .transitionTo("group", {groupId: encodeURIComponent(model.id)});
+      router.transitionTo("group", {groupId: encodeURIComponent(model.id)});
     } else {
-      this.context.router
-        .transitionTo("app", {appId: encodeURIComponent(model.id)});
+      router.transitionTo("app", {appId: encodeURIComponent(model.id)});
     }
   },
 

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -5,8 +5,8 @@ var AppStatusComponent = require("../components/AppStatusComponent");
 var Util = require("../helpers/Util");
 var ViewHelper = require("../helpers/ViewHelper");
 
-var AppComponent = React.createClass({
-  displayName: "AppComponent",
+var AppListItemComponent = React.createClass({
+  displayName: "AppListItemComponent",
 
   contextTypes: {
     router: React.PropTypes.func
@@ -51,12 +51,42 @@ var AppComponent = React.createClass({
       .transitionTo("app", {appId: encodeURIComponent(this.props.model.id)});
   },
 
+  getHealthBar: function () {
+    var model = this.props.model;
+    return (
+      <td className="text-right health-bar-column">
+        <AppHealthComponent model={model} />
+      </td>
+    );
+  },
+
+  getStatus: function () {
+    var model = this.props.model;
+    return (
+      <td className="text-right status">
+        <AppStatusComponent model={model} />
+      </td>
+    );
+  },
+
   render: function () {
     var model = this.props.model;
+    var status = null;
+    var healthBar = null;
+    var colSpan = 3;
+    var className = "group";
+
+    if (model.isGroup !== true) {
+      className = "app";
+      status = this.getStatus();
+      healthBar = this.getHealthBar();
+      colSpan = 1;
+    }
+
     return (
       // Set `title` on cells that potentially overflow so hovering on the
       // cells will reveal their full contents.
-      <tr onClick={this.onClick}>
+      <tr onClick={this.onClick} className={className}>
         <td className="overflow-ellipsis name" title={model.id}>
           <span>{model.id}</span>
           {this.getLabels()}
@@ -69,21 +99,17 @@ var AppComponent = React.createClass({
             {`${ViewHelper.convertMegabytesToString(model.totalMem)}`}
           </span>
         </td>
-        <td className="text-right status">
-          <AppStatusComponent model={model} />
-        </td>
-        <td className="text-right running tasks">
+        {status}
+        <td className="text-right running tasks" colSpan={colSpan}>
           <span>
             {model.tasksRunning}
           </span> of {model.instances}
         </td>
-        <td className="text-right health-bar-column">
-          <AppHealthComponent model={model} />
-        </td>
+        {healthBar}
         <td className="text-right actions">&hellip;</td>
       </tr>
     );
   }
 });
 
-module.exports = AppComponent;
+module.exports = AppListItemComponent;

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -83,7 +83,7 @@ var AppListItemComponent = React.createClass({
     var className = "group";
     var name = ViewHelper.getRelativePath(model.id, this.props.currentGroup);
 
-    if (model.isGroup !== true) {
+    if (!model.isGroup) {
       className = "app";
       status = this.getStatus();
       healthBar = this.getHealthBar();

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -13,6 +13,7 @@ var AppListItemComponent = React.createClass({
   },
 
   propTypes: {
+    currentGroup: React.PropTypes.string.isRequired,
     model: React.PropTypes.object.isRequired
   },
 
@@ -47,8 +48,14 @@ var AppListItemComponent = React.createClass({
   },
 
   onClick: function () {
-    this.context.router
-      .transitionTo("app", {appId: encodeURIComponent(this.props.model.id)});
+    var model = this.props.model;
+    if (model.isGroup) {
+      this.context.router
+        .transitionTo("group", {groupId: encodeURIComponent(model.id)});
+    } else {
+      this.context.router
+        .transitionTo("app", {appId: encodeURIComponent(model.id)});
+    }
   },
 
   getHealthBar: function () {
@@ -75,6 +82,7 @@ var AppListItemComponent = React.createClass({
     var healthBar = null;
     var colSpan = 3;
     var className = "group";
+    var name = ViewHelper.getRelativePath(model.id, this.props.currentGroup);
 
     if (model.isGroup !== true) {
       className = "app";
@@ -88,7 +96,7 @@ var AppListItemComponent = React.createClass({
       // cells will reveal their full contents.
       <tr onClick={this.onClick} className={className}>
         <td className="overflow-ellipsis name" title={model.id}>
-          <span>{model.id}</span>
+          <span>{name}</span>
           {this.getLabels()}
         </td>
         <td className="text-right total cpu">

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -92,7 +92,7 @@ var AppListItemComponent = React.createClass({
           {this.getLabels()}
         </td>
         <td className="text-right total cpu">
-          {model.totalCpus}
+          {parseFloat(model.totalCpus).toFixed(1)}
         </td>
         <td className="text-right total ram">
           <span title={`${model.totalMem}MB`}>

--- a/src/js/components/TabPanesComponent.jsx
+++ b/src/js/components/TabPanesComponent.jsx
@@ -25,11 +25,27 @@ var TabPanesComponent = React.createClass({
 
   getInitialState: function () {
     return {
+      currentGroup: "/",
       filterText: "",
       filterLabels: [],
       filterStatus: [],
       filterTypes: []
     };
+  },
+
+  componentWillReceiveProps: function () {
+    var {groupId} = this.context.router.getCurrentParams();
+    if (groupId == null) {
+      groupId = "/";
+    }
+    groupId = decodeURIComponent(groupId);
+    if (!groupId.endsWith("/")) {
+      groupId += "/";
+    }
+
+    this.setState({
+      currentGroup: groupId
+    });
   },
 
   updateFilterText: function (filterText) {
@@ -70,6 +86,15 @@ var TabPanesComponent = React.createClass({
 
   render: function () {
     var path = this.context.router.getCurrentPathname();
+    var state = this.state;
+
+    var appListProps = {
+      currentGroup: state.currentGroup,
+      filterText: state.filterText,
+      filterLabels: state.filterLabels,
+      filterTypes: state.filterTypes,
+      filterStatus: state.filterStatus
+    };
 
     return (
       <TogglableTabsComponent activeTabId={this.getTabId()}
@@ -144,10 +169,7 @@ var TabPanesComponent = React.createClass({
                   </div>
                 </div>
               </div>
-              <AppListComponent filterText={this.state.filterText}
-                filterLabels={this.state.filterLabels}
-                filterTypes={this.state.filterTypes}
-                filterStatus={this.state.filterStatus} />
+              <AppListComponent {...appListProps} />
             </main>
           </div>
         </TabPaneComponent>

--- a/src/js/components/TabPanesComponent.jsx
+++ b/src/js/components/TabPanesComponent.jsx
@@ -35,6 +35,14 @@ var TabPanesComponent = React.createClass({
   },
 
   componentWillReceiveProps: function () {
+    this.updateCurrentGroup();
+  },
+
+  componentWillMount: function () {
+    this.updateCurrentGroup();
+  },
+
+  updateCurrentGroup: function () {
     var {groupId} = this.context.router.getCurrentParams();
     if (groupId == null) {
       groupId = "/";

--- a/src/js/components/TabPanesComponent.jsx
+++ b/src/js/components/TabPanesComponent.jsx
@@ -13,6 +13,7 @@ var DeploymentsListComponent =
   require("../components/DeploymentsListComponent");
 var TabPaneComponent = require("../components/TabPaneComponent");
 var TogglableTabsComponent = require("../components/TogglableTabsComponent");
+var AppListViewTypes = require("../constants/AppListViewTypes");
 
 var tabs = require("../constants/tabs");
 
@@ -93,7 +94,8 @@ var TabPanesComponent = React.createClass({
       filterText: state.filterText,
       filterLabels: state.filterLabels,
       filterTypes: state.filterTypes,
-      filterStatus: state.filterStatus
+      filterStatus: state.filterStatus,
+      viewType: AppListViewTypes.LIST
     };
 
     return (

--- a/src/js/constants/AppListViewTypes.js
+++ b/src/js/constants/AppListViewTypes.js
@@ -1,1 +1,6 @@
-export default ["List", "Tree"];
+const AppListViewTypes = {
+  LIST: "List",
+  TREE: "Tree"
+};
+
+module.exports = Object.freeze(AppListViewTypes);

--- a/src/js/constants/AppListViewTypes.js
+++ b/src/js/constants/AppListViewTypes.js
@@ -1,0 +1,1 @@
+export default ["List", "Tree"];

--- a/src/js/helpers/ViewHelper.js
+++ b/src/js/helpers/ViewHelper.js
@@ -11,6 +11,12 @@ var ViewHelpers = {
       value = Math.round(megabytes / Math.pow(factor, index));
     }
     return `${value}${units[index]}`;
+  },
+  getRelativePath(id, currentGroup) {
+    if (!currentGroup.endsWith("/")) {
+      currentGroup += "/";
+    }
+    return id.substring(currentGroup.length);
   }
 };
 

--- a/src/js/main.jsx
+++ b/src/js/main.jsx
@@ -13,6 +13,7 @@ var Marathon = require("./components/Marathon");
 var routes = (
   <Route name="home" path="/" handler={Marathon}>
     <Route name="apps" path="apps" handler={TabPanesComponent} />
+    <Route name="group" path="group/:groupId" handler={TabPanesComponent} />
     <Route name="app" path="apps/:appId" handler={AppPageComponent} />
     <Route name="appView" path="apps/:appId/:view" handler={AppPageComponent} />
     <Route name="deployments" path="deployments" handler={TabPanesComponent} />

--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -755,7 +755,7 @@ describe("App component", function () {
       mem: 100,
       totalMem: 1030,
       cpus: 4,
-      totalCpus: 20,
+      totalCpus: 20.0000001,
       status: 0
     };
     this.renderer = TestUtils.createRenderer();
@@ -774,7 +774,7 @@ describe("App component", function () {
 
   it("has the correct amount of total cpus", function () {
     var cellContent = this.component.props.children[1].props.children;
-    expect(cellContent).to.equal(20);
+    expect(cellContent).to.equal("20.0");
   });
 
   it("has the correct amount of total memory", function () {

--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -18,7 +18,9 @@ TooltipMixin.getNewTooltip = _.noop;
 TooltipMixin.tip_destroyAllTips = _.noop;
 
 var AppsActions = require("../js/actions/AppsActions");
-var AppComponent = require("../js/components/AppComponent");
+var AppDispatcher = require("../js/AppDispatcher");
+var AppListComponent = require("../js/components/AppListComponent");
+var AppListItemComponent = require("../js/components/AppListItemComponent");
 var AppHealthComponent = require("../js/components/AppHealthComponent");
 var AppPageComponent = require("../js/components/AppPageComponent");
 var AppStatusComponent = require("../js/components/AppStatusComponent");
@@ -701,6 +703,47 @@ describe("Apps", function () {
 
 });
 
+describe("Groups", function () {
+
+  beforeEach(function () {
+    var apps = [
+      {id: "/app-1", instances: 1, mem: 16, cpus: 1},
+      {id: "/app-2", instances: 1, mem: 16, cpus: 1},
+      {id: "/group-1/app-3", instances: 1, mem: 16, cpus: 1},
+      {id: "/group-1/app-4", instances: 1, mem: 16, cpus: 1},
+      {id: "/group-2/app-5", instances: 1, mem: 16, cpus: 1},
+      {id: "/group-2/app-6", instances: 1, mem: 16, cpus: 1},
+      {id: "/group-1/group-3/app-7", instances: 1, mem: 16, cpus: 1},
+      {id: "/group-1/group-3/app-8", instances: 1, mem: 16, cpus: 1}
+    ];
+
+    AppDispatcher.dispatch({
+      actionType: AppsEvents.REQUEST_APPS,
+      data: {body: {apps: apps}}
+    });
+
+    this.renderer = TestUtils.createRenderer();
+    this.renderer.render(<AppListComponent />);
+    this.component = this.renderer.getRenderOutput();
+
+    var tbody = this.component.props.children[2];
+    var trs = tbody.props.children;
+    this.appNodes = trs[trs.length - 1];
+  });
+
+  afterEach(function () {
+    this.renderer.unmount();
+  });
+
+  it("are extrapolated from app IDs", function () {
+    var appNodeKeys = this.appNodes.map((app) => app.key);
+    expect(appNodeKeys).to.deep.equal([
+      "/app-1", "/app-2", "/group-1", "/group-2"
+    ]);
+  });
+
+});
+
 describe("App component", function () {
 
   beforeEach(function () {
@@ -716,7 +759,7 @@ describe("App component", function () {
       status: 0
     };
     this.renderer = TestUtils.createRenderer();
-    this.renderer.render(<AppComponent model={model} />);
+    this.renderer.render(<AppListItemComponent model={model} />);
     this.component = this.renderer.getRenderOutput();
   });
 

--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -723,12 +723,6 @@ describe("Groups", function () {
     });
 
     this.renderer = TestUtils.createRenderer();
-    this.renderer.render(<AppListComponent />);
-    this.component = this.renderer.getRenderOutput();
-
-    var tbody = this.component.props.children[2];
-    var trs = tbody.props.children;
-    this.appNodes = trs[trs.length - 1];
   });
 
   afterEach(function () {
@@ -736,9 +730,28 @@ describe("Groups", function () {
   });
 
   it("are extrapolated from app IDs", function () {
+    this.renderer.render(<AppListComponent currentGroup="/" />);
+    this.component = this.renderer.getRenderOutput();
+    var tbody = this.component.props.children[2];
+    var trs = tbody.props.children;
+    this.appNodes = trs[trs.length - 1];
+
     var appNodeKeys = this.appNodes.map((app) => app.key);
     expect(appNodeKeys).to.deep.equal([
       "/app-1", "/app-2", "/group-1", "/group-2"
+    ]);
+  });
+
+  it("correctly renders in group context", function () {
+    this.renderer.render(<AppListComponent currentGroup="/group-1/" />);
+    this.component = this.renderer.getRenderOutput();
+    var tbody = this.component.props.children[2];
+    var trs = tbody.props.children;
+    this.appNodes = trs[trs.length - 1];
+
+    var appNodeKeys = this.appNodes.map((app) => app.key);
+    expect(appNodeKeys).to.deep.equal([
+      "/group-1/app-3", "/group-1/app-4", "/group-1/group-3"
     ]);
   });
 
@@ -748,7 +761,7 @@ describe("App component", function () {
 
   beforeEach(function () {
     var model = {
-      id: "app-123",
+      id: "/app-123",
       deployments: [],
       tasksRunning: 4,
       instances: 5,
@@ -759,7 +772,9 @@ describe("App component", function () {
       status: 0
     };
     this.renderer = TestUtils.createRenderer();
-    this.renderer.render(<AppListItemComponent model={model} />);
+    this.renderer.render(
+      <AppListItemComponent model={model} currentGroup="/" />
+    );
     this.component = this.renderer.getRenderOutput();
   });
 

--- a/src/test/viewHelper.test.js
+++ b/src/test/viewHelper.test.js
@@ -30,4 +30,10 @@ describe("ViewHelper", function () {
     });
 
   });
+  describe("getRelativePath", function () {
+    it("trims initial group from app names", function () {
+      expect(ViewHelper.getRelativePath("/test/group/app", "/test/group"))
+        .to.equal("app");
+    });
+  });
 });


### PR DESCRIPTION
This implements the App List View.

It introduces a new `groups` route, which is necessary because React Router 0.13 does not support dynamic routes. We should obviously get back to this once we upgrade.

GIF for reference :

Notes: 
1. `minecraft` and `test` are two groups. `test/group` is a subgroup 
2. see how the URL changes

![groupies](https://cloud.githubusercontent.com/assets/1078545/10488878/06a76ca0-729b-11e5-81cd-549434542674.gif)