### PR TITLE
Always set the number of visible labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 - \#2626 - Status icons are rendered blotted
 - \#2627 - Tasks health column shows different health status
+- \#2634 - UI does not update/show the status correctly
 
 ## 0.13.3 - 2015-11-10
 ### Added

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -75,6 +75,7 @@ var AppListItemComponent = React.createClass({
     var labels = this.props.model.labels;
 
     if (labels == null || Object.keys(labels).length === 0) {
+      this.setState({numberOfVisibleLabels: 0});
       return;
     }
 


### PR DESCRIPTION
As the numberOfVisibleLabels is used in a component update condition we need to always set a proper value (>=0) otherwise we will prevent future component updates.

Fixes mesosphere/marathon#2634