### PR TITLE
Show proper info on app creation auth error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - \#2660 - Adapt Search box in App Collection View
 - \#2662 - Change Header When Applying Filter in App Collection View
 - \#2663 - Adapt filter count, reflect current result set
+- \#2702 - Show proper info on app creation auth error
 
 ### Fixed
 - \#2691 - Filters don't updated correctly on reload

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -281,6 +281,7 @@ function deleteField(fields, fieldId, index) {
 }
 
 function processResponseErrors(responseErrors, response, statusCode) {
+  var responseHasMessage = response != null && response.message != null;
   if (statusCode >= 500) {
     responseErrors.general =
       AppFormErrorMessages.getGeneralMessage("unknownServerError");
@@ -298,24 +299,33 @@ function processResponseErrors(responseErrors, response, statusCode) {
         AppFormErrorMessages.lookupServerResponseMessage(error.error);
     });
 
-  } else if (statusCode === 409 && response != null &&
-      response.message != null) {
+  } else if (statusCode === 409 && responseHasMessage) {
 
     responseErrors.general =
       AppFormErrorMessages.getGeneralMessage("errorPrefix") + " " +
       response.message;
 
-  } else if (statusCode === 403 && response != null &&
-      response.message != null) {
+  } else if (statusCode === 403) {
 
     responseErrors.general =
       AppFormErrorMessages.getGeneralMessage("forbiddenAccess");
 
-  } else if (statusCode === 401 && response != null &&
-      response.message != null) {
+    if (responseHasMessage) {
+      responseErrors.general =
+        AppFormErrorMessages.getGeneralMessage("errorPrefix") + " " +
+        response.message;
+    }
+
+  } else if (statusCode === 401) {
 
     responseErrors.general =
       AppFormErrorMessages.getGeneralMessage("unauthorizedAccess");
+
+    if (responseHasMessage) {
+      responseErrors.general =
+        AppFormErrorMessages.getGeneralMessage("errorPrefix") + " " +
+        response.message;
+    }
 
   } else if (statusCode === 400 && response != null &&
       Util.isArray(response.details)) {

--- a/src/test/appForm.test.js
+++ b/src/test/appForm.test.js
@@ -796,6 +796,71 @@ describe("App Form", function () {
         });
       });
 
+      it("processes error response codes 401 correctly",
+        function (done) {
+          this.server.setup("something strange", 401);
+
+          AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
+            expectAsync(function () {
+              expect(AppFormStore.responseErrors.general)
+                .to.equal(AppFormErrorMessages.getGeneralMessage("unauthorizedAccess"));
+            }, done);
+          });
+
+          AppsActions.createApp({
+            "howdy": "partner"
+          });
+        });
+
+      it("processes error response codes 401 with message correctly",
+        function (done) {
+          this.server.setup({"message": "something strange"}, 401);
+
+          AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
+            expectAsync(function () {
+              expect(AppFormStore.responseErrors.general)
+                .to.equal(AppFormErrorMessages.getGeneralMessage("errorPrefix") + " something strange");
+            }, done);
+          });
+
+          AppsActions.createApp({
+            "howdy": "partner"
+          });
+        });
+
+      it("processes error response codes 403 correctly",
+        function (done) {
+          this.server.setup("something strange", 403);
+
+          AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
+            expectAsync(function () {
+              expect(AppFormStore.responseErrors.general)
+                .to.equal(AppFormErrorMessages.getGeneralMessage("forbiddenAccess"));
+            }, done);
+          });
+
+          AppsActions.createApp({
+            "howdy": "partner"
+          });
+        });
+
+      it("processes error response codes 403 with message correctly",
+        function (done) {
+          this.server.setup({"message": "something strange"}, 403);
+
+          AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
+            expectAsync(function () {
+              expect(AppFormStore.responseErrors.general)
+                .to.equal(AppFormErrorMessages.getGeneralMessage("errorPrefix") + " something strange");
+            }, done);
+          });
+
+          AppsActions.createApp({
+            "howdy": "partner"
+          });
+        });
+
+
       it("processes error response codes >= 500 correctly", function (done) {
         this.server.setup("something strange with the server", 500);
 


### PR DESCRIPTION
Curently when user is not permited to create new app (unauthenticated or unauthorized) following message is displayed:
> App creation unsuccessful. Check your app settings and try again.

I changed it to use default values even when response is null since it's not used anyway. So now user will get following messages regardless of response message 

> App creation unsuccessful. Access forbidden. Could not execute operation.
> App creation unsuccessful. Unauthorized access. Could not execute operation.