### PR TITLE
Refactor: Bring sidebar into own component 

### DIFF
--- a/src/js/components/AppListFilterComponent.jsx
+++ b/src/js/components/AppListFilterComponent.jsx
@@ -95,7 +95,10 @@ var AppListFilterComponent = React.createClass({
         filterText: filterText,
         activated: filterText !== "" || state.focused
       }, this.restorePreviousCursorPosition);
-      this.props.onChange(filterText);
+
+      this.props.onChange({
+        filterText: filterText
+      });
     }
   },
 

--- a/src/js/components/SidebarComponent.jsx
+++ b/src/js/components/SidebarComponent.jsx
@@ -30,17 +30,25 @@ var SidebarComponent = React.createClass({
   updateFilterLabels: function (filterLabels) {
     var state = this.state;
 
-    this.setState(Object.assign(state.filters, {
+    var filters = Object.assign({}, state.filters, {
       filterLabels: filterLabels
-    }), this.props.onChange(state.filters));
+    });
+
+    this.setState({
+      filters: filters
+    }, this.props.onChange(filters));
   },
 
   updateFilterStatus: function (filterStatus) {
     var state = this.state;
 
-    this.setState(Object.assign(state.filters, {
+    var filters = Object.assign({}, state.filters, {
       filterStatus: filterStatus
-    }), this.props.onChange(state.filters));
+    });
+
+    this.setState({
+      filters: filters
+    }, this.props.onChange(filters));
   },
 
   getClearLinkForFilter: function (filterQueryParamKey) {

--- a/src/js/components/SidebarComponent.jsx
+++ b/src/js/components/SidebarComponent.jsx
@@ -27,23 +27,9 @@ var SidebarComponent = React.createClass({
     };
   },
 
-  updateFilterLabels: function (filterLabels) {
-    var state = this.state;
-
-    var filters = Object.assign({}, state.filters, {
-      filterLabels: filterLabels
-    });
-
-    this.setState({
-      filters: filters
-    }, this.props.onChange(filters));
-  },
-
-  updateFilterStatus: function (filterStatus) {
-    var state = this.state;
-
-    var filters = Object.assign({}, state.filters, {
-      filterStatus: filterStatus
+  updateFilter: function (filterName, filter) {
+    var filters = Object.assign({}, this.state.filters, {
+      [filterName]: filter
     });
 
     this.setState({
@@ -99,13 +85,13 @@ var SidebarComponent = React.createClass({
           {this.getClearLinkForFilter("filterStatus")}
         </div>
         <AppListStatusFilterComponent
-          onChange={this.updateFilterStatus} />
+          onChange={this.updateFilter.bind(null, "filterStatus")} />
         <div className="flex-row">
           <h3 className="small-caps">Label</h3>
           {this.getClearLinkForFilter("filterLabels")}
         </div>
         <AppListLabelsFilterComponent
-          onChange={this.updateFilterLabels} />
+          onChange={this.updateFilter.bind(null, "filterLabels")} />
       </nav>
     );
   }

--- a/src/js/components/SidebarComponent.jsx
+++ b/src/js/components/SidebarComponent.jsx
@@ -1,0 +1,106 @@
+var Link = require("react-router").Link;
+var React = require("react/addons");
+
+var AppListLabelsFilterComponent =
+  require("../components/AppListLabelsFilterComponent");
+var AppListStatusFilterComponent =
+  require("../components/AppListStatusFilterComponent");
+
+var SidebarComponent = React.createClass({
+  displayName: "SidebarComponent",
+
+  contextTypes: {
+    router: React.PropTypes.func
+  },
+
+  propTypes: {
+    groupId: React.PropTypes.string.isRequired,
+    onChange: React.PropTypes.func.isRequired
+  },
+
+  getInitialState: function () {
+    return {
+      filters: {
+        filterLabels: [],
+        filterStatus: []
+      }
+    };
+  },
+
+  updateFilterLabels: function (filterLabels) {
+    var state = this.state;
+
+    this.setState(Object.assign(state.filters, {
+      filterLabels: filterLabels
+    }), this.props.onChange(state.filters));
+  },
+
+  updateFilterStatus: function (filterStatus) {
+    var state = this.state;
+
+    this.setState(Object.assign(state.filters, {
+      filterStatus: filterStatus
+    }), this.props.onChange(state.filters));
+  },
+
+  getClearLinkForFilter: function (filterQueryParamKey) {
+    var state = this.state;
+
+    if (state.filters[filterQueryParamKey].length === 0) {
+      return null;
+    }
+
+    let router = this.context.router;
+    let currentPathname = router.getCurrentPathname();
+    let query = Object.assign({}, router.getCurrentQuery());
+    let params = router.getCurrentParams();
+
+    if (query[filterQueryParamKey] != null) {
+      delete query[filterQueryParamKey];
+    }
+
+    return (
+      <Link to={currentPathname} query={query} params={params}>
+        Clear
+      </Link>
+    );
+  },
+
+  render: function () {
+    var path = this.context.router.getCurrentPathname();
+    var props = this.props;
+
+    var newAppModalQuery = {
+      modal: "new-app"
+    };
+
+    if (props.groupId != null && props.groupId !== "/") {
+      newAppModalQuery.groupId = props.groupId;
+    }
+
+    return (
+      <nav className="sidebar">
+        <Link to={path}
+          query={newAppModalQuery}
+          className="btn btn-success create-app"
+          activeClassName="create-app-active">
+          Create
+        </Link>
+        <div className="flex-row">
+          <h3 className="small-caps">Status</h3>
+          {this.getClearLinkForFilter("filterStatus")}
+        </div>
+        <AppListStatusFilterComponent
+          onChange={this.updateFilterStatus} />
+        <div className="flex-row">
+          <h3 className="small-caps">Label</h3>
+          {this.getClearLinkForFilter("filterLabels")}
+        </div>
+        <AppListLabelsFilterComponent
+          onChange={this.updateFilterLabels} />
+      </nav>
+    );
+  }
+});
+
+module.exports = SidebarComponent;

--- a/src/js/components/TabPanesComponent.jsx
+++ b/src/js/components/TabPanesComponent.jsx
@@ -1,19 +1,15 @@
-var Link = require("react-router").Link;
 var React = require("react/addons");
 
 var AppListFilterComponent = require("../components/AppListFilterComponent");
-var AppListLabelsFilterComponent =
-  require("../components/AppListLabelsFilterComponent");
-var AppListStatusFilterComponent =
-  require("../components/AppListStatusFilterComponent");
 var AppListComponent = require("../components/AppListComponent");
 var BreadcrumbComponent = require("../components/BreadcrumbComponent");
 var DeploymentsListComponent =
   require("../components/DeploymentsListComponent");
+var SidebarComponent = require("../components/SidebarComponent");
 var TabPaneComponent = require("../components/TabPaneComponent");
 var TogglableTabsComponent = require("../components/TogglableTabsComponent");
-var AppListViewTypes = require("../constants/AppListViewTypes");
 
+var AppListViewTypes = require("../constants/AppListViewTypes");
 var tabs = require("../constants/tabs");
 
 var TabPanesComponent = React.createClass({
@@ -26,10 +22,7 @@ var TabPanesComponent = React.createClass({
   getInitialState: function () {
     return {
       currentGroup: "/",
-      filterText: "",
-      filterLabels: [],
-      filterStatus: [],
-      filterTypes: []
+      filters: {}
     };
   },
 
@@ -56,28 +49,8 @@ var TabPanesComponent = React.createClass({
     });
   },
 
-  updateFilterText: function (filterText) {
-    this.setState({
-      filterText: filterText
-    });
-  },
-
-  updateFilterLabels: function (filterLabels) {
-    this.setState({
-      filterLabels: filterLabels
-    });
-  },
-
-  updateFilterStatus: function (filterStatus) {
-    this.setState({
-      filterStatus: filterStatus
-    });
-  },
-
-  updateFilterTypes: function (filterTypes) {
-    this.setState({
-      filterTypes: filterTypes
-    });
+  updateFilters: function (filters) {
+    this.setState(Object.assign(this.state.filters, filters));
   },
 
   getTabId: function () {
@@ -92,80 +65,26 @@ var TabPanesComponent = React.createClass({
     return tabs[0].id;
   },
 
-  getClearLinkForFilter: function (filterQueryParamKey) {
-    var state = this.state;
-
-    if (state[filterQueryParamKey].length === 0) {
-      return null;
-    }
-
-    let router = this.context.router;
-    let currentPathname = router.getCurrentPathname();
-    let query = Object.assign({}, router.getCurrentQuery());
-    let params = router.getCurrentParams();
-
-    if (query[filterQueryParamKey] != null) {
-      delete query[filterQueryParamKey];
-    }
-
-    return (
-      <Link to={currentPathname} query={query} params={params}>
-        Clear
-      </Link>
-    );
-  },
-
   render: function () {
-    var path = this.context.router.getCurrentPathname();
     var state = this.state;
 
-    var appListProps = {
+    var appListProps = Object.assign({
       currentGroup: state.currentGroup,
-      filterText: state.filterText,
-      filterLabels: state.filterLabels,
-      filterTypes: state.filterTypes,
-      filterStatus: state.filterStatus,
       viewType: AppListViewTypes.LIST
-    };
-
-    var newAppModalQuery = {
-      modal: "new-app"
-    };
-
-    if (state.currentGroup != null && state.currentGroup !== "/") {
-      newAppModalQuery.groupId = state.currentGroup;
-    }
+    }, state.filters);
 
     return (
       <TogglableTabsComponent activeTabId={this.getTabId()}
           className="container-fluid content">
         <TabPaneComponent id={tabs[0].id} className="flex-container">
           <div className="wrapper">
-            <nav className="sidebar">
-              <Link to={path}
-                query={newAppModalQuery}
-                className="btn btn-success create-app"
-                activeClassName="create-app-active">
-                Create
-              </Link>
-              <div className="flex-row">
-                <h3 className="small-caps">Status</h3>
-                {this.getClearLinkForFilter("filterStatus")}
-              </div>
-              <AppListStatusFilterComponent
-                onChange={this.updateFilterStatus} />
-              <div className="flex-row">
-                <h3 className="small-caps">Label</h3>
-                {this.getClearLinkForFilter("filterLabels")}
-              </div>
-              <AppListLabelsFilterComponent
-                onChange={this.updateFilterLabels} />
-            </nav>
+            <SidebarComponent groupId={state.currentGroup}
+              onChange={this.updateFilters} />
             <main>
               <div className="contextual-bar">
                 <BreadcrumbComponent groupId={state.currentGroup} />
                 <div className="app-list-controls">
-                  <AppListFilterComponent onChange={this.updateFilterText}/>
+                  <AppListFilterComponent onChange={this.updateFilters} />
                 </div>
               </div>
               <AppListComponent {...appListProps} />

--- a/src/js/components/TabPanesComponent.jsx
+++ b/src/js/components/TabPanesComponent.jsx
@@ -50,7 +50,10 @@ var TabPanesComponent = React.createClass({
   },
 
   updateFilters: function (filters) {
-    this.setState(Object.assign(this.state.filters, filters));
+    var filters = Object.assign({}, this.state.filters, filters);
+    this.setState({
+      filters: filters
+    });
   },
 
   getTabId: function () {


### PR DESCRIPTION
This moves the sidebar into it's own component and introduces a more handy filters-object, where the actual filters lives in, so every onChange-handler from every filter component is generic now.