### PR TITLE
Fix - button sizes

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -69,7 +69,6 @@ a:focus {
 
 .btn {
   transition: all 0.2s ease-in-out;
-  padding: @base-font-size*0.5 @base-spacing-unit*2;
 }
 
 .caret {
@@ -522,6 +521,12 @@ a:focus {
 
 .btn-sm {
   padding: 5px 14px;
+}
+
+.btn-lg {
+  padding: @base-font-size*0.5 @base-spacing-unit*2;
+  font-size: @base-font-size;
+  border-radius: @base-spacing-unit*0.5;
 }
 
 .btn-link {

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -348,7 +348,7 @@ var AppPageComponent = React.createClass({
     }
 
     return (
-      <button className="btn btn-sm btn-default pull-right"
+      <button className="btn btn-lg btn-default"
           onClick={this.handleResetDelay}>
         Reset Delay
       </button>
@@ -364,18 +364,21 @@ var AppPageComponent = React.createClass({
 
     return (
       <div className="header-btn">
-        <button className="btn btn-success" onClick={this.handleScaleApp}>
+        <button className="btn btn-lg btn-success"
+            onClick={this.handleScaleApp}>
           Scale Application
         </button>
-        <button className="btn btn-default" onClick={this.handleRestartApp}>
+        <button className="btn btn-lg btn-default"
+            onClick={this.handleRestartApp}>
           Restart
         </button>
-        <button className="btn btn-default"
+        <button className="btn btn-lg btn-default"
             onClick={this.handleSuspendApp}
             disabled={state.app.instances < 1}>
           Suspend
         </button>
-        <button className="btn btn-danger" onClick={this.handleDestroyApp}>
+        <button className="btn btn-lg btn-danger"
+            onClick={this.handleDestroyApp}>
           Destroy
         </button>
         {this.getResetDelayButton()}


### PR DESCRIPTION
Bootstrap button size were overriden by accident before.

Before:
![b-before](https://cloud.githubusercontent.com/assets/859154/10577146/f0deabfa-7668-11e5-86c8-54ee0df8b447.png)

After:
![b-after](https://cloud.githubusercontent.com/assets/859154/10577147/f2d77d42-7668-11e5-8348-2b2877370057.png)

The buttons on the app page didn't changed visually.