### PR TITLE
Force user to root on filter

### DIFF
--- a/src/js/components/AppListFilterComponent.jsx
+++ b/src/js/components/AppListFilterComponent.jsx
@@ -50,7 +50,7 @@ var AppListFilterComponent = React.createClass({
       delete queryParams.filterText;
     }
 
-    router.transitionTo(router.getCurrentPathname(), {}, queryParams);
+    router.transitionTo("apps", {}, queryParams);
   },
 
   updateFilterText: function () {


### PR DESCRIPTION
This PR is intended to promote discussion of how to handle filter input when the user has navigated to a group context. 

This implementation removes group context when the user performs a filtering operation, this preventing them getting empty results when filtering within a group when matches exist outside that group. 

However, it does not solve the more significant problem of how to filter for applications which are not in the root group. 

Of interest to @mwasn @aquamatthias and @gkleiman. 