### PR TITLE
Fix refresh button margin

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -950,6 +950,10 @@ fieldset[disabled] .btn-info.active {
   margin-bottom: 0px;
 }
 
+.tasks-controls {
+  padding-bottom: @base-spacing-unit;
+}
+
 @media (min-width: 768px) {
   .dl-horizontal-lg dt {
     width: 190px;

--- a/src/js/components/TaskViewComponent.jsx
+++ b/src/js/components/TaskViewComponent.jsx
@@ -152,7 +152,7 @@ var TaskViewComponent = React.createClass({
     return (
       <div>
         <div className="row">
-          <div className="col-sm-6">
+          <div className="col-sm-6 tasks-controls">
             {this.getButtons()}
           </div>
           <div className="col-sm-6">


### PR DESCRIPTION
Before:
![button-before](https://cloud.githubusercontent.com/assets/859154/10607351/50020f2a-7739-11e5-9441-6d94d56bf986.png)

After:
![button-after](https://cloud.githubusercontent.com/assets/859154/10607353/5506bcc8-7739-11e5-8490-25a95a46df0e.png)

I am not sure about the css class naming ```.add-bottom```.