### PR TITLE
Rhabarber - 426 hoist groups to top of list

### DIFF
--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -196,7 +196,6 @@ var AppListComponent = React.createClass({
       .sortBy((app) => {
         return app[sortKey];
       }, state.sortDescending)
-
       // Hoist groups to top of the application list
       .sort((a, b) => {
         if (a.isGroup && !b.isGroup) {
@@ -207,7 +206,6 @@ var AppListComponent = React.createClass({
         }
         return 0;
       })
-
       .map((app) => {
         switch (props.viewType) {
           case AppListViewTypes.LIST:

--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -196,6 +196,18 @@ var AppListComponent = React.createClass({
       .sortBy((app) => {
         return app[sortKey];
       }, state.sortDescending)
+
+      // Hoist groups to top of the application list
+      .sort((a, b) => {
+        if (a.isGroup && !b.isGroup) {
+          return -1;
+        }
+        if (b.isGroup && !a.isGroup) {
+          return 1;
+        }
+        return 0;
+      })
+
       .map((app) => {
         switch (props.viewType) {
           case AppListViewTypes.LIST:

--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -741,7 +741,7 @@ describe("Groups", function () {
 
     var appNodeKeys = this.appNodes.map((app) => app.key);
     expect(appNodeKeys).to.deep.equal([
-      "/app-1", "/app-2", "/group-1", "/group-2"
+      "/group-1", "/group-2", "/app-1", "/app-2"
     ]);
   });
 
@@ -754,7 +754,7 @@ describe("Groups", function () {
 
     var appNodeKeys = this.appNodes.map((app) => app.key);
     expect(appNodeKeys).to.deep.equal([
-      "/group-1/app-3", "/group-1/app-4", "/group-1/group-3"
+      "/group-1/group-3", "/group-1/app-3", "/group-1/app-4"
     ]);
   });
 


### PR DESCRIPTION
This hoists the groups always on top of the application list, after regular sorting took effect.

Sort id ascending:
![goups-sort-1](https://cloud.githubusercontent.com/assets/859154/10633798/8a49a53a-77ed-11e5-9efe-8edcb647f312.png)
Sort id descending: 
![goups-sort-2](https://cloud.githubusercontent.com/assets/859154/10633799/8c216ae6-77ed-11e5-9bd7-1ccd6f676e6e.png)
Sort by memory:
![goups-sort-3](https://cloud.githubusercontent.com/assets/859154/10633801/8e317e70-77ed-11e5-86aa-6abd44bf6f96.png)

