### PR TITLE
Remove activeClassName with null

### DIFF
--- a/src/js/components/TabPanesComponent.jsx
+++ b/src/js/components/TabPanesComponent.jsx
@@ -79,7 +79,6 @@ var TabPanesComponent = React.createClass({
             <nav className="sidebar">
               <Link to={path}
                 query={{modal: "new-app"}}
-                activeClassName={null}
                 className="btn btn-success">
                 Create
               </Link>


### PR DESCRIPTION
Not sure about the intention, but it leads to this warning:
```
Warning: Failed propType: Required prop `activeClassName` was not specified in `Link`. Check the render method of `TabPanesComponent`.
```