### PR TITLE
Rhabarber - Enable group hoisting and app sorting for V8

### DIFF
--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -192,19 +192,24 @@ var AppListComponent = React.createClass({
       });
     }
 
+    let sortDirection = state.sortDescending ? 1 : -1;
+
     return appsSequence
+      // Alphabetically presort
       .sortBy((app) => {
-        return app[sortKey] || 0;
+        return app.id;
       }, state.sortDescending)
-      // Hoist groups to top of the application list
+      // Hoist groups to top of the app list and sort everything by sortKey
       .sort((a, b) => {
         if (a.isGroup && !b.isGroup) {
           return -1;
-        }
-        if (b.isGroup && !a.isGroup) {
+        } else if (b.isGroup && !a.isGroup) {
           return 1;
+        } else {
+          return a[sortKey] > b[sortKey]
+            ? -1 * sortDirection
+            : 1 * sortDirection;
         }
-        return 0;
       })
       .map((app) => {
         switch (props.viewType) {


### PR DESCRIPTION
This enables the group hoisting also in chrome.

Problem described here:
http://stackoverflow.com/questions/3195941/sorting-an-array-of-objects-in-chrome

Therefor no sorting by basename is needed, it's done with the appId.