### PR TITLE
Feature/marathon 354 labels dropdown bis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Added
 - Prefill ID field with group structure in app creation modal
 - Show an animated loading bar on app deployment status
+- Show all labels inside a dropdown menu revealed on click
 
 ### Changed
 - Adjust the task list column order

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -412,6 +412,57 @@ a:focus {
             visibility: inherit;
           }
         }
+
+        .more:hover {
+          background-color: @btn-default-active-bg-color;
+        }
+
+        .labels-dropdown {
+          background-color: @navbar-bg-color;
+          display: none;
+          left: 100%;
+          margin-left: @base-spacing-unit * 2;
+          margin-top: -@base-spacing-unit * 2;
+          position: absolute;
+          top: 0;
+          z-index: 1;
+
+          &.visible {
+            display: block;
+          }
+
+          > h5 {
+            color: @table-text-color;
+            padding: @base-spacing-unit * 2;
+            margin: 0;
+          }
+
+          > .left-arrow {
+            display: block;
+            border-top: @base-spacing-unit solid transparent;
+            border-bottom: @base-spacing-unit solid transparent;
+            border-right: @base-spacing-unit solid @navbar-bg-color;
+            height: 0;
+            margin-left: -@base-spacing-unit;
+            margin-top: @base-spacing-unit * 2;
+            position: absolute;
+            top: 0;
+            width: 0;
+          }
+
+          > ul {
+            padding: 0 @base-spacing-unit * 2;
+
+            li {
+              display: block;
+              margin: 0 0 @base-spacing-unit 0;
+
+              .label {
+                margin: 0;
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -611,7 +611,7 @@ fieldset[disabled] .btn-info.active {
 }
 
 .navbar-inverse {
-  background-color: #222426;
+  background-color: @navbar-bg-color;
   border: none;
   margin: 0;
 }
@@ -1086,7 +1086,7 @@ fieldset[disabled] .btn-info.active {
   .panel-heading {
     color: @link-color;
   }
-  background-color: #222426;
+  background-color: @navbar-bg-color;
   border-radius: 0;
   border: none;
 
@@ -1217,7 +1217,7 @@ fieldset[disabled] .btn-info.active {
  * ==============
  */
 .tooltip {
-  background: #222426;
+  background: @navbar-bg-color;
   text-transform: capitalize;
 
   &.default {

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -387,6 +387,7 @@ a:focus {
 
       .labels {
         display: inline-block;
+        position: relative;
 
         .label, .more {
           position: fixed;

--- a/src/css/variables.less
+++ b/src/css/variables.less
@@ -7,7 +7,7 @@
 @sidebar-heading-color: #5E646C;
 @navbar-inactive-color: #8E929B;
 @navbar-bg-color: #222426;
-@navbar-active-color: #ffffff;
+@navbar-active-color: #FFFFFF;
 @btn-default-border-color: #5E646C;
 @btn-default-text-color: #FFFFFF;
 @btn-default-active-bg-color: #5E646C;

--- a/src/css/variables.less
+++ b/src/css/variables.less
@@ -6,7 +6,8 @@
 @sidebar-bg-color: #2A2D30;
 @sidebar-heading-color: #5E646C;
 @navbar-inactive-color: #8E929B;
-@navbar-active-color: #FFFFFF;
+@navbar-bg-color: #222426;
+@navbar-active-color: #ffffff;
 @btn-default-border-color: #5E646C;
 @btn-default-text-color: #FFFFFF;
 @btn-default-active-bg-color: #5E646C;

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -208,7 +208,7 @@ var AppListItemComponent = React.createClass({
         <td className="icon-cell">
           {this.getIcon()}
         </td>
-        <td className="overflow-ellipsis name-cell" title={model.id}
+        <td className="name-cell" title={model.id}
             ref="nameCell">
           <span className="name" ref="nameNode">{name}</span>
           {this.getLabels()}

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -32,7 +32,6 @@ var AppListItemComponent = React.createClass({
       window.addEventListener("focus", this.handleResize);
     }
     this.updateNumberOfVisibleLabels();
-
   },
 
   componentDidUpdate: function (prevProps) {
@@ -74,7 +73,7 @@ var AppListItemComponent = React.createClass({
     var labels = this.props.model.labels;
 
     if (labels == null || Object.keys(labels).length === 0) {
-      return null;
+      return;
     }
 
     let refs = this.refs;
@@ -111,7 +110,6 @@ var AppListItemComponent = React.createClass({
 
   getLabels: function () {
     var labels = this.props.model.labels;
-
     if (labels == null || Object.keys(labels).length === 0) {
       return null;
     }

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -2,6 +2,8 @@ var classNames = require("classnames");
 var React = require("react/addons");
 
 var AppHealthComponent = require("../components/AppHealthComponent");
+var AppListItemLabelsComponent =
+  require("../components/AppListItemLabelsComponent");
 var AppStatusComponent = require("../components/AppStatusComponent");
 var Util = require("../helpers/Util");
 var PathUtil = require("../helpers/PathUtil");
@@ -88,9 +90,11 @@ var AppListItemComponent = React.createClass({
 
     let labelsWidth = 0;
     let numberOfVisibleLabels = 0;
+    let labelNodes = React.findDOMNode(refs.labels).querySelectorAll(".label");
 
-    refs.labels.props.children[0].find((label) => {
-      labelsWidth += DOMUtil.getOuterWidth(React.findDOMNode(refs[label.ref]));
+    // labelNodes is not an Array, but a NodeList
+    [].forEach.call(labelNodes, function (label) {
+      labelsWidth += DOMUtil.getOuterWidth(label);
       if (labelsWidth > availableWidth) {
         return true;
       }
@@ -114,51 +118,19 @@ var AppListItemComponent = React.createClass({
       return null;
     }
 
-    let numberOfVisibleLabels = this.state.numberOfVisibleLabels;
-    let nodes = Object.keys(labels).sort().map(function (key, i) {
-      if (key == null || Util.isEmptyString(key)) {
-        return null;
-      }
-
-      let labelText = key;
-      if (!Util.isEmptyString(labels[key])) {
-        labelText = `${key}:${labels[key]}`;
-      }
-
-      let labelClassName = classNames("label", {
-        "visible": i < numberOfVisibleLabels
-      });
-
-      return (
-        <span key={i} className={labelClassName} title={labelText}
-            ref={`label${i}`}>
-          {labelText}
-        </span>
-      );
-    });
-
-    let moreLabelClassName = classNames("more", {
-      "visible": Object.keys(labels).length > numberOfVisibleLabels
+    var moreLabelClassName = classNames("more", {
+      "visible": Object.keys(labels).length > this.state.numberOfVisibleLabels
     });
 
     return (
-      <div className="labels" ref="labels">
-        {nodes}
-        <span className={moreLabelClassName}
-            onClick={this.handleMoreLabelClick}
-            ref="moreLabel">
+     <AppListItemLabelsComponent ref="labels"
+          labels={this.props.model.labels}
+          numberOfVisibleLabels={this.state.numberOfVisibleLabels}>
+        <span className={moreLabelClassName} ref="moreLabel">
           &hellip;
         </span>
-      </div>
+     </AppListItemLabelsComponent>
     );
-  },
-
-  handleMoreLabelClick: function (event) {
-    event.stopPropagation();  // Prevent this.onClick being called
-    this.context.router.transitionTo("appView", {
-      appId: encodeURIComponent(this.props.model.id),
-      view: "configuration"
-    });
   },
 
   onClick: function () {

--- a/src/js/components/AppListItemLabelsComponent.jsx
+++ b/src/js/components/AppListItemLabelsComponent.jsx
@@ -66,7 +66,7 @@ var AppListItemLabelsComponent = React.createClass({
     }
 
     let height = dropdownNode.offsetHeight;
-    let vh = document.documentElement.clientHeight;
+    let viewportHeight = document.documentElement.clientHeight;
     let offsetTop = 0;
 
     if (dropdownNode.dataset.dropdownReversed != null) {
@@ -75,7 +75,7 @@ var AppListItemLabelsComponent = React.createClass({
       offsetTop = dropdownNode.getBoundingClientRect().top + height;
     }
 
-    if (offsetTop >= vh) {
+    if (offsetTop >= viewportHeight) {
       dropdownNode.style.marginTop = `-${height - this.initialMarginTop * 2}px`;
       leftArrowNode.style.marginTop = `${height - this.initialMarginTop * 2}px`;
       dropdownNode.dataset.dropdownReversed = 1;

--- a/src/js/components/AppListItemLabelsComponent.jsx
+++ b/src/js/components/AppListItemLabelsComponent.jsx
@@ -1,0 +1,159 @@
+var classNames = require("classnames");
+var React = require("react/addons");
+
+var OnClickOutsideMixin = require("react-onclickoutside");
+var Util = require("../helpers/Util");
+
+var AppListItemLabelsComponent = React.createClass({
+  displayName: "AppListItemLabelsComponent",
+
+  initialMarginTop: null,
+
+  mixins: [OnClickOutsideMixin],
+
+  propTypes: {
+    children: React.PropTypes.node,
+    labels: React.PropTypes.object,
+    numberOfVisibleLabels: React.PropTypes.number
+  },
+
+  getInitialState: function () {
+    return {
+      isDropdownVisible: false
+    };
+  },
+
+  componentDidUpdate: function () {
+    if (this.state.isDropdownVisible === true) {
+      this.recalculateDropdownPosition();
+    }
+  },
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return this.didPropsChange(nextProps, nextState);
+  },
+
+  didPropsChange: function (props, state) {
+    let keys = ["labels", "numberOfVisibleLabels"];
+    return !Util.compareProperties(this.props, props, ...keys) ||
+      this.state.isDropdownVisible !== state.isDropdownVisible;
+  },
+
+  handleClickOutside: function () {
+    this.setState({
+      isDropdownVisible: false
+    });
+  },
+
+  handleShowMoreClick: function (event) {
+    event.stopPropagation();
+    this.setState({
+      isDropdownVisible: !this.state.isDropdownVisible
+    });
+  },
+
+  recalculateDropdownPosition: function () {
+    if (global.window == null) {
+      return;
+    }
+
+    let dropdownNode = React.findDOMNode(this.refs.labelsDropdown);
+    let leftArrowNode = React.findDOMNode(this.refs.leftArrow);
+
+    // First time the dropdown becomes visible: get its initial top offset
+    if (this.initialMarginTop == null) {
+      this.initialMarginTop = Math.abs(dropdownNode.offsetTop);
+    }
+
+    let height = dropdownNode.offsetHeight;
+    let vh = document.documentElement.clientHeight;
+    let offsetTop = 0;
+
+    if (dropdownNode.dataset.dropdownReversed != null) {
+      offsetTop = dropdownNode.getBoundingClientRect().bottom + height;
+    } else {
+      offsetTop = dropdownNode.getBoundingClientRect().top + height;
+    }
+
+    if (offsetTop >= vh) {
+      dropdownNode.style.marginTop = `-${height - this.initialMarginTop * 2}px`;
+      leftArrowNode.style.marginTop = `${height - this.initialMarginTop * 2}px`;
+      dropdownNode.dataset.dropdownReversed = 1;
+    } else {
+      dropdownNode.style.marginTop = `-${this.initialMarginTop}px`;
+      leftArrowNode.style.marginTop = `${this.initialMarginTop}px`;
+      dropdownNode.removeAttribute("data-dropdown-reversed");
+    }
+  },
+
+  render: function () {
+    var props = this.props;
+    var labels = props.labels;
+
+    if (labels == null || Object.keys(labels).length === 0) {
+      return null;
+    }
+
+    let numberOfVisibleLabels = props.numberOfVisibleLabels;
+    let labelNodes = [];
+    let dropdownNodes = [];
+
+    Object.keys(labels).sort().forEach(function (key, i) {
+      if (key == null || Util.isEmptyString(key)) {
+        return null;
+      }
+
+      let labelText = key;
+      if (!Util.isEmptyString(labels[key])) {
+        labelText = `${key}:${labels[key]}`;
+      }
+
+      let labelClassName = classNames("label", {
+        "visible": i < numberOfVisibleLabels
+      });
+
+      labelNodes.push((
+        <span key={i} className={labelClassName} title={labelText}
+          ref={`label${i}`}>
+          {labelText}
+        </span>
+      ));
+
+      dropdownNodes.push((
+        <li key={i} title={labelText}>
+          <span className="label visible">{labelText}</span>
+        </li>
+      ));
+    });
+
+    let labelsDropdownClassName = classNames("labels-dropdown", {
+      "visible": this.state.isDropdownVisible &&
+        numberOfVisibleLabels < labelNodes.length
+    });
+
+    let labelsDropdown = (
+      <div className={labelsDropdownClassName} ref="labelsDropdown">
+        <span className="left-arrow" ref="leftArrow"></span>
+        <h5>All Labels</h5>
+        <ul>
+          {dropdownNodes}
+        </ul>
+      </div>
+    );
+
+    // Keep the parent's ref for measurements, but handle events internally
+    var showMore = React.Children.map(this.props.children, (child) =>
+      React.cloneElement(child, {onClick: this.handleShowMoreClick})
+    );
+
+    return (
+      <div className="labels">
+        {labelNodes}
+        {showMore}
+        {labelsDropdown}
+      </div>
+    );
+  }
+});
+
+module.exports = AppListItemLabelsComponent;

--- a/src/js/components/AppListItemLabelsComponent.jsx
+++ b/src/js/components/AppListItemLabelsComponent.jsx
@@ -95,14 +95,14 @@ var AppListItemLabelsComponent = React.createClass({
     }
 
     if (offsetTop >= viewportHeight) {
-      dropdownNode.style.marginTop =
-        `-${height - _initialTopMargins[id] * 2}px`;
-      leftArrowNode.style.marginTop =
-        `${height - _initialTopMargins[id] * 2}px`;
+      const marginTop = height - _initialTopMargins[id] * 2;
+      dropdownNode.style.marginTop = `-${marginTop}px`;
+      leftArrowNode.style.marginTop = `${marginTop}px`;
       _reversedDropdowns[id] = true;
     } else {
-      dropdownNode.style.marginTop = `-${_initialTopMargins[id]}px`;
-      leftArrowNode.style.marginTop = `${_initialTopMargins[id]}px`;
+      const marginTop = _initialTopMargins[id];
+      dropdownNode.style.marginTop = `-${marginTop}px`;
+      leftArrowNode.style.marginTop = `${marginTop}px`;
       _reversedDropdowns[id] = false;
     }
   },


### PR DESCRIPTION
This PR addresses most of the issues of the previous attempt, and does so by extracting the relevant labels part into a new component as suggested by @orlandohohmeier. 

In order to use `position: absolute` (for the dropdown) within the parent with `postion: relative` (name cell) I had to remove the `overflow: hidden` of the .name cell. So the line-breaking ellipsis on smaller widths is still an issue. But we can solve that in a separate PR, even by simply toggling this className on/off under a certain min width of the container element.

![dd](https://cloud.githubusercontent.com/assets/1078545/11128075/dc23b4cc-8977-11e5-8d40-3c300276d8d8.gif)
