### PR TITLE
Feature - 441 prefill id field with group in app modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unversioned
+### Added
+- Prefill ID field with group structure in app creation modal
+
 ## 0.13.3 - 2015-11-10
 ### Changed
 - Introduced a maximum width for labels in the app list.

--- a/src/js/components/Marathon.jsx
+++ b/src/js/components/Marathon.jsx
@@ -54,11 +54,12 @@ var Marathon = React.createClass({
 
     var params = router.getCurrentParams();
     var path = router.getCurrentPathname();
-    var modalQuery = router.getCurrentQuery().modal;
+    var query = router.getCurrentQuery();
+    var modalQuery = query.modal;
     var modal = null;
 
     if (modalQuery === "new-app") {
-      modal = this.getNewAppModal();
+      modal = this.getNewAppModal(query.groupId);
     } else if (modalQuery === "about") {
       modal = this.getAboutModal();
     } else if (modalQuery === "help") {
@@ -207,9 +208,14 @@ var Marathon = React.createClass({
     );
   },
 
-  getNewAppModal: function () {
+  getNewAppModal: function (groupId) {
+    var app = groupId != null
+      ? {id: groupId}
+      : null;
+
     return (
       <AppModalComponent
+        app={app}
         onDestroy={this.handleModalDestroy} />
     );
   },

--- a/src/js/components/TabPanesComponent.jsx
+++ b/src/js/components/TabPanesComponent.jsx
@@ -128,6 +128,14 @@ var TabPanesComponent = React.createClass({
       viewType: AppListViewTypes.LIST
     };
 
+    var newAppModalQuery = {
+      modal: "new-app"
+    };
+
+    if (state.currentGroup != null && state.currentGroup !== "/") {
+      newAppModalQuery.groupId = state.currentGroup;
+    }
+
     return (
       <TogglableTabsComponent activeTabId={this.getTabId()}
           className="container-fluid content">
@@ -135,7 +143,7 @@ var TabPanesComponent = React.createClass({
           <div className="wrapper">
             <nav className="sidebar">
               <Link to={path}
-                query={{modal: "new-app"}}
+                query={newAppModalQuery}
                 className="btn btn-success create-app"
                 activeClassName="create-app-active">
                 Create

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -79,9 +79,8 @@ var AppModalComponent = React.createClass({
   setCursorToEndOfAppIdInput: function () {
     var appIdInput = React.findDOMNode(this.refs.appId);
     appIdInput.focus();
-    appIdInput.selectionStart =
-     appIdInput.selectionEnd =
-     appIdInput.value.length;
+    var valueLength = appIdInput.value.length;
+    appIdInput.setSelectionRange(valueLength, valueLength);
   },
 
   componentWillUnmount: function () {

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -206,7 +206,7 @@ var AppModalComponent = React.createClass({
 
     var modalTitle = "New Application";
 
-    if (props.app != null) {
+    if (props.app != null && props.app.version != null) {
       modalTitle = "Edit Application";
     }
 

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -72,6 +72,18 @@ var AppModalComponent = React.createClass({
       this.onFieldValidationError);
   },
 
+  componentDidMount: function () {
+    this.setCursorToEndOfAppIdInput();
+  },
+
+  setCursorToEndOfAppIdInput: function () {
+    var appIdInput = React.findDOMNode(this.refs.appId);
+    appIdInput.focus();
+    appIdInput.selectionStart =
+     appIdInput.selectionEnd =
+     appIdInput.value.length;
+  },
+
   componentWillUnmount: function () {
     AppsStore.removeListener(AppsEvents.CREATE_APP,
       this.onCreateApp);
@@ -237,7 +249,7 @@ var AppModalComponent = React.createClass({
                 value={state.fields.appId}
                 label="ID"
                 onChange={this.handleFieldUpdate}>
-              <input autoFocus />
+              <input ref="appId" />
             </FormGroupComponent>
             <div className="row">
               <div className="col-sm-3">


### PR DESCRIPTION
"As Alice I want the ID to be pre-filled with the group structure so that I can easily create a new app within a given group."

![prefill](https://cloud.githubusercontent.com/assets/859154/11060035/cf3ba0de-879d-11e5-8ca2-ca188cf52e49.png)

There is a more complex problem with the errors response on groups. If I don't modify the prefilled ID, the API response with an error, that the appId is an already existing group. Problem the error isn't shown, because of the dynamic approach of the error attribute structure.
The is a general problem and not related to this PR directly.
I've created an issue for this.
https://github.com/mesosphere/marathon/issues/2609