### PR TITLE
Fix - 2627 unhealthy task status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 - \#2626 - Status icons are rendered blotted
+- \#2627 - Tasks health column shows different health status
 
 ## 0.13.3 - 2015-11-10
 ### Added

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -317,28 +317,23 @@ var AppPageComponent = React.createClass({
     }).join(" ");
   },
 
-  getTaskHealthMessage: function (taskId) {
+  getTaskHealthMessage: function (taskId, unhealthyDetails = false) {
     var task = AppsStore.getTask(this.state.appId, taskId);
 
     if (task === undefined) {
       return null;
     }
 
-    var msg;
-
     switch (task.healthStatus) {
       case HealthStatus.HEALTHY:
-        msg = "Healthy";
-        break;
+        return "Healthy";
       case HealthStatus.UNHEALTHY:
-        msg = this.getUnhealthyTaskMessage(task.healthCheckResults);
-        break;
+        return unhealthyDetails
+          ? this.getUnhealthyTaskMessage(task.healthCheckResults)
+          : "Unhealthy";
       default:
-        msg = "Unknown";
-        break;
+        return "Unknown";
     }
-
-    return msg;
   },
 
   getResetDelayButton: function () {
@@ -398,7 +393,7 @@ var AppPageComponent = React.createClass({
       <TaskDetailComponent
         appId={state.appId}
         fetchState={state.fetchState}
-        taskHealthMessage={this.getTaskHealthMessage(state.activeTaskId)}
+        taskHealthMessage={this.getTaskHealthMessage(state.activeTaskId, true)}
         hasHealth={Object.keys(model.healthChecks).length > 0}
         task={task} />
     );

--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -35,26 +35,21 @@ function removeTasks(tasks, relatedAppId, taskIds) {
 }
 
 function getTaskHealth(task) {
-  var nullResult = true;
-  var health = false;
   var healthCheckResults = task.healthCheckResults;
 
-  if (healthCheckResults != null) {
-    health = lazy(healthCheckResults).every(function (hcr) {
+  if (healthCheckResults != null && healthCheckResults.length > 0) {
+    let isHealthy = healthCheckResults.every(function (hcr) {
       if (hcr.firstSuccess) {
-        nullResult = false;
         return hcr.alive;
       }
 
       return false;
     });
-  }
 
-  if (!health && nullResult) { // health check has not returned yet
+    return isHealthy ? HealthStatus.HEALTHY : HealthStatus.UNHEALTHY;
+  } else {
     return HealthStatus.UNKNOWN;
   }
-
-  return health ? HealthStatus.HEALTHY : HealthStatus.UNHEALTHY;
 }
 
 function setTaskStatus(task) {

--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -955,11 +955,18 @@ describe("App Page component", function () {
   });
 
   it("returns the right health message for failing tasks", function () {
-    var msg = this.element.getTaskHealthMessage("test-task-1");
+    var msg = this.element.getTaskHealthMessage("test-task-1", true);
     expect(msg).to.equal("Warning: Health check 'HTTP /' failed.");
   });
 
-  it("returns the right health message for tasks with unknown health", function () {
+  it("returns the right shorthand health message for failing tasks",
+      function () {
+    var msg = this.element.getTaskHealthMessage("test-task-1");
+    expect(msg).to.equal("Unhealthy");
+  });
+
+  it("returns the right health message for tasks with unknown health",
+      function () {
     var app = Util.extendObject(appScheme, {
       id: "/test-app-1",
       status: AppStatus.RUNNING,


### PR DESCRIPTION
This fixes https://github.com/mesosphere/marathon/issues/2627

And it returns the correct label "Unhealthy" now in the column and not the detailed unhealthy message, that was mistakenly introduced before.

![hc2](https://cloud.githubusercontent.com/assets/859154/11192428/73914ae6-8ca1-11e5-80bc-372354c9736e.png)

![hc1](https://cloud.githubusercontent.com/assets/859154/11192429/77443d1a-8ca1-11e5-9607-b76a4b9f7178.png)

