### PR TITLE
sick -> unhealthy

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -907,8 +907,8 @@ fieldset[disabled] .btn-info.active {
     color:@task-health-healthy-color;
   }
 
-  .sick {
-    color:@task-health-sick-color;
+  .unhealthy {
+    color: @task-health-unhealthy-color;
   }
 
   .unknown {

--- a/src/css/variables.less
+++ b/src/css/variables.less
@@ -27,7 +27,7 @@
 @app-status-delayed-color: #F04F42;
 @app-status-suspended-color: @table-text-color;
 @task-health-healthy-color: #00D99C;
-@task-health-sick-color: #FD5B77;
+@task-health-unhealthy-color: #FD5B77;
 @task-health-unknown-color: @table-text-color;
 @health-bar-inner-color: #2A2C31;
 @health-bar-over-capacity-color: #4CA0FF;

--- a/src/js/components/TaskListItemComponent.jsx
+++ b/src/js/components/TaskListItemComponent.jsx
@@ -89,7 +89,7 @@ var TaskListItemComponent = React.createClass({
 
     var healthClassSet = classNames({
       "hidden": !hasHealth,
-      "sick": taskHealth === HealthStatus.UNHEALTHY,
+      "unhealthy": taskHealth === HealthStatus.UNHEALTHY,
       "healthy": taskHealth === HealthStatus.HEALTHY,
       "unknown": taskHealth === HealthStatus.UNKNOWN
     });


### PR DESCRIPTION
Following a conversation with @air and @ashenden, we're going to use 'unhealthy' instead of 'sick'.

This PR removes all references to 'sick' from the codebase. 