### PR TITLE
Fix/1780 add delete task error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - \#2626 - Status icons are rendered blotted
 - \#2627 - Tasks health column shows different health status
 - \#2634 - UI does not update/show the status correctly
+- \#1780 - When app is locked by deployment, deleting tasks via the UI does
+nothing
 
 ## 0.13.3 - 2015-11-10
 ### Added

--- a/src/js/actions/TasksActions.js
+++ b/src/js/actions/TasksActions.js
@@ -27,13 +27,17 @@ var TasksActions = {
         });
       });
   },
-  deleteTasksAndScale: function (appId, taskIds = []) {
+  deleteTasksAndScale: function (appId, taskIds = [], force = false) {
+    var url = `${config.apiURL}v2/tasks/delete?scale=true`;
+    if (force) {
+      url = url + "&force=true";
+    }
     this.request({
       method: "POST",
       data: {
         "ids": taskIds
       },
-      url: `${config.apiURL}v2/tasks/delete?scale=true`
+      url: url
     })
       .success(function () {
         AppDispatcher.dispatch({

--- a/src/js/actions/TasksActions.js
+++ b/src/js/actions/TasksActions.js
@@ -49,7 +49,8 @@ var TasksActions = {
       .error(function (error) {
         AppDispatcher.dispatch({
           actionType: TasksEvents.DELETE_ERROR,
-          data: error
+          data: error,
+          taskIds: taskIds
         });
       });
   },

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -25,6 +25,8 @@ var PathUtil = require("../helpers/PathUtil");
 var QueueActions = require("../actions/QueueActions");
 var QueueEvents = require("../events/QueueEvents");
 var QueueStore = require("../stores/QueueStore");
+var TasksActions = require("../actions/TasksActions");
+var TasksEvents = require("../events/TasksEvents");
 
 var tabsTemplate = [
   {id: "apps/:appId", text: "Tasks"},
@@ -102,6 +104,7 @@ var AppPageComponent = React.createClass({
     AppsStore.on(AppsEvents.RESTART_APP_ERROR, this.onRestartAppError);
     AppsStore.on(AppsEvents.DELETE_APP_ERROR, this.onDeleteAppError);
     AppsStore.on(AppsEvents.DELETE_APP, this.onDeleteAppSuccess);
+    AppsStore.on(TasksEvents.DELETE_ERROR, this.onDeleteTaskError);
     QueueStore.on(QueueEvents.RESET_DELAY_ERROR, this.onResetDelayError);
     QueueStore.on(QueueEvents.RESET_DELAY, this.onResetDelaySuccess);
   },
@@ -218,6 +221,26 @@ var AppPageComponent = React.createClass({
 
   onDeleteAppSuccess: function () {
     this.context.router.transitionTo("apps");
+  },
+
+  onDeleteTaskError: function (errorMessage, statusCode, taskIds) {
+    if (statusCode === 409) {
+      let appId = this.state.appId;
+      const dialogId = DialogActions.
+      confirm(`Failed to kill task and scale ${appId}. If you want to stop any
+        current deployment of the app and force a new one to kill the task and
+        scale it, press the OK button.`);
+      DialogStore.handleUserResponse(dialogId, function () {
+        TasksActions.deleteTasksAndScale(appId, taskIds, true);
+      });
+    } else if (statusCode === 401) {
+      DialogActions.alert(`Not scaling: ${Messages.UNAUTHORIZED}`);
+    } else if (statusCode === 403) {
+      DialogActions.alert(`Not scaling: ${Messages.FORBIDDEN}`);
+    } else {
+      DialogActions.alert(`Not scaling:
+          ${errorMessage.message || errorMessage}`);
+    }
   },
 
   onResetDelaySuccess: function () {

--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -316,7 +316,8 @@ AppDispatcher.register(function (action) {
       AppsStore.emit(
         TasksEvents.DELETE_ERROR,
         action.data.body,
-        action.data.status
+        action.data.status,
+        action.taskIds
       );
       break;
   }


### PR DESCRIPTION
![task-delete-error-message](https://cloud.githubusercontent.com/assets/647035/11190489/0ba0f73e-8c96-11e5-8768-18bbb4c3c33f.gif)

When app is locked by deployment show an error message and offer a method to forcefully kill tasks and scale the respective app accordingly.

Closes mesosphere/marathon#1780