### PR TITLE
Fix overflowing labels in IE10

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1457,6 +1457,7 @@ fieldset[disabled] .btn-info.active {
     color: @link-color;
     display: flex;
     justify-content: space-between;
+    overflow-x: hidden;
 
     &:active, &:focus, &:hover {
       background-color: transparent;


### PR DESCRIPTION
IE10 on Win7

![screen shot 2015-10-23 at 09 35 33](https://cloud.githubusercontent.com/assets/1078545/10686963/c4956648-7969-11e5-8f02-08d32f80b894.png)

IE11 on Win8
![screen shot 2015-10-23 at 09 36 12](https://cloud.githubusercontent.com/assets/1078545/10686964/c4a98f42-7969-11e5-8489-a86d6fcc8e9d.png)


