### PR TITLE
Remove conflicting class from create app button

### DIFF
--- a/src/js/components/TabPanesComponent.jsx
+++ b/src/js/components/TabPanesComponent.jsx
@@ -115,7 +115,8 @@ var TabPanesComponent = React.createClass({
             <nav className="sidebar">
               <Link to={path}
                 query={{modal: "new-app"}}
-                className="btn btn-success">
+                className="btn btn-success create-app"
+                activeClassName="create-app-active">
                 Create
               </Link>
               <div className="flex-row">


### PR DESCRIPTION
Fun facts:
* The `Link` component adds an `active` class to itself when its route matches the current URI
* `react-router` in 0.13.* has a bug where it doesn't compare `query` or `params` if the `to` matches.
* this is fixed in `react-router` 0.1.*

Upgrading react-router is a larger piece of work, hence this interim fix which simply prevents `active` being added to the create app button. 

Before:
http://cl.ly/1S1v1K252G2q

After:
http://cl.ly/image/1C0F3v1b3833

CC @cleverroffey