### PR TITLE
Fix the group health object reference issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 - \#2691 - Filters don't updated correctly on reload
+- \#2699 - App list health bar update/render issue
 
 ## 0.13.4 - 2015-11-18
 ### Fixed

--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -37,8 +37,8 @@ function getGroupHealth(groupHealth, appHealth) {
 
   return appHealth.map(appHealthState => {
     var groupHealthState =
-      groupHealth.find(groupHealthState => {
-        return groupHealthState.state === appHealthState.state;
+      groupHealth.find(healthState => {
+        return healthState.state === appHealthState.state;
       });
 
     if (groupHealthState == null) {

--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -28,20 +28,30 @@ function getGroupStatus(status, app) {
   return status;
 }
 
-function getGroupHealth(health, app) {
-  if (health == null) {
-    return app.health;
+function getGroupHealth(groupHealth, app) {
+  if (groupHealth == null) {
+    groupHealth = [];
   }
 
-  return health.map(healthState => {
-    var appHealthState =
-      app.health.find(appHealth => appHealth.state === healthState.state);
+  if (app.health == null) {
+    return groupHealth;
+  }
 
-    if (appHealthState != null) {
-      healthState.quantity += appHealthState.quantity;
+  let appHealth = app.health;
+
+  return appHealth.map(appHealthState => {
+    var groupHealthState =
+      groupHealth.find(groupHealthState => {
+        return groupHealthState.state === appHealthState.state;
+      });
+
+    if (groupHealthState == null) {
+      return Object.assign({}, appHealthState);
     }
 
-    return healthState;
+    groupHealthState.quantity += appHealthState.quantity;
+
+    return groupHealthState;
   });
 }
 


### PR DESCRIPTION
Refactor the get group health method to fix some nasty object reference issues. This  should fix health-bar update/render issue mesosphere/marathon#2699.