### PR TITLE
Fix - Update filters in correct cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 - \#2662 - Change Header When Applying Filter in App Collection View
 - \#2663 - Adapt filter count, reflect current result set
 
+### Fixed
+- \#2691 - Filters don't updated correctly on reload
+
 ## 0.13.4 - 2015-11-18
 ### Fixed
 - \#2626 - Status icons are rendered blotted

--- a/src/js/components/TabPanesComponent.jsx
+++ b/src/js/components/TabPanesComponent.jsx
@@ -78,9 +78,10 @@ var TabPanesComponent = React.createClass({
   },
 
   updateFilters: function (filters) {
-    var updatedFilters = Object.assign({}, this.state.filters, filters);
-    this.setState({
-      filters: updatedFilters
+    this.setState(function (prevState) {
+      return {
+        filters: Object.assign({}, prevState.filters, filters)
+      };
     });
   },
 


### PR DESCRIPTION
Due to the updateFilter()-callbacks the render cycle must be treated correctly.

This fixes https://github.com/mesosphere/marathon/issues/2691 mentioned here https://github.com/mesosphere/marathon-ui/pull/411#issuecomment-158522289 .