### PR TITLE
Fix - Breadcrumbs colors

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1349,6 +1349,7 @@ fieldset[disabled] .btn-info.active {
 
         .breadcrumb {
           background-color: transparent;
+          color: @breadcrumb-text-color;
           font-size: @font-size-h2;
           padding: 0;
           align-items: center;
@@ -1360,6 +1361,8 @@ fieldset[disabled] .btn-info.active {
 
           .clear {
             margin-left: @horizontal-spacing-unit;
+            text-decoration: underline;
+            color: @text-color-muted;
           }
         }
       }

--- a/src/css/variables.less
+++ b/src/css/variables.less
@@ -16,6 +16,7 @@
 @breadcrumb-text-color: #C3C9D7;
 @checkbox-active-color: #2568F5;
 @link-color: #FFFFFF;
+@breadcrumb-text-color: #FFFFFF;
 @text-color-muted: #8E929B;
 @dropdown-bg-color: #FFFFFF;
 @dropdown-separator-color: #DADCDE;


### PR DESCRIPTION
This fixes https://github.com/mesosphere/marathon-ui/pull/411#issuecomment-158364732 detected by @philipnrmn 

![breadcrumbs-colors](https://cloud.githubusercontent.com/assets/859154/11298956/fded0ba6-8f82-11e5-9320-3dd8bab3cb3a.png)
