### PR TITLE
TEST BEFORE MERGING: Use webpack's builtin cache instead of Gulp's

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,6 +35,11 @@ var files = {
   index: "index.html"
 };
 
+var webpackWatch = false;
+if (process.env.GULP_ENV === "development") {
+  webpackWatch = true;
+}
+
 var webpackConfig = {
   entry: dirs.js + "/" + files.mainJs + ".jsx",
   output: {
@@ -63,7 +68,7 @@ var webpackConfig = {
   resolve: {
     extensions: ["", ".jsx", ".js"]
   },
-  watch: true
+  watch: webpackWatch
 };
 
 // Use webpack to compile jsx into js,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,7 +61,7 @@ var webpackConfig = {
     ],
     postLoaders: [
       {
-        loader: "transform?envify"
+        loader: "transform/cacheable?envify"
       }
     ]
   },

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,7 +45,7 @@ var webpackConfig = {
     loaders: [
       {
         test: /\.(js|jsx)$/,
-        loader: "babel-loader",
+        loader: "babel-loader?cacheDirectory",
         exclude: /node_modules/
       },
       {
@@ -62,11 +62,13 @@ var webpackConfig = {
   },
   resolve: {
     extensions: ["", ".jsx", ".js"]
-  }
+  },
+  watch: true
 };
 
 // Use webpack to compile jsx into js,
 gulp.task("webpack", function (callback) {
+  var isFirstRun = true;
   // Extend options with source mapping
   if (process.env.GULP_ENV === "development" &&
     !process.env.DISABLE_SOURCE_MAP ||
@@ -94,16 +96,25 @@ gulp.task("webpack", function (callback) {
       timing: true
     }));
 
-    browserSync.reload();
-    callback();
+
+    if (isFirstRun) {
+      // This runs on initial gulp webpack load.
+      isFirstRun = false;
+      callback();
+    } else {
+      // This runs after webpack's internal watch rebuild.
+      eslintFn();
+      browserSync.reload();
+    }
   });
 });
 
-gulp.task("eslint", function () {
+function eslintFn() {
   return gulp.src([dirs.js + "/**/*.?(js|jsx)"])
     .pipe(eslint())
     .pipe(eslint.formatEach("stylish", process.stderr));
-});
+}
+gulp.task("eslint", eslintFn);
 
 gulp.task("less", function () {
   return gulp.src(dirs.styles + "/" + files.mainLess + ".less")
@@ -167,7 +178,6 @@ gulp.task("browsersync", function () {
 
 gulp.task("watch", function () {
   gulp.watch(dirs.styles + "/**/*", ["less"]);
-  gulp.watch(dirs.js + "/**/*.?(js|jsx)", ["eslint", "webpack"]);
   gulp.watch(dirs.img + "/**/*.*", ["images"]);
   gulp.watch(dirs.fonts + "/**/*.*", ["fonts"]);
 });


### PR DESCRIPTION
This is the first and most impactful optimisation to our build system.
It lowers JS transpilation time down to ~2s from ~8s.

@orlandohohmeier @aldipower @philipnrmn I'd appreciate if you could also give this a spin to make sure it works with no hiccups.

Props to @kennyt for the tips!

See https://github.com/mesosphere/marathon/issues/1688#issuecomment-153723819