### PR TITLE
Fix - 2529 closebutton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - \#2662 - Change Header When Applying Filter in App Collection View
 - \#2663 - Adapt filter count, reflect current result set
 - \#2702 - Show proper info on app creation auth error
+ -\#2529 - The Health checks close button (x) is misleading
 
 ## 0.13.6 - 2015-11-25
 ### Fixed

--- a/src/js/components/HealthChecksComponent.jsx
+++ b/src/js/components/HealthChecksComponent.jsx
@@ -79,7 +79,7 @@ var HealthChecksComponent = React.createClass({
     return (
       <div key={row.consecutiveKey} className={rowClassSet}>
         <button type="button" className="close"
-          aria-hidden="true" onClick={handleRemoveRow}>&times;</button>
+          aria-hidden="true" onClick={handleRemoveRow}>&ndash;</button>
         <h4>Health Check {i + 1} - {row.protocol}</h4>
         <fieldset onChange={handleChange}>
           <div className="row">
@@ -213,7 +213,7 @@ var HealthChecksComponent = React.createClass({
               <button className="btn btn-default"
                   type="button"
                   onClick={handleAddRow}>
-                Add Health Check
+                Add Another Health Check
               </button>
             </div>
           </div>


### PR DESCRIPTION
* This changes the health checks close button from an X to an &ndash; .
* It changes the button caption "Add Health Check" to "Add Another Health Check".

Closes https://github.com/mesosphere/marathon/issues/2529

![healthcheck](https://cloud.githubusercontent.com/assets/859154/11423810/f9c47b30-9447-11e5-9b29-739dd5080a5e.png)
