### PR TITLE
Allow nav and app list to scroll independently

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -320,6 +320,26 @@ a:focus {
 
 
 /* ==============
+ * Fixed/scrolling layout for apps tabs:
+ * ==============
+ */
+.content-fixed {
+  position: fixed;
+}
+
+.sidebar-scroll {
+  // ~ is escaped string, otherwise LESS maths takes place
+  height: ~"calc(100vh - 50px)";
+  overflow-y: auto;
+}
+
+.app-list-scroll {
+  // 50px header, 36px context bar
+  height: ~"calc(100vh - " (50px + 36px + (2 * @base-spacing-unit )) ~")";
+  overflow-y: auto;
+}
+
+/* ==============
  * App List (Table)
  * ==============
  */
@@ -1234,7 +1254,6 @@ fieldset[disabled] .btn-info.active {
   display: flex;
   flex: 1;
   flex-direction: column;
-  min-height: 100vh;
 
   .wrapper {
     display: flex;
@@ -1275,7 +1294,6 @@ fieldset[disabled] .btn-info.active {
 
     nav.sidebar {
       background: @sidebar-bg-color;
-      min-height: 100vh;
       margin: 0 0 0 -@base-spacing-unit*2;
       padding: @base-spacing-unit*2;
       width: @sidebar-width;

--- a/src/js/components/TabPanesComponent.jsx
+++ b/src/js/components/TabPanesComponent.jsx
@@ -132,10 +132,10 @@ var TabPanesComponent = React.createClass({
 
     return (
       <TogglableTabsComponent activeTabId={this.getTabId()}
-          className="container-fluid content">
+          className="container-fluid content content-fixed">
         <TabPaneComponent id={tabs[0].id} className="flex-container">
           <div className="wrapper">
-            <nav className="sidebar">
+            <nav className="sidebar sidebar-scroll">
               <Link to={path}
                 query={{modal: "new-app"}}
                 className="btn btn-success create-app"
@@ -200,7 +200,9 @@ var TabPanesComponent = React.createClass({
                   </div>
                 </div>
               </div>
-              <AppListComponent {...appListProps} />
+              <div className="app-list-scroll">
+                <AppListComponent {...appListProps} />
+              </div>
             </main>
           </div>
         </TabPaneComponent>


### PR DESCRIPTION
This also fixes the header in place. 

This PR fulfils the requirements and is a pure-CSS solution. It makes use of `calc`, which is now [widely supported](caniuse.com/#feat=calc). I've tried to keep the impact of this PR as low as possible, but am still a little uncomfortable making such a significant change so close to a scheduled release. 

![moving pixels](https://s3.amazonaws.com/f.cl.ly/items/1T2g0D0w1v3Y100z2u2d/Screen%20Recording%202015-10-23%20at%2012.43%20am.gif)

