### PR TITLE
Show correct button label when creating inside group

### DIFF
--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -185,9 +185,10 @@ var AppModalComponent = React.createClass({
   },
 
   getSubmitButton: function () {
-    var submitButtonTitle = this.props.app != null
-      ? "Change and deploy configuration"
-      : "+ Create";
+    var submitButtonTitle = "+ Create";
+    if (this.props.app != null && this.props.app.version != null) {
+      submitButtonTitle = "Change and deploy configuration";
+    }
 
     var classSet = classNames({
       "btn btn-success": true,


### PR DESCRIPTION
This fixes the following issue:

![create](https://cloud.githubusercontent.com/assets/1078545/11398690/b6eca5dc-9382-11e5-8bda-4e24a2f08e5c.gif)


the button should say "+ Create" .