### PR TITLE
Implement dropdown to reveal all labels

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -409,6 +409,10 @@ a:focus {
             visibility: inherit;
           }
         }
+
+        .more:hover {
+          background-color: @btn-default-active-bg-color;
+        }
       }
 
       .labels-dropdown {

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -387,6 +387,7 @@ a:focus {
 
       .labels {
         display: inline-block;
+        position: relative;
 
         .label, .more {
           position: absolute;
@@ -406,6 +407,52 @@ a:focus {
             position: relative;
             transform: translateX(0);
             visibility: inherit;
+          }
+        }
+      }
+
+      .labels-dropdown {
+        background-color: @navbar-bg-color;
+        left: 100%;
+        margin-left: @base-spacing-unit * 2;
+        position: absolute;
+        top: -@base-spacing-unit * 2;
+        visibility: hidden;
+        z-index: 1;
+
+        &.visible {
+          visibility: visible;
+        }
+
+        > h5 {
+          color: @table-text-color;
+          padding: @base-spacing-unit * 2;
+          margin: 0;
+
+          &::before {
+            /* Left arrow */
+            content: "";
+            border-top: @base-spacing-unit solid transparent;
+            border-bottom: @base-spacing-unit solid transparent;
+            border-right: @base-spacing-unit solid @navbar-bg-color;
+            height: 0;
+            left: -@base-spacing-unit;
+            position: absolute;
+            top: @base-spacing-unit * 2;
+            width: 0;
+          }
+        }
+
+        > ul {
+          padding: 0 @base-spacing-unit * 2;
+
+          li {
+            display: block;
+            margin: 0 0 @base-spacing-unit 0;
+
+            .label {
+              margin: 0;
+            }
           }
         }
       }

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -608,7 +608,7 @@ fieldset[disabled] .btn-info.active {
 }
 
 .navbar-inverse {
-  background-color: #222426;
+  background-color: @navbar-bg-color;
   border: none;
   margin: 0;
 }
@@ -1066,7 +1066,7 @@ fieldset[disabled] .btn-info.active {
   .panel-heading {
     color: @link-color;
   }
-  background-color: #222426;
+  background-color: @navbar-bg-color;
   border-radius: 0;
   border: none;
 
@@ -1197,7 +1197,7 @@ fieldset[disabled] .btn-info.active {
  * ==============
  */
 .tooltip {
-  background: #222426;
+  background: @navbar-bg-color;
   text-transform: capitalize;
 
   &.default {

--- a/src/css/variables.less
+++ b/src/css/variables.less
@@ -7,6 +7,7 @@
 @brand-primary: #2568F5;
 @sidebar-bg-color: #2A2D30;
 @sidebar-heading-color: #5E646C;
+@navbar-bg-color: #222426;
 @navbar-inactive-color: #8E929B;
 @navbar-active-color: #ffffff;
 @btn-default-border-color: #5E646C;

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -78,7 +78,6 @@ var AppListItemComponent = React.createClass({
     });
   },
 
-
   handleResize: function () {
     requestAnimationFrame(this.updateNumberOfVisibleLabels);
   },

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -1,4 +1,5 @@
 var classNames = require("classnames");
+var OnClickOutsideMixin = require("react-onclickoutside");
 var React = require("react/addons");
 
 var AppHealthComponent = require("../components/AppHealthComponent");
@@ -9,6 +10,8 @@ var DOMUtil = require("../helpers/DOMUtil");
 
 var AppListItemComponent = React.createClass({
   displayName: "AppListItemComponent",
+
+  mixins: [OnClickOutsideMixin],
 
   contextTypes: {
     router: React.PropTypes.func
@@ -21,7 +24,8 @@ var AppListItemComponent = React.createClass({
 
   getInitialState: function () {
     return {
-      numberOfVisibleLabels: -1
+      numberOfVisibleLabels: -1,
+      isLabelsDropdownShown: false
     };
   },
 
@@ -49,12 +53,14 @@ var AppListItemComponent = React.createClass({
   },
 
   shouldComponentUpdate: function (nextProps, nextState) {
+    var state = this.state;
     if (nextState.numberOfVisibleLabels === -1 && !this.props.model.isGroup) {
       this.updateNumberOfVisibleLabels();
       return false;
     }
 
-    if (this.state.numberOfVisibleLabels !== nextState.numberOfVisibleLabels) {
+    if (state.numberOfVisibleLabels !== nextState.numberOfVisibleLabels ||
+      state.isLabelsDropdownShown !== nextState.isLabelsDropdownShown) {
       return true;
     }
 
@@ -65,6 +71,13 @@ var AppListItemComponent = React.createClass({
     return !Util.compareProperties(this.props.model, newProps.model, "status",
       "tasksRunning", "health", "totalMem", "totalCpus", "instances", "labels");
   },
+
+  handleClickOutside: function () {
+    this.setState({
+      isLabelsDropdownShown: false
+    });
+  },
+
 
   handleResize: function () {
     requestAnimationFrame(this.updateNumberOfVisibleLabels);
@@ -116,12 +129,14 @@ var AppListItemComponent = React.createClass({
       return null;
     }
 
-    let numberOfVisibleLabels = this.state.numberOfVisibleLabels;
-    let nodes = Object.keys(labels).sort().map(function (key, i) {
-      if (key == null || Util.isEmptyString(key)) {
-        return null;
-      }
+    let state = this.state;
+    let numberOfVisibleLabels = state.numberOfVisibleLabels;
 
+    let labelKeys = Object.keys(labels).filter(function (key) {
+      return (key != null && !Util.isEmptyString(key));
+    }).sort();
+
+    let visibleNodes = labelKeys.map(function (key, i) {
       let labelText = key;
       if (!Util.isEmptyString(labels[key])) {
         labelText = `${key}:${labels[key]}`;
@@ -140,26 +155,55 @@ var AppListItemComponent = React.createClass({
     });
 
     let moreLabelClassName = classNames("more", {
-      "visible": Object.keys(labels).length > numberOfVisibleLabels
+      "visible": labelKeys.length > numberOfVisibleLabels
     });
+
+    let labelsDropdownClassName = classNames("labels-dropdown", {
+      "visible": state.isLabelsDropdownShown &&
+        labelKeys.length > numberOfVisibleLabels
+    });
+
+    let allNodes = labelKeys.map(function (key, i) {
+      let labelText = key;
+      if (!Util.isEmptyString(labels[key])) {
+        labelText = `${key}:${labels[key]}`;
+      }
+
+      return (
+        <li key={i} title={labelText}>
+          <span className="label visible">
+            {labelText}
+          </span>
+        </li>
+      );
+    });
+
+    let labelsDropdown = (
+      <div className={labelsDropdownClassName}>
+        <h5>All Labels</h5>
+        <ul>
+          {allNodes}
+        </ul>
+      </div>
+    );
 
     return (
       <div className="labels" ref="labels">
-        {nodes}
+        {visibleNodes}
         <span className={moreLabelClassName}
             onClick={this.handleMoreLabelClick}
             ref="moreLabel">
           &hellip;
         </span>
+        {labelsDropdown}
       </div>
     );
   },
 
   handleMoreLabelClick: function (event) {
     event.stopPropagation();  // Prevent this.onClick being called
-    this.context.router.transitionTo("appView", {
-      appId: encodeURIComponent(this.props.model.id),
-      view: "configuration"
+    this.setState({
+      isLabelsDropdownShown: !this.state.isLabelsDropdownShown
     });
   },
 

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -210,7 +210,7 @@ var AppListItemComponent = React.createClass({
         <td className="icon-cell">
           {this.getIcon()}
         </td>
-        <td className="overflow-ellipsis name-cell" title={model.id}
+        <td className="name-cell" title={model.id}
             ref="nameCell">
           <span className="name" ref="nameNode">{name}</span>
           {this.getLabels()}

--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -782,7 +782,10 @@ describe("App component", function () {
   });
 
   afterEach(function () {
-    this.renderer.unmount();
+    // The OnClickOutsideMixin is not render-friendly as of now.
+    // TODO: uncomment once this PR is merged:
+    // https://github.com/Pomax/react-onclickoutside/pull/48/files
+    // this.renderer.unmount();
   });
 
   it("has the correct app id", function () {


### PR DESCRIPTION
Notes
---------------
I wanted a pure CSS solutions. This meant that in order to use `position: absolute` (dropdown) on top of `postion: relative` (name cell) I had to remove the `overflow: hidden` of the `.name` cell. 
I couldn't see any side-effects of doing so: https://github.com/mesosphere/marathon-ui/commit/fdd412912716917ecb4567522c56cc47bb45c3ec – please let me know otherwise.

Also, more importantly, there is currently an issue with the tests and the (otherwise very handy) `onclickoutside` mixin. To make the tests pass, I had to pull the following nasty little trick: https://github.com/mesosphere/marathon-ui/commit/47888040d81e8030b62d101226ce6d7d6041fd3c – as written in the commit,  I opened a PR to address the issue: https://github.com/Pomax/react-onclickoutside/pull/48 so fingers crossed... 

![labelsdd](https://cloud.githubusercontent.com/assets/1078545/11041130/382ae8ae-8710-11e5-9425-62c8975eaaf6.gif)
