### PR TITLE
Rhabarber - Apply filters globally

### DIFF
--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -117,7 +117,7 @@ var AppListComponent = React.createClass({
     var currentGroup = this.props.currentGroup;
 
     return appsSequence
-      .filter((app) => app.id.startsWith(currentGroup))
+      .filter(app => app.id.startsWith(currentGroup))
       .reduce((memo, app) => {
         let relativePath = app.id.substring(currentGroup.length);
         let pathParts = relativePath.split("/");
@@ -147,7 +147,7 @@ var AppListComponent = React.createClass({
     var sortKey = state.sortKey;
     var props = this.props;
 
-    var appsSequence = lazy(this.state.apps);
+    var appsSequence = lazy(state.apps);
 
     if (props.filterText != null && props.filterText !== "") {
       appsSequence = appsSequence
@@ -191,13 +191,13 @@ var AppListComponent = React.createClass({
       });
     }
 
-    let sortDirection = state.sortDescending ? 1 : -1;
-
     appsSequence
       // Alphabetically presort
       .sortBy((app) => {
         return app.id;
       }, state.sortDescending);
+
+    let sortDirection = state.sortDescending ? 1 : -1;
 
     return this.getGroupedNodes(appsSequence)
       // Hoist groups to top of the app list and sort everything by sortKey

--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -113,11 +113,10 @@ var AppListComponent = React.createClass({
     });
   },
 
-  getGroupedNodes: function () {
-    var apps = this.state.apps;
+  getGroupedNodes: function (appsSequence) {
     var currentGroup = this.props.currentGroup;
 
-    return lazy(apps)
+    return appsSequence
       .filter((app) => app.id.startsWith(currentGroup))
       .reduce((memo, app) => {
         let relativePath = app.id.substring(currentGroup.length);
@@ -148,7 +147,7 @@ var AppListComponent = React.createClass({
     var sortKey = state.sortKey;
     var props = this.props;
 
-    var appsSequence = lazy(this.getGroupedNodes());
+    var appsSequence = lazy(this.state.apps);
 
     if (props.filterText != null && props.filterText !== "") {
       appsSequence = appsSequence
@@ -194,11 +193,13 @@ var AppListComponent = React.createClass({
 
     let sortDirection = state.sortDescending ? 1 : -1;
 
-    return appsSequence
+    appsSequence
       // Alphabetically presort
       .sortBy((app) => {
         return app.id;
-      }, state.sortDescending)
+      }, state.sortDescending);
+
+    return this.getGroupedNodes(appsSequence)
       // Hoist groups to top of the app list and sort everything by sortKey
       .sort((a, b) => {
         if (a.isGroup && !b.isGroup) {
@@ -222,8 +223,7 @@ var AppListComponent = React.createClass({
           default:
             return null;
         }
-      })
-      .value();
+      });
   },
 
   getCaret: function (sortKey) {


### PR DESCRIPTION
This applies the filters before grouping the apps.

I recognized that unfortunately the query params aren't preserved, so if clicking on a group the filter settings are lost.