### PR TITLE
Link ... label to application configuration

### DIFF
--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -56,9 +56,19 @@ var AppListItemComponent = React.createClass({
     return (
       <div className="labels">
         {nodes}
-        <span className="label more">&hellip;</span>
+        <span className="label more" onClick={this.handleMoreLabelClick}>
+          &hellip;
+        </span>
       </div>
     );
+  },
+
+  handleMoreLabelClick: function (event) {
+    event.stopPropagation();  // Prevent this.onClick being called
+    this.context.router.transitionTo("appView", {
+      appId: encodeURIComponent(this.props.model.id),
+      view: "configuration"
+    });
   },
 
   onClick: function () {


### PR DESCRIPTION
```When the user clicks on the label ellipse, the link points to the tab "Tasks" of the Task Detail Page. Instead, the tab "Configuration" should be shown in order to see the other labels.```