### PR TITLE
Fix - Blotted status icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Adjust the task list column order
 - Use colored labels instead of dots for task health
 
+### Fixed
+- \#2626 - Status icons are rendered blotted
+
 ## 0.13.3 - 2015-11-10
 ### Added
 - Show application count on application status filters
@@ -15,7 +18,7 @@
 
 ### Fixed
 - \#2593 - Very long labels expand horizontal scrollbar in app list
-- \#2615 - Keep input focus position when updating the Filter bar 
+- \#2615 - Keep input focus position when updating the Filter bar
 
 ## 0.13.2 - 2015-11-09
 ### Fixed

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -208,6 +208,7 @@ a:focus {
 .icon {
   display: inline-block;
   vertical-align: middle;
+  background-repeat: no-repeat;
 
   svg {
     width: 100%;

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -27,7 +27,8 @@
  */
 
 body {
-  font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-family:
+    'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   background-color: #323539;
   color: #f6f6f6;
   // Overwrite default bootstrap line height
@@ -222,7 +223,8 @@ a:focus {
 
     &:before {
 
-      line-height: floor(floor(@icon-mini-height * @icon-mini-scale) + (@icon-mini-offset * @icon-mini-scale));
+      line-height: floor(floor(@icon-mini-height * @icon-mini-scale)
+        + (@icon-mini-offset * @icon-mini-scale));
 
     }
 
@@ -264,7 +266,8 @@ a:focus {
 
     &:before {
 
-      line-height: floor(floor(@icon-small-height * @icon-small-scale) + (@icon-small-offset * @icon-small-scale));
+      line-height: floor(floor(@icon-small-height * @icon-small-scale)
+        + (@icon-small-offset * @icon-small-scale));
 
     }
 
@@ -289,7 +292,8 @@ a:focus {
 
     &:before {
 
-      line-height: floor(floor(@icon-medium-height * @icon-medium-scale) + (@icon-medium-offset * @icon-medium-scale));
+      line-height: floor(floor(@icon-medium-height * @icon-medium-scale)
+        + (@icon-medium-offset * @icon-medium-scale));
 
     }
 
@@ -304,7 +308,8 @@ a:focus {
 
     &:before {
 
-      line-height: floor(floor(@icon-large-height * @icon-large-scale) + (@icon-large-offset * @icon-large-scale));
+      line-height: floor(floor(@icon-large-height * @icon-large-scale)
+        + (@icon-large-offset * @icon-large-scale));
 
     }
 
@@ -1412,7 +1417,8 @@ fieldset[disabled] .btn-info.active {
   label::before {
     border: 1px solid @btn-default-text-color;
     content: "";
-    transition: border @transition-fast ease-in-out, color @transition-fast ease-in-out;
+    transition: border @transition-fast ease-in-out,
+      color @transition-fast ease-in-out;
   }
 }
 


### PR DESCRIPTION
This fixes https://github.com/mesosphere/marathon/issues/2626

Before:
![bg-repeat](https://cloud.githubusercontent.com/assets/859154/11120215/a007ae86-894e-11e5-950f-faed483a7090.png)

After:
![bg-no-repeat](https://cloud.githubusercontent.com/assets/859154/11120218/a4d84498-894e-11e5-8944-28bbec7c33ab.png)
