### PR TITLE
Show only last 4 characters of environment variables

### DIFF
--- a/src/js/components/AppVersionComponent.jsx
+++ b/src/js/components/AppVersionComponent.jsx
@@ -146,7 +146,7 @@ var AppVersionComponent = React.createClass({
       ? <UNSPECIFIED_NODE />
       // Print environment variables as key value pairs like "key=value"
       : Object.keys(appVersion.env).map(function (k) {
-        return <dd key={k}>{k + "=" + appVersion.env[k]}</dd>;
+        return <dd key={k}>{k + "=" + "xxxxxxxx" + appVersion.env[k].slice(-4)}</dd>;
       });
 
     var executorNode = (appVersion.executor === "")


### PR DESCRIPTION
Some of the environment variables are secret which shouldn't be exposed as plain-text. This patch just prints the last 4 digits of the variable value. I know it is not the general use-case. I am just opening this pull request to get a feedback on what is the ideal way of implementing it in marathon.