### PR TITLE
Fix app list labels position

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -430,6 +430,7 @@ a:focus {
           color: @navbar-inactive-color;
           font-size: @small-font-size;
           font-weight: normal;
+          line-height: inherit;
           max-width: @horizontal-spacing-unit * 64;
           overflow: hidden;
           text-overflow: ellipsis;

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -401,6 +401,7 @@ a:focus {
 
       .name, .group-id {
         display: inline-block;
+        line-height: inherit;
         max-width: 100%;
         overflow: hidden;
         text-overflow: ellipsis;

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -399,22 +399,18 @@ a:focus {
         padding-bottom: @base-spacing-unit*0.75;
       }
 
-      .name {
+      .name, .group-id {
         display: inline-block;
         max-width: 100%;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+      }
 
-        .app-name {
-          display: inline-block;
-        }
-
-        .group-id {
-          color: @text-color-muted;
-          display: block;
-          margin-top: @base-spacing-unit*0.25;
-        }
+      .group-id {
+        color: @text-color-muted;
+        display: block;
+        margin-top: @base-spacing-unit*0.25;
       }
 
       .labels {

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -187,10 +187,11 @@ var AppListItemComponent = React.createClass({
         <td className="overflow-ellipsis name-cell global-app-list"
             title={model.id} ref="nameCell">
           <span className="name" ref="nameNode">
-            <span className="app-name">{appName}</span>
-            {this.getLabels()}
-            <span className="group-id">{groupId}</span>
+            {appName}
           </span>
+          {this.getLabels()}
+          <span className="group-id">{groupId}</span>
+
         </td>
       );
     }


### PR DESCRIPTION
![app-list-label-position](https://cloud.githubusercontent.com/assets/647035/11298792/e19943bc-8f81-11e5-982d-9724b14d37e6.gif)
Display app name and labels always in one row.
