### PR TITLE
Remove bolding from app status

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -539,7 +539,7 @@ a:focus {
 .page-header .app-status {
   font-size: @font-size-icon;
   line-height: @base-font-size;
-  font-weight: bold;
+
   .tasks-summary {
     margin: @base-spacing-unit * 0.25 0 0 @horizontal-spacing-unit;
     font-size: @base-font-size;;


### PR DESCRIPTION
From:
![screen shot 2015-11-18 at 18 31 18](https://cloud.githubusercontent.com/assets/1078545/11248657/97faa76a-8e22-11e5-931b-6c89778bfb36.png)

To: 
![screen shot 2015-11-18 at 18 31 01](https://cloud.githubusercontent.com/assets/1078545/11248659/9b57406c-8e22-11e5-836e-681027e2f881.png)

This was probably a leftover in
https://github.com/mesosphere/marathon-ui/pull/389, specifically in https://github.com/mesosphere/marathon-ui/commit/743633efe1962f2c4ba7a939dfdcb5296104d727#diff-57882be50a7849b9e3df98ad4d8a24faR536.

cc @leemunroe 