### PR TITLE
Fix/2684 remove suspended apps from health bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 - \#2663 - Adapt filter count, reflect current result set
 - \#2702 - Show proper info on app creation auth error
 
+### Fixed
+- \#2684 - Running instances are confusing
+
 ## 0.13.5 - 2015-11-24
 ### Fixed
 - \#2699 - App list health bar update/render issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,6 @@
 - \#2662 - Change Header When Applying Filter in App Collection View
 - \#2663 - Adapt filter count, reflect current result set
 - \#2702 - Show proper info on app creation auth error
-
-### Fixed
 - \#2684 - Running instances are confusing
 
 ## 0.13.5 - 2015-11-24

--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -85,12 +85,12 @@ function getAppHealth(app) {
     healthData[i].quantity = Math.min(capacityLeft, healthData[i].quantity);
   }
 
-  // ... show everything above that in blue
+  // get the number for tasks overcapacity
   var overCapacity = Math.max(0, tasksSum - app.instances);
 
   healthData.push({quantity: overCapacity, state: HealthStatus.OVERCAPACITY});
 
-  // add unscheduled tasks
+  // count unscheduled tasks
   var unscheduled = Math.max(0, (app.instances - tasksSum));
 
   healthData.push({

--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -90,13 +90,11 @@ function getAppHealth(app) {
 
   healthData.push({quantity: overCapacity, state: HealthStatus.OVERCAPACITY});
 
-  // add unscheduled task, or show black if completely suspended
-  var isSuspended = app.instances === 0 && tasksSum === 0;
+  // add unscheduled tasks
   var unscheduled = Math.max(0, (app.instances - tasksSum));
-  var unscheduledOrSuspended = isSuspended ? 1 : unscheduled;
 
   healthData.push({
-    quantity: unscheduledOrSuspended,
+    quantity: unscheduled,
     state: HealthStatus.UNSCHEDULED
   });
 

--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -77,7 +77,6 @@ function getAppHealth(app) {
     {quantity: app.tasksStaged || 0, state: HealthStatus.STAGED}
   ];
 
-  // cut off after `instances` many tasks...
   var tasksSum = 0;
   for (let i = 0; i < healthData.length; i++) {
     let capacityLeft = Math.max(0, app.instances - tasksSum);
@@ -85,14 +84,10 @@ function getAppHealth(app) {
     healthData[i].quantity = Math.min(capacityLeft, healthData[i].quantity);
   }
 
-  // get the number for tasks overcapacity
   var overCapacity = Math.max(0, tasksSum - app.instances);
-
   healthData.push({quantity: overCapacity, state: HealthStatus.OVERCAPACITY});
 
-  // count unscheduled tasks
   var unscheduled = Math.max(0, (app.instances - tasksSum));
-
   healthData.push({
     quantity: unscheduled,
     state: HealthStatus.UNSCHEDULED

--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -237,7 +237,7 @@ describe("Apps", function () {
       it("has correct health weight", function (done) {
         AppsStore.once(AppsEvents.CHANGE, function () {
           expectAsync(function () {
-            expect(AppsStore.apps[0].healthWeight).to.equal(1);
+            expect(AppsStore.apps[0].healthWeight).to.equal(0);
           }, done);
         });
 
@@ -253,7 +253,7 @@ describe("Apps", function () {
               {quantity: 0, state: HealthStatus.UNKNOWN},
               {quantity: 0, state: HealthStatus.STAGED},
               {quantity: 0, state: HealthStatus.OVERCAPACITY},
-              {quantity: 1, state: HealthStatus.UNSCHEDULED}
+              {quantity: 0, state: HealthStatus.UNSCHEDULED}
             ]);
           }, done);
         });

--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -115,22 +115,65 @@ describe("Apps", function () {
       AppsActions.requestApps();
     });
 
-    describe("App", function () {
+    describe("basic app", function () {
       beforeEach(function () {
         this.server.setup({
           "apps": [{
             id: "/app-1",
-            container: {
-              type: "DOCKER"
-            },
             tasksHealthy: 2,
             tasksUnhealthy: 2,
             tasksRunning: 5,
             tasksStaged: 2,
             instances: 10
-          },
-          {
-            id: "/app-2",
+          }]
+        }, 200);
+      });
+
+      it("has correct health weight", function (done) {
+        AppsStore.once(AppsEvents.CHANGE, function () {
+          expectAsync(function () {
+            expect(AppsStore.apps[0].healthWeight).to.equal(47);
+          }, done);
+        });
+
+        AppsActions.requestApps();
+      });
+
+      it("has the correct app type", function (done) {
+        AppsStore.once(AppsEvents.CHANGE, function () {
+          expectAsync(function () {
+            expect(AppsStore.apps[0].type).to.equal("BASIC");
+          }, done);
+        });
+
+        AppsActions.requestApps();
+      });
+
+      it("has correct health data object", function (done) {
+        AppsStore.once(AppsEvents.CHANGE, function () {
+          expectAsync(function () {
+            expect(AppsStore.apps[0].health).to.deep.equal([
+              {quantity: 2, state: HealthStatus.HEALTHY},
+              {quantity: 2, state: HealthStatus.UNHEALTHY},
+              {quantity: 1, state: HealthStatus.UNKNOWN},
+              {quantity: 2, state: HealthStatus.STAGED},
+              {quantity: 0, state: HealthStatus.OVERCAPACITY},
+              {quantity: 3, state: HealthStatus.UNSCHEDULED}
+            ]);
+          }, done);
+        });
+        AppsActions.requestApps();
+      });
+    });
+
+    describe("docker app", function () {
+      beforeEach(function () {
+        this.server.setup({
+          "apps": [{
+            id: "/app-1-docker",
+            container: {
+              type: "DOCKER"
+            },
             tasksHealthy: 2,
             tasksUnhealthy: 2,
             tasksRunning: 5,
@@ -154,7 +197,6 @@ describe("Apps", function () {
         AppsStore.once(AppsEvents.CHANGE, function () {
           expectAsync(function () {
             expect(AppsStore.apps[0].type).to.equal("DOCKER");
-            expect(AppsStore.apps[1].type).to.equal("BASIC");
           }, done);
         });
 
@@ -165,16 +207,138 @@ describe("Apps", function () {
         AppsStore.once(AppsEvents.CHANGE, function () {
           expectAsync(function () {
             expect(AppsStore.apps[0].health).to.deep.equal([
-              { quantity: 2, state: HealthStatus.HEALTHY },
-              { quantity: 2, state: HealthStatus.UNHEALTHY },
-              { quantity: 1, state: HealthStatus.UNKNOWN },
-              { quantity: 2, state: HealthStatus.STAGED },
-              { quantity: 0, state: HealthStatus.OVERCAPACITY },
-              { quantity: 3, state: HealthStatus.UNSCHEDULED }
+              {quantity: 2, state: HealthStatus.HEALTHY},
+              {quantity: 2, state: HealthStatus.UNHEALTHY},
+              {quantity: 1, state: HealthStatus.UNKNOWN},
+              {quantity: 2, state: HealthStatus.STAGED},
+              {quantity: 0, state: HealthStatus.OVERCAPACITY},
+              {quantity: 3, state: HealthStatus.UNSCHEDULED}
             ]);
           }, done);
         });
+        AppsActions.requestApps();
+      });
+    });
 
+    describe("basic suspended app", function () {
+      beforeEach(function () {
+        this.server.setup({
+          "apps": [{
+            id: "/app-1",
+            tasksHealthy: 0,
+            tasksUnhealthy: 0,
+            tasksRunning: 0,
+            tasksStaged: 0,
+            instances: 0
+          }]
+        }, 200);
+      });
+
+      it("has correct health weight", function (done) {
+        AppsStore.once(AppsEvents.CHANGE, function () {
+          expectAsync(function () {
+            expect(AppsStore.apps[0].healthWeight).to.equal(1);
+          }, done);
+        });
+
+        AppsActions.requestApps();
+      });
+
+      it("has correct health data object", function (done) {
+        AppsStore.once(AppsEvents.CHANGE, function () {
+          expectAsync(function () {
+            expect(AppsStore.apps[0].health).to.deep.equal([
+              {quantity: 0, state: HealthStatus.HEALTHY},
+              {quantity: 0, state: HealthStatus.UNHEALTHY},
+              {quantity: 0, state: HealthStatus.UNKNOWN},
+              {quantity: 0, state: HealthStatus.STAGED},
+              {quantity: 0, state: HealthStatus.OVERCAPACITY},
+              {quantity: 1, state: HealthStatus.UNSCHEDULED}
+            ]);
+          }, done);
+        });
+        AppsActions.requestApps();
+      });
+    });
+
+    describe("basic deploying app", function () {
+      beforeEach(function () {
+        this.server.setup({
+          "apps": [{
+            id: "/app-1",
+            tasksHealthy: 5,
+            tasksUnhealthy: 0,
+            tasksRunning: 0,
+            tasksStaged: 5,
+            instances: 15
+          }]
+        }, 200);
+      });
+
+      it("has correct health weight", function (done) {
+        AppsStore.once(AppsEvents.CHANGE, function () {
+          expectAsync(function () {
+            expect(AppsStore.apps[0].healthWeight).to.equal(13);
+          }, done);
+        });
+
+        AppsActions.requestApps();
+      });
+
+      it("has correct health data object", function (done) {
+        AppsStore.once(AppsEvents.CHANGE, function () {
+          expectAsync(function () {
+            expect(AppsStore.apps[0].health).to.deep.equal([
+              {quantity: 5, state: HealthStatus.HEALTHY},
+              {quantity: 0, state: HealthStatus.UNHEALTHY},
+              {quantity: 0, state: HealthStatus.UNKNOWN},
+              {quantity: 5, state: HealthStatus.STAGED},
+              {quantity: 0, state: HealthStatus.OVERCAPACITY},
+              {quantity: 5, state: HealthStatus.UNSCHEDULED}
+            ]);
+          }, done);
+        });
+        AppsActions.requestApps();
+      });
+    });
+
+    describe("basic app overcapacity", function () {
+      beforeEach(function () {
+        this.server.setup({
+          "apps": [{
+            id: "/app-1",
+            tasksHealthy: 0,
+            tasksUnhealthy: 0,
+            tasksRunning: 1,
+            tasksStaged: 0,
+            instances: 0
+          }]
+        }, 200);
+      });
+
+      it("has correct health weight", function (done) {
+        AppsStore.once(AppsEvents.CHANGE, function () {
+          expectAsync(function () {
+            expect(AppsStore.apps[0].healthWeight).to.equal(16);
+          }, done);
+        });
+
+        AppsActions.requestApps();
+      });
+
+      it("has correct health data object", function (done) {
+        AppsStore.once(AppsEvents.CHANGE, function () {
+          expectAsync(function () {
+            expect(AppsStore.apps[0].health).to.deep.equal([
+              {quantity: 0, state: HealthStatus.HEALTHY},
+              {quantity: 0, state: HealthStatus.UNHEALTHY},
+              {quantity: 0, state: HealthStatus.UNKNOWN},
+              {quantity: 0, state: HealthStatus.STAGED},
+              {quantity: 1, state: HealthStatus.OVERCAPACITY},
+              {quantity: 0, state: HealthStatus.UNSCHEDULED}
+            ]);
+          }, done);
+        });
         AppsActions.requestApps();
       });
     });


### PR DESCRIPTION
Remove the suspended app healt count from the apps store `getAppHealth` method. Until now, the app health unscheduled task count is set to 1 for suspended apps. This was most probably only introduced for health bar rendering and isn't needed anymore.
These changes should fix the confusing health bar / instance count described in mesosphere/marathon#2684.