### PR TITLE
Rhabarber/marathon 425 refactor label collapsing

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -383,21 +383,22 @@ a:focus {
     &.name-cell {
       color: inherit;
 
-      & > span {
+      .name {
         display: inline-block;
-        float: left;
+        max-width: 100%;
         overflow: hidden;
         text-overflow: ellipsis;
-        max-width: @app-list-name-width;
         white-space: nowrap;
       }
 
       .labels {
-        .label {
-          display: none;
-          overflow: hidden;
-          text-overflow: ellipsis;
-          max-width: @app-list-label-width;
+        display: inline-block;
+
+        .label, .more {
+          position: absolute;
+          transform: translateX(-1vw);
+          display: inline-block;
+          visibility: hidden;
           white-space: nowrap;
           padding: @horizontal-spacing-unit*0.25 @base-spacing-unit*1.5;
           margin-left: @horizontal-spacing-unit;
@@ -407,26 +408,11 @@ a:focus {
           font-size: @small-font-size;
           font-weight: normal;
 
-          &.more {
-            display: inline-block;
+          &.visible {
+            position: relative;
+            transform: translateX(0);
+            visibility: inherit;
           }
-
-          .label-loop(@i) when (@i > 0) {
-            @breakpoint: (@app-list-labels-breakpoint + @i *
-              @app-list-label-width *1.15 );
-            @next: @i + 1;
-            @media only screen and (min-width: @breakpoint) {
-              &:nth-child(@{i}) {
-                display: inline-block;
-              }
-
-              &.more:nth-child(-n+@{next}) {
-                display: none;
-              }
-            }
-            .label-loop(@i - 1);
-          }
-          .label-loop(10);
         }
       }
     }

--- a/src/js/components/AppHealthComponent.jsx
+++ b/src/js/components/AppHealthComponent.jsx
@@ -1,3 +1,4 @@
+var _ = require("underscore");
 var classNames = require("classnames");
 var React = require("react/addons");
 
@@ -25,6 +26,10 @@ var AppHealthComponent = React.createClass({
 
   propTypes: {
     model: React.PropTypes.object.isRequired
+  },
+
+  shouldComponentUpdate: function (nextProps) {
+    return !_.isEqual(this.props, nextProps);
   },
 
   handleMouseOverHealthBar: function (ref) {

--- a/src/js/components/AppStatusComponent.jsx
+++ b/src/js/components/AppStatusComponent.jsx
@@ -1,3 +1,4 @@
+var _ = require("underscore");
 var classNames = require("classnames");
 var moment = require("moment");
 var React = require("react/addons");
@@ -27,6 +28,10 @@ var AppStatusComponent = React.createClass({
   propTypes: {
     model: React.PropTypes.object.isRequired,
     showSummary: React.PropTypes.bool
+  },
+
+  shouldComponentUpdate: function (nextProps) {
+    return !_.isEqual(this.props, nextProps);
   },
 
   getTasksSummary: function () {

--- a/src/js/helpers/DOMUtil.js
+++ b/src/js/helpers/DOMUtil.js
@@ -1,0 +1,20 @@
+var DOMUtil = {
+  getInnerWidth(node) {
+    var computedStyle = window.getComputedStyle(node);
+    var width = parseInt(node.clientWidth);
+    width -= parseInt(computedStyle.paddingLeft);
+    width -= parseInt(computedStyle.paddingRight);
+    return width;
+  },
+  getOuterWidth(node) {
+    var computedStyle = window.getComputedStyle(node);
+    var width = parseInt(node.clientWidth);
+    width += parseInt(computedStyle.marginLeft);
+    width += parseInt(computedStyle.marginRight);
+    width += parseInt(computedStyle.borderLeftWidth);
+    width += parseInt(computedStyle.borderRightWidth);
+    return width;
+  }
+};
+
+module.exports = DOMUtil;


### PR DESCRIPTION
![label collapsing](https://cloud.githubusercontent.com/assets/647035/10665197/aa395f70-78c9-11e5-9245-0b83d274c385.gif)

Use javascript to measure and display the amount of labels that fit into the name cell. With this new approach, we're able to show as many labels as the cell width allows.

**AC**
* [ ] Show as many labels as the cell width allows
* [ ] Render the app list item if the number of visible labels differs or any of the props is updated
* [ ] Render the app status and health bar only if the props differ