### PR TITLE
Clear the lable filter input

### DIFF
--- a/src/js/components/AppListLabelsFilterComponent.jsx
+++ b/src/js/components/AppListLabelsFilterComponent.jsx
@@ -168,7 +168,8 @@ var AppListLabelsFilterComponent = React.createClass({
 
   toggleActivatedState: function () {
     this.setState({
-      activated: !this.state.activated
+      activated: !this.state.activated,
+      filterText: ""
     });
   },
 


### PR DESCRIPTION
Whenever a user closes the dropdown (toggles the component active state), the filter input should be cleared.

![clear-filter-input](https://cloud.githubusercontent.com/assets/647035/11009922/e45714b4-848f-11e5-99b3-0cc419616c0d.gif)

Closes mesosphere/marathon#2574