### PR TITLE
Refactor ugly syntax to ES6 spread operator

### DIFF
--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -94,7 +94,7 @@ var AppListItemComponent = React.createClass({
     let labelNodes = React.findDOMNode(refs.labels).querySelectorAll(".label");
 
     // labelNodes is not an Array, but a NodeList
-    [].forEach.call(labelNodes, function (label) {
+    [...labelNodes].forEach(label => {
       labelsWidth += DOMUtil.getOuterWidth(label);
       if (labelsWidth > availableWidth) {
         return true;


### PR DESCRIPTION
That nasty `[].forEach.call` really was annoying. This allows us to treat a NodeList as a regular array.