### PR TITLE
Feature - 2661 search on root level

### DIFF
--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -164,13 +164,7 @@ var AppListComponent = React.createClass({
 
   filterNodes: function (nodesSequence, appsStatusesCount) {
     var props = this.props;
-    var currentGroup = props.currentGroup;
     var filters = props.filters;
-
-    if (currentGroup !== "/") {
-      nodesSequence = nodesSequence
-        .filter(app => app.id.startsWith(currentGroup));
-    }
 
     if (filters.filterText != null && filters.filterText !== "") {
       nodesSequence = nodesSequence


### PR DESCRIPTION
This closes finally https://github.com/mesosphere/marathon/issues/2661

If you type something in the text search field, the search is always from the root level, even if you are inside a group.

Inside a group (without searchinput):
![g-before](https://cloud.githubusercontent.com/assets/859154/11301295/5177ced8-8f96-11e5-81f4-3a8fc50a4656.png)

After search input, a global result set:
![g-after](https://cloud.githubusercontent.com/assets/859154/11301310/648390ca-8f96-11e5-89d9-1cf3dd99ccf0.png)
