### PR TITLE
Prevent line-break when collapsing cell width

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -393,7 +393,7 @@ a:focus {
 
       .labels {
         display: inline-block;
-        position: relative;
+        position: absolute;
 
         .label, .more {
           position: fixed;

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -180,7 +180,7 @@ var AppListItemComponent = React.createClass({
         <td className="icon-cell">
           {this.getIcon()}
         </td>
-        <td className="name-cell" title={model.id}
+        <td className="overflow-ellipsis name-cell" title={model.id}
             ref="nameCell">
           <span className="name" ref="nameNode">{name}</span>
           {this.getLabels()}


### PR DESCRIPTION
For the dropdown to escape the overflow:hidden the parent needs to be
positioned. By using absolute instead of relative, we also fix the line
break.

The only issue with this is that the (...) slightly overlap the CPU column. 
![linebreakfix](https://cloud.githubusercontent.com/assets/1078545/11148815/5d0e36f0-8a1f-11e5-9211-576fe325f738.gif)


This fixes https://github.com/mesosphere/marathon-ui/pull/392