### PR TITLE
Collapsing breadcrumbs

### DIFF
--- a/src/js/components/BreadcrumbComponent.jsx
+++ b/src/js/components/BreadcrumbComponent.jsx
@@ -1,6 +1,8 @@
+var _ = require("underscore");
 var React = require("react/addons");
 var Link = require("react-router").Link;
 
+var CollapsibleLinkComponent = require("./CollapsibleLinkComponent");
 var PathUtil = require("../helpers/PathUtil");
 
 var BreadcrumbComponent = React.createClass({
@@ -12,13 +14,78 @@ var BreadcrumbComponent = React.createClass({
     taskId: React.PropTypes.string
   },
 
+  getInitialState: function () {
+    return {
+      collapsed: false
+    };
+  },
+
+  componentDidMount: function () {
+    // Avoid referencing window from Node context
+    if (global.window != null) {
+      window.addEventListener("resize", this.handleResize);
+    }
+    this.handleResize();
+  },
+
+  componentDidUpdate: function () {
+    this.measureOffsetWidth();
+    this.measureInnerWidth();
+  },
+
+  componentWillUnmount: function () {
+    if (global.window != null) {
+      window.removeEventListener("resize", this.handleResize);
+    }
+  },
+
   shouldComponentUpdate: function (nextProps) {
+    var state = this.state;
+    if (state.innerWidth == null || state.offsetWidth == null) {
+      this.measureOffsetWidth();
+      this.measureInnerWidth();
+    }
+    var collapsed = state.innerWidth > state.offsetWidth;
+    if (collapsed !== state.collapsed) {
+      this.setState({collapsed: collapsed});
+      return true;
+    }
+    return this.didPropsChange(nextProps);
+  },
+
+  didPropsChange: function (nextProps) {
     return nextProps.appId !== this.props.appId ||
       nextProps.groupId !== this.props.groupId ||
       nextProps.taskId !== this.props.taskId;
   },
 
-  getGroupLinks: function () {
+  handleResize: _.debounce(function () {
+    this.measureOffsetWidth();
+  }, 50),
+
+  measureOffsetWidth: function () {
+    var domNode = this.getDOMNode();
+    this.setState({
+      offsetWidth: domNode.offsetWidth
+    });
+  },
+
+  measureInnerWidth: function () {
+    if (this.state.collapsed) {
+      return;
+    }
+    var domNode = this.getDOMNode();
+    var listItems = domNode.children;
+    var innerWidth = Object.values(listItems)
+      .map((item) => item.offsetWidth)
+      .reduce((memo, width) => memo + width, 0);
+
+    this.setState({
+      innerWidth: innerWidth
+    });
+  },
+
+  getGroupLinks: function (collapse, collapseLast) {
     var groupId = this.props.groupId;
     if (groupId == null) {
       return null;
@@ -27,11 +94,18 @@ var BreadcrumbComponent = React.createClass({
     var pathParts = groupId.split("/").slice(0, -1);
     return pathParts.map((name, i) => {
       var id = pathParts.slice(0, i + 1).join("/") + "/";
+      var isLast = i === pathParts.length - 1;
+      var collapseLink = isLast
+        ? collapse && collapseLast
+        : collapse;
+
       return (
         <li key={id}>
-          <Link to="group" params={{groupId: encodeURIComponent(id)}}>
+          <CollapsibleLinkComponent to="group"
+              params={{groupId: encodeURIComponent(id)}}
+              collapse={collapseLink}>
             {name}
-          </Link>
+          </CollapsibleLinkComponent>
         </li>
       );
     }).slice(1);
@@ -76,12 +150,15 @@ var BreadcrumbComponent = React.createClass({
   },
 
   render: function () {
+    var state = this.state;
+    var collapseLastGroup = state.app != null || state.task != null;
+
     return (
       <ol className="breadcrumb">
         <li>
           <Link to="apps">Applications</Link>
         </li>
-        {this.getGroupLinks()}
+        {this.getGroupLinks(state.collapsed, collapseLastGroup)}
         {this.getAppLink()}
         {this.getTaskLink()}
       </ol>

--- a/src/js/components/CollapsibleLinkComponent.jsx
+++ b/src/js/components/CollapsibleLinkComponent.jsx
@@ -1,0 +1,30 @@
+var React = require("react/addons");
+var Link = require("react-router").Link;
+
+var CollapsibleLinkComponent = React.createClass({
+  displayName: "CollapsibleLinkComponent",
+
+  propTypes: {
+    collapse: React.PropTypes.bool
+  },
+
+  defaultProps: {
+    activeClassName: "active"
+  },
+
+  render: function () {
+    var props = Object.assign({}, this.props);
+    var child = props.collapse
+      ? <span title={props.children}>...</span>
+      : props.children;
+
+    return (
+      <Link {...props}>
+        {child}
+      </Link>
+    );
+  }
+
+});
+
+module.exports = CollapsibleLinkComponent;


### PR DESCRIPTION
A tentative PR, as this functionality has some issues and I'm not sure it's yet good enough to merge. 

The breadcrumbs now collapse to ellipsis when the user manipulates the window size in the usual 'is it responsive' test. More usefully, they render as ellipsis when the path is too long to fit. 

The drawback is that when the user uses the breadcrumbs to navigate to parent groups, the breadcrumb component cannot gauge whether they can render in the available space without performing that render step. That is to say, having collapsed the breadcrumbs, it's hard to expand them. 

Without a pure CSS solution (I was not able to find one that was satisfactory) and without resorting to funky text-width heuristics, this is hard to resolve elegantly. The only alternative I could work out was to maintain an `visibility: hidden` set of text elements in the DOM to track the inner width of the breadcrumbs, but this is a brutal way of going about it and I reverted that work. 