### PR TITLE
Rhabarber/451 utils optimisation

### DIFF
--- a/src/js/components/AppHealthComponent.jsx
+++ b/src/js/components/AppHealthComponent.jsx
@@ -28,7 +28,7 @@ var AppHealthComponent = React.createClass({
   },
 
   shouldComponentUpdate: function (nextProps) {
-    return !Util.isArrayEqual(this.props.model.health, nextProps.model.health);
+    return !Util.compareArrays(this.props.model.health, nextProps.model.health);
   },
 
   handleMouseOverHealthBar: function (ref) {

--- a/src/js/helpers/Util.js
+++ b/src/js/helpers/Util.js
@@ -134,19 +134,18 @@ var Util = {
       a.every((v, i) => v === b[i]);
   },
   compareProperties: function (a, b, ...keys) {
-    return keys.reduce((memo, key) => {
+    return keys.every((key) => {
       var aVal = a[key];
       var bVal = b[key];
       if (Array.isArray(aVal)) {
-        return memo && this.isArrayEqual(aVal, bVal);
+        return this.isArrayEqual(aVal, bVal);
       }
       if (this.isObject(aVal) && this.isObject(bVal)) {
-        return memo
-          && this.isArrayEqual(Object.keys(aVal), Object.keys(bVal))
+        return this.isArrayEqual(Object.keys(aVal), Object.keys(bVal))
           && this.isArrayEqual(Object.values(aVal), Object.values(bVal));
       }
-      return memo && aVal === bVal;
-    }, true);
+      return aVal === bVal;
+    });
   }
 };
 

--- a/src/js/helpers/Util.js
+++ b/src/js/helpers/Util.js
@@ -126,7 +126,7 @@ var Util = {
 
     return filesize + " " + units[unitIndex];
   },
-  isArrayEqual: function (a, b) {
+  compareArrays: function (a, b) {
     return a === b ||
       a != null &&
       b != null &&
@@ -138,11 +138,11 @@ var Util = {
       var aVal = a[key];
       var bVal = b[key];
       if (Array.isArray(aVal)) {
-        return this.isArrayEqual(aVal, bVal);
+        return this.compareArrays(aVal, bVal);
       }
       if (this.isObject(aVal) && this.isObject(bVal)) {
-        return this.isArrayEqual(Object.keys(aVal), Object.keys(bVal))
-          && this.isArrayEqual(Object.values(aVal), Object.values(bVal));
+        return this.compareArrays(Object.keys(aVal), Object.keys(bVal))
+          && this.compareArrays(Object.values(aVal), Object.values(bVal));
       }
       return aVal === bVal;
     });


### PR DESCRIPTION
This PR optimises the object comparison utility method with [Felix's suggestion](https://github.com/mesosphere/marathon-ui/pull/361#discussion_r42869981) to use `every` instead of `reduce`.

It also addresses [Orlando's suggestion](https://github.com/mesosphere/marathon-ui/pull/361#issuecomment-150585587) to rename the array comparison method (missed it the first time around, sorry!)