### PR TITLE
Fix filter/search input border

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -960,7 +960,7 @@ fieldset[disabled] .btn-info.active {
 
   .search-icon-container {
     .icon {
-      font-size: 1.4em;
+      font-size: @font-size-icon;
     }
     padding: @base-font-size*0.5 @base-spacing-unit;
   }


### PR DESCRIPTION
Use the proper icon font size, to fix the filter/search input border.

Closes mesosphere/marathon#2528