### PR TITLE
Adjust the status header caret position

### DIFF
--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -350,7 +350,7 @@ var AppListComponent = React.createClass({
             <th className="status-cell">
               <span onClick={this.sortBy.bind(null, "status")}
                     className={headerClassSet}>
-                {this.getCaret("status")} Status
+                Status {this.getCaret("status")}
               </span>
             </th>
             <th className="text-right instances-cell" colSpan="3">


### PR DESCRIPTION
![status-header](https://cloud.githubusercontent.com/assets/647035/11010569/9025c6ec-8494-11e5-97a1-caafc31fb903.gif)

AC
* [ ] Switch the label and caret position, to avoid shifting the text to the right

Closes mesosphere/marathon#2586