### PR TITLE
Fix invalid filterText check

### DIFF
--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -178,7 +178,7 @@ var AppListComponent = React.createClass({
     var filterLabels = filters[FilterTypes.LABELS];
     var filterStatus = filters[FilterTypes.STATUS];
 
-    if (!Util.isEmptyString(filterText)) {
+    if (filterText != null && filterText !== "") {
       nodesSequence = nodesSequence
         .filter(app => app.id.indexOf(filterText) !== -1);
     } else if (currentGroup !== "/") {


### PR DESCRIPTION
This fixes https://github.com/mesosphere/marathon/issues/2722 .
I don't think this needs a changelog entry, the bug was just introduced.

We should rethink the naming of Util.isEmptyString(), it's misleading..