### PR TITLE
Collapsing breadcrumbs V2

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1323,6 +1323,7 @@ fieldset[disabled] .btn-info.active {
 
     a {
       color: @link-color;
+      white-space: nowrap;
 
       &:hover {
         color: darken(@link-color, 40%);

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1240,7 +1240,7 @@ fieldset[disabled] .btn-info.active {
           overflow-x: hidden;
 
           li {
-            line-height: @font-size-h2;
+            line-height: @font-size-h2 + @base-spacing-unit;
           }
         }
       }
@@ -1324,6 +1324,7 @@ fieldset[disabled] .btn-info.active {
     a {
       color: @link-color;
       white-space: nowrap;
+      overflow: hidden;
 
       &:hover {
         color: darken(@link-color, 40%);
@@ -1337,7 +1338,6 @@ fieldset[disabled] .btn-info.active {
         content: "...";
         width: 0.75em;
       }
-      overflow: hidden;
       width: 0.75em;
     }
     li:first-child,

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1220,16 +1220,11 @@ fieldset[disabled] .btn-info.active {
       flex: 1;
 
       .contextual-bar {
-        align-items: center;
         display: flex;
         padding: @base-spacing-unit*2;
 
         .app-list-controls {
-          align-items: center;
           display: flex;
-          flex-direction: row;
-          flex: 1;
-          justify-content: flex-end;
 
           .toggle-list-view {
             margin-left: @base-spacing-unit*2;

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1305,6 +1305,7 @@ fieldset[disabled] .btn-info.active {
       margin: 0 0 0 @base-spacing-unit;
       width: @base-spacing-unit*2;
       vertical-align: baseline;
+      display: inline-block;
     }
 
     &:last-child {

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1315,6 +1315,9 @@ fieldset[disabled] .btn-info.active {
       a {
         color: darken(@link-color, 40%);
         cursor: default;
+        &::before {
+          content: "";
+        }
       }
     }
 
@@ -1323,6 +1326,27 @@ fieldset[disabled] .btn-info.active {
 
       &:hover {
         color: darken(@link-color, 40%);
+      }
+    }
+  }
+
+  &.collapsed {
+    a {
+      &::before {
+        content: "...";
+        width: 0.75em;
+      }
+      overflow: hidden;
+      width: 0.75em;
+    }
+    li:first-child,
+    li:last-child {
+      a {
+        width: auto;
+        &::before {
+          content: "";
+        }
+
       }
     }
   }

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1308,16 +1308,17 @@ fieldset[disabled] .btn-info.active {
     }
 
     &:last-child {
-      &::after {
-        opacity: 0;
-      }
-
       a {
         color: darken(@link-color, 40%);
         cursor: default;
+
         &::before {
           content: "";
         }
+      }
+
+      &::after {
+        opacity: 0;
       }
     }
 
@@ -1334,16 +1335,18 @@ fieldset[disabled] .btn-info.active {
 
   &.collapsed {
     a {
+      width: 0.75em;
+
       &::before {
         content: "...";
         width: 0.75em;
       }
-      width: 0.75em;
     }
     li:first-child,
     li:last-child {
       a {
         width: auto;
+
         &::before {
           content: "";
         }

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1227,6 +1227,7 @@ fieldset[disabled] .btn-info.active {
           display: flex;
 
           .toggle-list-view {
+            display: flex;  // prevent line-break between buttons
             margin-left: @base-spacing-unit*2;
           }
         }
@@ -1235,6 +1236,8 @@ fieldset[disabled] .btn-info.active {
           background-color: transparent;
           font-size: @font-size-h2;
           padding: 0;
+          align-items: center;
+          overflow-x: hidden;
 
           li {
             line-height: @font-size-h2;
@@ -1285,9 +1288,8 @@ fieldset[disabled] .btn-info.active {
   padding: @base-spacing-unit*2;
 
   li {
-    height: @base-spacing-unit*2;
     line-height: @base-spacing-unit*2;
-    margin: 0 @horizontal-spacing-unit 0 0;
+    display: flex;
 
     + li::before {
       display: none; /* override Bootstrap */
@@ -1302,6 +1304,7 @@ fieldset[disabled] .btn-info.active {
       height: @base-spacing-unit*2;
       margin: 0 0 0 @base-spacing-unit;
       width: @base-spacing-unit*2;
+      vertical-align: baseline;
     }
 
     &:last-child {

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1338,6 +1338,7 @@ fieldset[disabled] .btn-info.active {
       width: 0.75em;
 
       &::before {
+        display: inline-block;
         content: "...";
         width: 0.75em;
       }
@@ -1348,6 +1349,7 @@ fieldset[disabled] .btn-info.active {
         width: auto;
 
         &::before {
+          width: auto;
           content: "";
         }
 

--- a/src/js/components/BreadcrumbComponent.jsx
+++ b/src/js/components/BreadcrumbComponent.jsx
@@ -5,8 +5,8 @@ var Link = require("react-router").Link;
 
 var PathUtil = require("../helpers/PathUtil");
 
-var COLLAPSE_BUFFER = 12;
-var PADDED_ICON_WIDTH = 24; // 16px icon + 8px padding
+const COLLAPSE_BUFFER = 12;
+const PADDED_ICON_WIDTH = 24; // 16px icon + 8px padding
 
 var BreadcrumbComponent = React.createClass({
   displayName: "BreadcrumbComponent",

--- a/src/js/components/BreadcrumbComponent.jsx
+++ b/src/js/components/BreadcrumbComponent.jsx
@@ -85,7 +85,7 @@ var BreadcrumbComponent = React.createClass({
 
   handleMutation: _.throttle(function () {
     this.updateExpandedWidth();
-  }),
+  }, 50),
 
   handleResize: _.throttle(function () {
     this.updateAvailableWidth();

--- a/src/js/components/BreadcrumbComponent.jsx
+++ b/src/js/components/BreadcrumbComponent.jsx
@@ -4,9 +4,8 @@ var React = require("react/addons");
 var Link = require("react-router").Link;
 
 var PathUtil = require("../helpers/PathUtil");
-var StyleDimensions = require("../constants/StyleDimensions");
-var PADDED_ICON_WIDTH = StyleDimensions.ICON_SIDE +
-  StyleDimensions.BASE_SPACING_UNIT;
+
+var PADDED_ICON_WIDTH = 24; // 16px icon + 8px padding
 
 var BreadcrumbComponent = React.createClass({
   displayName: "BreadcrumbComponent",

--- a/src/js/components/BreadcrumbComponent.jsx
+++ b/src/js/components/BreadcrumbComponent.jsx
@@ -116,7 +116,9 @@ var BreadcrumbComponent = React.createClass({
       var id = pathParts.slice(0, i + 1).join("/") + "/";
       return (
         <li key={id}>
-          <Link to="group" params={{groupId: encodeURIComponent(id)}}>
+          <Link to="group"
+              params={{groupId: encodeURIComponent(id)}}
+              title={name}>
             {name}
           </Link>
         </li>

--- a/src/js/components/BreadcrumbComponent.jsx
+++ b/src/js/components/BreadcrumbComponent.jsx
@@ -5,6 +5,7 @@ var Link = require("react-router").Link;
 
 var PathUtil = require("../helpers/PathUtil");
 
+var COLLAPSE_BUFFER = 12;
 var PADDED_ICON_WIDTH = 24; // 16px icon + 8px padding
 
 var BreadcrumbComponent = React.createClass({
@@ -104,7 +105,7 @@ var BreadcrumbComponent = React.createClass({
     this.setState({
       availableWidth: availableWidth,
       expandedWidth: expandedWidth,
-      collapsed: expandedWidth >= availableWidth
+      collapsed: this.shouldCollapse(availableWidth, expandedWidth)
     });
   },
 
@@ -136,6 +137,13 @@ var BreadcrumbComponent = React.createClass({
         return this.getWidthFromCollapsedItem(item);
       })
       .reduce((memo, width) => memo + width, 0);
+  },
+
+  shouldCollapse: function (availableWidth, expandedWidth) {
+    // Smooth collapse action to prevent flickering between states
+    return this.state.collapsed
+      ? expandedWidth >= availableWidth - COLLAPSE_BUFFER
+      : expandedWidth >= availableWidth + COLLAPSE_BUFFER;
   },
 
   getGroupLinks: function () {

--- a/src/js/components/BreadcrumbComponent.jsx
+++ b/src/js/components/BreadcrumbComponent.jsx
@@ -1,4 +1,3 @@
-var _ = require("underscore");
 var classNames = require("classnames");
 var React = require("react/addons");
 var Link = require("react-router").Link;
@@ -83,13 +82,13 @@ var BreadcrumbComponent = React.createClass({
     mutationObserver.disconnect();
   },
 
-  handleMutation: _.throttle(function () {
+  handleMutation: function () {
     this.updateExpandedWidth();
-  }, 50),
+  },
 
-  handleResize: _.throttle(function () {
+  handleResize: function () {
     this.updateAvailableWidth();
-  }, 50),
+  },
 
   updateDimensions: function () {
     var availableWidth = this.getAvailableWidth();

--- a/src/js/components/BreadcrumbComponent.jsx
+++ b/src/js/components/BreadcrumbComponent.jsx
@@ -29,6 +29,7 @@ var BreadcrumbComponent = React.createClass({
     // Avoid referencing window from Node context
     if (global.window != null) {
       window.addEventListener("resize", this.handleResize);
+      window.addEventListener("focus", this.handleResize);
     }
   },
 
@@ -39,6 +40,7 @@ var BreadcrumbComponent = React.createClass({
   componentWillUnmount: function () {
     if (global.window != null) {
       window.removeEventListener("resize", this.handleResize);
+      window.removeEventListener("focus", this.handleResize);
     }
   },
 

--- a/src/js/components/BreadcrumbComponent.jsx
+++ b/src/js/components/BreadcrumbComponent.jsx
@@ -44,15 +44,11 @@ var BreadcrumbComponent = React.createClass({
     }
   },
 
-  shouldComponentUpdate: function (nextProps) {
-    var state = this.state;
-    if (state.availableWidth == null || state.expandedWidth == null) {
-      // first render
-      return true;
+  shouldComponentUpdate: function (nextProps, nextState) {
+    if (nextState.availableWidth == null || nextState.expandedWidth == null) {
+      return false;
     }
-    var collapsed = state.expandedWidth > state.availableWidth;
-    if (collapsed !== state.collapsed) {
-      this.setState({collapsed: collapsed});
+    if (this.state.collapsed !== nextState.collapsed) {
       return true;
     }
     return this.didPropsChange(nextProps);
@@ -65,15 +61,23 @@ var BreadcrumbComponent = React.createClass({
   },
 
   handleResize: _.throttle(function () {
+    var availableWidth = this.getAvailableWidth();
     // no need to update expanded width
-    this.setState({availableWidth: this.getAvailableWidth()});
+    var expandedWidth = this.state.expandedWidth;
+    this.setState({
+      availableWidth: availableWidth,
+      collapsed: expandedWidth >= availableWidth
+    });
   }, 50),
 
   updateDimensions: function () {
+    var availableWidth = this.getAvailableWidth();
+    var expandedWidth = this.getExpandedWidth();
     // combine state updates where possible for performance
     this.setState({
-      availableWidth: this.getAvailableWidth(),
-      expandedWidth: this.getExpandedWidth()
+      availableWidth: availableWidth,
+      expandedWidth: expandedWidth,
+      collapsed: expandedWidth >= availableWidth
     });
   },
 

--- a/src/js/components/BreadcrumbComponent.jsx
+++ b/src/js/components/BreadcrumbComponent.jsx
@@ -84,28 +84,36 @@ var BreadcrumbComponent = React.createClass({
   },
 
   handleMutation: _.throttle(function () {
-    this.updateDimensions(false, true);
+    this.updateExpandedWidth();
   }),
 
   handleResize: _.throttle(function () {
-    this.updateDimensions(true, false);
+    this.updateAvailableWidth();
   }, 50),
 
-  updateDimensions: function (updateAvailableWidth = true,
-                              updateExpandedWidth = true) {
-    var state = this.state;
-    var availableWidth = updateAvailableWidth
-      ? this.getAvailableWidth()
-      : state.availableWidth;
-    var expandedWidth = updateExpandedWidth
-      ? this.getExpandedWidth()
-      : state.expandedWidth;
-
-    // combine state updates for best performance
+  updateDimensions: function () {
+    var availableWidth = this.getAvailableWidth();
+    var expandedWidth = this.getExpandedWidth();
     this.setState({
       availableWidth: availableWidth,
       expandedWidth: expandedWidth,
       collapsed: this.shouldCollapse(availableWidth, expandedWidth)
+    });
+  },
+
+  updateAvailableWidth: function () {
+    var availableWidth = this.getAvailableWidth();
+    this.setState({
+      availableWidth: availableWidth,
+      collapsed: this.shouldCollapse(availableWidth, this.state.expandedWidth)
+    });
+  },
+
+  updateExpandedWidth: function () {
+    var expandedWidth = this.getExpandedWidth();
+    this.setState({
+      expandedWidth: expandedWidth,
+      collapsed: this.shouldCollapse(this.state.availableWidth, expandedWidth)
     });
   },
 

--- a/src/js/components/BreadcrumbComponent.jsx
+++ b/src/js/components/BreadcrumbComponent.jsx
@@ -83,11 +83,19 @@ var BreadcrumbComponent = React.createClass({
   },
 
   handleMutation: function () {
-    this.updateExpandedWidth();
+    var expandedWidth = this.getExpandedWidth();
+    this.setState({
+      expandedWidth: expandedWidth,
+      collapsed: this.shouldCollapse(this.state.availableWidth, expandedWidth)
+    });
   },
 
   handleResize: function () {
-    this.updateAvailableWidth();
+    var availableWidth = this.getAvailableWidth();
+    this.setState({
+      availableWidth: availableWidth,
+      collapsed: this.shouldCollapse(availableWidth, this.state.expandedWidth)
+    });
   },
 
   updateDimensions: function () {
@@ -97,22 +105,6 @@ var BreadcrumbComponent = React.createClass({
       availableWidth: availableWidth,
       expandedWidth: expandedWidth,
       collapsed: this.shouldCollapse(availableWidth, expandedWidth)
-    });
-  },
-
-  updateAvailableWidth: function () {
-    var availableWidth = this.getAvailableWidth();
-    this.setState({
-      availableWidth: availableWidth,
-      collapsed: this.shouldCollapse(availableWidth, this.state.expandedWidth)
-    });
-  },
-
-  updateExpandedWidth: function () {
-    var expandedWidth = this.getExpandedWidth();
-    this.setState({
-      expandedWidth: expandedWidth,
-      collapsed: this.shouldCollapse(this.state.availableWidth, expandedWidth)
     });
   },
 

--- a/src/js/constants/StyleDimensions.js
+++ b/src/js/constants/StyleDimensions.js
@@ -1,6 +1,0 @@
-const StyleDimensions = {
-  ICON_SIDE: 16,
-  BASE_SPACING_UNIT: 8
-};
-
-module.exports = Object.freeze(StyleDimensions);

--- a/src/js/constants/StyleDimensions.js
+++ b/src/js/constants/StyleDimensions.js
@@ -1,0 +1,6 @@
+const StyleDimensions = {
+  ICON_SIDE: 16,
+  BASE_SPACING_UNIT: 8
+};
+
+module.exports = Object.freeze(StyleDimensions);


### PR DESCRIPTION
I addressed several comments from my previous PR (#321), but did not preserve commits from there. 

The technique used here is to keep the link text of all groups in the DOM, but use `overflow: hidden` to prevent it being visible to the user. Measuring the potential expanded width of the element is then as simple as measuring the link's `scrollWidth`, subtracting the width of the ellipsis, and adding the width of the icon separator. This works across all browsers. 

This technique is significantly more performant than my previous attempt. 