### PR TITLE
Rhabarber/refactor filesize conversion

### DIFF
--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -4,6 +4,7 @@ var React = require("react/addons");
 var AppHealthComponent = require("../components/AppHealthComponent");
 var AppStatusComponent = require("../components/AppStatusComponent");
 var Util = require("../helpers/Util");
+var ViewHelper = require("../helpers/ViewHelper");
 
 var AppListItemComponent = React.createClass({
   displayName: "AppListItemComponent",

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -4,7 +4,6 @@ var React = require("react/addons");
 var AppHealthComponent = require("../components/AppHealthComponent");
 var AppStatusComponent = require("../components/AppStatusComponent");
 var Util = require("../helpers/Util");
-var ViewHelper = require("../helpers/ViewHelper");
 
 var AppListItemComponent = React.createClass({
   displayName: "AppListItemComponent",
@@ -105,8 +104,8 @@ var AppListItemComponent = React.createClass({
           {parseFloat(model.totalCpus).toFixed(1)}
         </td>
         <td className="text-right total ram">
-          <span title={`${model.totalMem}MB`}>
-            {`${ViewHelper.convertMegabytesToString(model.totalMem)}`}
+          <span title={`${model.totalMem} MiB`}>
+            {`${Util.filesize(model.totalMem * Math.pow(1024, 2))}`}
           </span>
         </td>
         {this.getStatus()}

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -105,7 +105,7 @@ var AppListItemComponent = React.createClass({
         </td>
         <td className="text-right total ram">
           <span title={`${model.totalMem} MiB`}>
-            {`${Util.filesize(model.totalMem * Math.pow(1024, 2))}`}
+            {`${Util.filesize(model.totalMem * Math.pow(1024, 2), 0)}`}
           </span>
         </td>
         {this.getStatus()}

--- a/src/js/helpers/Util.js
+++ b/src/js/helpers/Util.js
@@ -88,6 +88,43 @@ var Util = {
     }
 
     return obj;
+  },
+  filesize: function (size, decimals, threshold, multiplier, units) {
+    size = size || 0;
+    if (decimals == null) {
+      decimals = 2;
+    }
+    threshold = threshold || 800; // Steps to next unit if exceeded
+    multiplier = multiplier || 1024;
+    units = units || ["B", "KiB", "MiB", "GiB", "TiB", "PiB"];
+
+    var factorize = 1;
+    var unitIndex;
+
+    for (unitIndex = 0; unitIndex < units.length; unitIndex++) {
+      if (unitIndex > 0) {
+        factorize = Math.pow(multiplier, unitIndex);
+      }
+
+      if (size < multiplier * factorize && size < threshold * factorize) {
+        break;
+      }
+    }
+
+    if (unitIndex >= units.length) {
+      unitIndex = units.length - 1;
+    }
+
+    var filesize = size / factorize;
+
+    filesize = filesize.toFixed(decimals);
+
+    // This removes unnecessary 0 or . chars at the end of the string/decimals
+    if (filesize.indexOf(".") > -1) {
+      filesize = filesize.replace(/\.?0*$/, "");
+    }
+
+    return filesize + " " + units[unitIndex];
   }
 };
 

--- a/src/js/helpers/Util.js
+++ b/src/js/helpers/Util.js
@@ -89,8 +89,8 @@ var Util = {
 
     return obj;
   },
-  filesize: function (size, decimals, threshold, multiplier, units) {
-    size = size || 0;
+  filesize: function (bytes, decimals, threshold, multiplier, units) {
+    bytes = bytes || 0;
     if (decimals == null) {
       decimals = 2;
     }
@@ -106,7 +106,7 @@ var Util = {
         factorize = Math.pow(multiplier, unitIndex);
       }
 
-      if (size < multiplier * factorize && size < threshold * factorize) {
+      if (bytes < multiplier * factorize && bytes < threshold * factorize) {
         break;
       }
     }
@@ -115,7 +115,7 @@ var Util = {
       unitIndex = units.length - 1;
     }
 
-    var filesize = size / factorize;
+    var filesize = bytes / factorize;
 
     filesize = filesize.toFixed(decimals);
 

--- a/src/js/helpers/ViewHelper.js
+++ b/src/js/helpers/ViewHelper.js
@@ -1,17 +1,4 @@
 var ViewHelpers = {
-  convertMegabytesToString(megabytes) {
-    // For a documentation of the different unit prefixes please refer to:
-    // https://en.wikipedia.org/wiki/Template:Quantities_of_bytes
-    var units = ["MB", "GB", "TiB", "PiB", "EiB", "ZiB", "YiB"];
-    var factor = 1024;
-    var value = 0;
-    var index = 0;
-    if (megabytes > 0) {
-      index = Math.floor(Math.log(megabytes) / Math.log(factor));
-      value = Math.round(megabytes / Math.pow(factor, index));
-    }
-    return `${value}${units[index]}`;
-  },
   getRelativePath(id, currentGroup) {
     if (!currentGroup.endsWith("/")) {
       currentGroup += "/";

--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -794,12 +794,12 @@ describe("App component", function () {
 
   it("has the correct amount of total memory", function () {
     var cellContent = this.component.props.children[2].props.children.props.title;
-    expect(cellContent).to.equal("1030MB");
+    expect(cellContent).to.equal("1030 MiB");
   });
 
   it("displays the correct amount memory", function () {
     var cellContent = this.component.props.children[2].props.children.props.children;
-    expect(cellContent).to.equal("1GB");
+    expect(cellContent).to.equal("1 GiB");
   });
 
   it("has correct number of tasks running", function () {

--- a/src/test/util.test.js
+++ b/src/test/util.test.js
@@ -280,4 +280,94 @@ describe("Util", function () {
     });
 
   });
+
+  describe("filesize", function () {
+    beforeEach(function () {
+      this.baseSize = 796;
+    });
+
+    // Regular tests
+    it("should convert to correct unit of B", function () {
+      expect(Util.filesize(this.baseSize)).to.equal("796 B");
+    });
+
+    it("should convert to correct unit of KiB", function () {
+      expect(Util.filesize(this.baseSize * 1024)).to.equal("796 KiB");
+    });
+
+    it("should convert to correct unit of MiB", function () {
+      var factorize = Math.pow(1024, 2);
+      expect(Util.filesize(this.baseSize * factorize)).to.equal("796 MiB");
+    });
+
+    it("should convert to correct unit of GiB", function () {
+      var factorize = Math.pow(1024, 3);
+      expect(Util.filesize(this.baseSize * factorize)).to.equal("796 GiB");
+    });
+
+    it("should convert to correct unit of PiB", function () {
+      var factorize = Math.pow(1024, 5);
+      expect(Util.filesize(this.baseSize * factorize)).to.equal("796 PiB");
+    });
+
+    it("should convert to correct unit of large PiB", function () {
+      var factorize = Math.pow(1024, 6);
+      expect(Util.filesize(this.baseSize * factorize)).to.equal("815104 PiB");
+    });
+
+    it("should convert to correct unit of MiB", function () {
+      expect(Util.filesize((this.baseSize + 108) * 1024)).to.equal("0.88 MiB");
+    });
+
+    it("should convert to correct unit of GiB", function () {
+      var factorize = Math.pow(1024, 2);
+      expect(Util.filesize((this.baseSize + 128) * factorize)).to.equal("0.9 GiB");
+    });
+
+    it("should convert to correct unit of TiB", function () {
+      var factorize = Math.pow(1024, 3);
+      expect(Util.filesize((this.baseSize + 158) * factorize)).to.equal("0.93 TiB");
+    });
+
+    it("should convert to correct unit of PiB", function () {
+      var factorize = Math.pow(1024, 5);
+      expect(Util.filesize((this.baseSize + 230) * factorize)).to.equal("1026 PiB");
+    });
+
+    // Special tests
+    it("should return '0 B' for vales of zero", function () {
+      expect(Util.filesize(0, 0)).to.equal("0 B");
+    });
+
+    it("does not show decimals if set to 0", function () {
+      var size = (this.baseSize + 352) * 1024;
+      var filesize = Util.filesize(size, 0, 1024);
+      expect(filesize).to.equal("1 MiB");
+    });
+
+    it("trims trailing zeroes from the mantissa", function () {
+      var size = (this.baseSize + 102) * 1024;
+      var filesize = Util.filesize(size, 4);
+      expect(filesize).to.equal("0.877 MiB");
+    });
+
+    it("shows decimals places to the specified accuracy", function () {
+      var size = (this.baseSize + 116) * 1024;
+      var filesize = Util.filesize(size, 4);
+      expect(filesize).to.equal("0.8906 MiB");
+    });
+
+    it("has correct custom unit and threshold", function () {
+      var size = (this.baseSize + 24) * 1024 * 1024;
+      var filesize = Util.filesize(size, 2, 500, 1024, ["byte", "KB", "MB", "GB"]);
+      expect(filesize).to.equal("0.8 GB");
+    });
+
+    it("has correct amount of 0 digits", function () {
+      var size = 1000 * 1024;
+      var filesize = Util.filesize(size, 2, 1024);
+      expect(filesize).to.equal("1000 KiB");
+    });
+
+  });
 });

--- a/src/test/viewHelper.test.js
+++ b/src/test/viewHelper.test.js
@@ -2,34 +2,6 @@ var expect = require("chai").expect;
 var ViewHelper = require("../js/helpers/ViewHelper");
 
 describe("ViewHelper", function () {
-
-  describe("convertMegabytesToString", function () {
-
-    it("appends the correct unit for megabytes", function () {
-      expect(ViewHelper.convertMegabytesToString(100)).to.equal("100MB");
-    });
-
-    it("appends the correct unit for gigabytes", function () {
-      expect(ViewHelper.convertMegabytesToString(1040)).to.equal("1GB");
-    });
-
-    it("appends the correct unit for tebibyte", function () {
-      expect(ViewHelper.convertMegabytesToString(1064960)).to.equal("1TiB");
-    });
-
-    it("handles 0 values correctly", function () {
-      expect(ViewHelper.convertMegabytesToString(0)).to.equal("0MB");
-    });
-
-    it("handles null values correctly", function () {
-      expect(ViewHelper.convertMegabytesToString(null)).to.equal("0MB");
-    });
-
-    it("handles undefined values correctly", function () {
-      expect(ViewHelper.convertMegabytesToString(undefined)).to.equal("0MB");
-    });
-
-  });
   describe("getRelativePath", function () {
     it("trims initial group from app names", function () {
       expect(ViewHelper.getRelativePath("/test/group/app", "/test/group"))


### PR DESCRIPTION
Add a new ``Util.filesize`` function, as discussed with @aldipower, to replace the current ``ViewHelper.convertMegabytesToString``, which seems to have problems with values smaller than 1 MiB.  ``Util.filesize`` will use only the [IEC](https://en.wikipedia.org/wiki/Template:Quantities_of_bytes) units by default, wich is proably better as it more consistent but needs to be discussed with the design guys.

**AC**
* [x] Add new ``Util.filesize`` function
* [x] Refactor ``AppComponent`` using the new ``filesize`` function 
* [x] Remove the unused ``ViewHelper``