### PR TITLE
Fix app column sorting on status or undefined values

### DIFF
--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -314,9 +314,9 @@ var AppListComponent = React.createClass({
               </span>
             </th>
             <th className="text-right instances-cell" colSpan="2">
-              <span onClick={this.sortBy.bind(null, "instances")}
+              <span onClick={this.sortBy.bind(null, "tasksRunning")}
                   className={headerClassSet}>
-                {this.getCaret("instances")} Running Instances
+                {this.getCaret("tasksRunning")} Running Instances
               </span>
             </th>
             <th className="text-center actions-cell"></th>

--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -194,7 +194,7 @@ var AppListComponent = React.createClass({
 
     return appsSequence
       .sortBy((app) => {
-        return app[sortKey];
+        return app[sortKey] || 0;
       }, state.sortDescending)
       // Hoist groups to top of the application list
       .sort((a, b) => {


### PR DESCRIPTION
Adding group nodes to the app list introduces undefined values e.g. on the status-field.
This means that sorting on the status column failed silently and didn't worked. This is now fixed.

Also the sorting on the instances got meaningless, I've changed that to tasksRunning to match the column headline.

Sorting on the health status isn't possible anymore due to the new layout. This is a regression. :(