### PR TITLE
Update task endpoints for IP-per-container 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - \#2704 - Change format of groupId under app name
 - \#2705 - Link groupId in search results to individual groups
 - \#2729 - Expose IP-per-container app definition in App Details page
+- \#2727 - Integrate IP-Per-Container ipAddresses into task detail view
 
 ### Changed
 - Adjust the task list column order

--- a/src/js/components/TaskDetailComponent.jsx
+++ b/src/js/components/TaskDetailComponent.jsx
@@ -2,6 +2,7 @@ var classNames = require("classnames");
 var Link = require("react-router").Link;
 var React = require("react/addons");
 
+var AppsStore = require("../stores/AppsStore");
 var States = require("../constants/States");
 var TimeFieldComponent = require("../components/TimeFieldComponent");
 var TaskHealthComponent = require("../components/TaskHealthComponent");
@@ -41,8 +42,31 @@ var TaskDetailComponent = React.createClass({
   getTaskEndpoints: function () {
     var props = this.props;
     var task = props.task;
-    if (task.ports == null || task.ports.length === 0) {
+    var app = AppsStore.getCurrentApp(props.appId);
+
+    if ((task.ports == null || task.ports.length === 0) &&
+        (task.ipAddresses == null || task.ipAddresses.length === 0)) {
       return (<dd>None</dd>);
+    }
+
+    if (app.ipAddress != null &&
+        app.ipAddress.discovery != null &&
+        app.ipAddress.discovery.ports != null &&
+        task.ipAddresses != null &&
+        task.ipAddresses.length > 0) {
+
+      let endpoints = task.ipAddresses.reduce((memo, address) => {
+        app.ipAddress.discovery.ports.forEach(port => {
+          memo.push(`${address.ipAddress}:${port.number}`);
+        });
+        return memo;
+      }, []);
+
+      return endpoints.map(endpoint => (
+        <dd key={endpoint} className="overflow-ellipsis">
+          <a href={`//${endpoint}`} target="_blank">{endpoint}</a>
+        </dd>
+      ));
     }
 
     return task.ports.map((port) => {
@@ -53,6 +77,46 @@ var TaskDetailComponent = React.createClass({
         </dd>
       );
     });
+  },
+
+  getIpAddresses: function () {
+    var props = this.props;
+    var task = props.task;
+
+    var ipAddresses = (task.ipAddresses != null && task.ipAddresses.length > 0)
+      ? task.ipAddresses.map(address => address.ipAddress)
+      : [task.host];
+
+    return ipAddresses.map(ipAddress => (<dd key={ipAddress}>{ipAddress}</dd>));
+  },
+
+  getPorts: function () {
+    var task = this.props.task;
+    var ports = "[]";
+
+    if (task.ports != null && task.ports.length > 0) {
+      ports = `[${task.ports.toString()}]`;
+    }
+
+    return (<dd>{ports}</dd>);
+  },
+
+  getServiceDiscovery: function () {
+    var app = AppsStore.getCurrentApp(this.props.appId);
+
+    if (app == null ||
+        app.ipAddress == null ||
+        app.ipAddress.discovery == null ||
+        app.ipAddress.discovery.ports == null ||
+        app.ipAddress.discovery.ports.length === 0) {
+      return (<dd>n/a</dd>);
+    }
+
+    return app.ipAddress.discovery.ports.map(port => (
+      <dd key={port.number}>
+        {`${port.name}, ${port.number}, ${port.protocol}`}
+      </dd>
+    ));
   },
 
   getTaskHealthComponent: function () {
@@ -102,12 +166,14 @@ var TaskDetailComponent = React.createClass({
     return (
       <div>
         <dl className="dl-horizontal task-details">
-          <dt>Host</dt>
-          <dd>{task.host}</dd>
+          <dt>IP Addresses</dt>
+          {this.getIpAddresses()}
           <dt>Ports</dt>
-          <dd>[{task.ports.toString()}]</dd>
+          {this.getPorts()}
           <dt>Endpoints</dt>
           {this.getTaskEndpoints()}
+          <dt>Service Discovery</dt>
+          {this.getServiceDiscovery()}
           <dt>Status</dt>
           <dd>{task.status}</dd>
           {timeFields}

--- a/src/js/components/TaskDetailComponent.jsx
+++ b/src/js/components/TaskDetailComponent.jsx
@@ -55,8 +55,9 @@ var TaskDetailComponent = React.createClass({
         task.ipAddresses != null &&
         task.ipAddresses.length > 0) {
 
+      let ports = app.ipAddress.discovery.ports;
       let endpoints = task.ipAddresses.reduce((memo, address) => {
-        app.ipAddress.discovery.ports.forEach(port => {
+        ports.forEach(port => {
           memo.push(`${address.ipAddress}:${port.number}`);
         });
         return memo;

--- a/src/js/components/TaskDetailComponent.jsx
+++ b/src/js/components/TaskDetailComponent.jsx
@@ -1,5 +1,6 @@
 var classNames = require("classnames");
 var Link = require("react-router").Link;
+var objectPath = require("object-path");
 var React = require("react/addons");
 
 var AppsStore = require("../stores/AppsStore");
@@ -49,9 +50,7 @@ var TaskDetailComponent = React.createClass({
       return (<dd>None</dd>);
     }
 
-    if (app.ipAddress != null &&
-        app.ipAddress.discovery != null &&
-        app.ipAddress.discovery.ports != null &&
+    if (objectPath.get(app, "ipAddress.discovery.ports") != null &&
         task.ipAddresses != null &&
         task.ipAddresses.length > 0) {
 
@@ -105,10 +104,7 @@ var TaskDetailComponent = React.createClass({
   getServiceDiscovery: function () {
     var app = AppsStore.getCurrentApp(this.props.appId);
 
-    if (app == null ||
-        app.ipAddress == null ||
-        app.ipAddress.discovery == null ||
-        app.ipAddress.discovery.ports == null ||
+    if (objectPath.get(app, "ipAddress.discovery.ports") == null ||
         app.ipAddress.discovery.ports.length === 0) {
       return (<dd>n/a</dd>);
     }

--- a/src/js/components/TaskListItemComponent.jsx
+++ b/src/js/components/TaskListItemComponent.jsx
@@ -2,51 +2,9 @@ var classNames = require("classnames");
 var React = require("react/addons");
 var Moment = require("moment");
 
+var AppsStore = require("../stores/AppsStore");
 var HealthStatus = require("../constants/HealthStatus");
 var TaskStatus = require("../constants/TaskStatus");
-
-function buildHref(host, port) {
-  return "http://" + host + ":" + port;
-}
-
-function buildTaskAnchors(task) {
-  var taskAnchors;
-  var ports = task.ports;
-  var portsLength = ports.length;
-
-  if (portsLength > 1) {
-    // Linkify each port with the hostname. The port is the text of the
-    // anchor, but the href contains the hostname and port, a full link.
-    taskAnchors = (
-      <span className="text-muted">
-        {task.host}:[{ports.map(function (p, index) {
-          return (
-            <span key={p}>
-              <a className="text-muted" href={buildHref(task.host, p)}>
-                {p}
-              </a>
-              {index < portsLength - 1 ? ", " : ""}
-            </span>
-          );
-        })}]
-      </span>
-    );
-  } else if (portsLength === 1) {
-    // Linkify the hostname + port since there is only one port.
-    taskAnchors = (
-      <a className="text-muted" href={buildHref(task.host, ports[0])}>
-        {task.host}:{ports[0]}
-      </a>
-    );
-  } else {
-    // Ain't no ports; don't linkify.
-    taskAnchors = (
-      <span className="text-muted">{task.host}</span>
-    );
-  }
-
-  return taskAnchors;
-}
 
 var TaskListItemComponent = React.createClass({
   displayName: "TaskListItemComponent",
@@ -58,6 +16,110 @@ var TaskListItemComponent = React.createClass({
     onToggle: React.PropTypes.func.isRequired,
     task: React.PropTypes.object.isRequired,
     taskHealthMessage: React.PropTypes.string
+  },
+
+  getHostAndPorts: function () {
+    var task = this.props.task;
+    var ports = task.ports;
+
+    if (ports == null || ports.length === 0 ) {
+      return (<span className="text-muted">{task.host}</span>);
+    }
+
+    if (ports != null && ports.length === 1) {
+      return (
+        <a className="text-muted" href={`//${task.host}:${ports[0]}`}>
+          {`${task.host}:${ports[0]}`}
+        </a>
+      );
+    }
+
+    if (ports != null && ports.length > 1) {
+      let portNodes = ports.map(function (port, index) {
+        return (
+          <span key={port}>
+            <a className="text-muted" href={`//${task.host}:${port}`}>
+              {port}
+            </a>
+            {index < ports.length - 1 ? ", " : ""}
+          </span>
+        );
+      });
+
+      return (
+        <span className="text-muted">
+          {task.host}:[{portNodes}]
+        </span>
+      );
+    }
+  },
+
+  getEndpoints: function () {
+    var task = this.props.task;
+
+    if (task.ipAddresses == null) {
+      return this.getHostAndPorts();
+    }
+
+    return this.getServiceDiscoveryEndpoints();
+  },
+
+  getServiceDiscoveryEndpoints: function () {
+    var props = this.props;
+    var task = props.task;
+    var app = AppsStore.getCurrentApp(props.appId);
+
+    if (app.ipAddress != null &&
+        app.ipAddress.discovery != null &&
+        app.ipAddress.discovery.ports != null &&
+        task.ipAddresses != null &&
+        task.ipAddresses.length > 0) {
+
+      let serviceDiscoveryPorts = app.ipAddress.discovery.ports;
+
+      let endpoints = task.ipAddresses.map((address, i) => {
+        let ipAddress = address.ipAddress;
+        let trailingComma = i < task.ipAddresses.length - 1;
+
+        if (serviceDiscoveryPorts.length === 1) {
+          let port = serviceDiscoveryPorts[0].number;
+          return (
+            <span className="text-muted" key={`${ipAddress}:${port}`}>
+              <a className="text-muted"
+                  href={`//${ipAddress}:${port}`}>
+                {`${ipAddress}:${port}`}
+              </a>
+              {trailingComma ? ", " : ""}
+            </span>
+          );
+        }
+
+        let portNodes = serviceDiscoveryPorts.map((port, j) => {
+          return (
+            <span key={port.number}>
+              <a className="text-muted"
+                  href={`//${ipAddress}:${port.number}`}>
+                {port.number}
+              </a>
+              {j < serviceDiscoveryPorts.length - 1 ? ", " : ""}
+            </span>
+          );
+        });
+
+        return (
+          <span className="text-muted">
+            {address.ipAddress}:[{portNodes}]
+            {trailingComma ? ", " : ""}
+          </span>
+        );
+      });
+
+      return (
+        <span className="text-muted">
+          {endpoints}
+        </span>
+      );
+    }
   },
 
   handleClick: function (event) {
@@ -119,7 +181,7 @@ var TaskListItemComponent = React.createClass({
         <td>
             <a href={taskUri}>{taskId}</a>
           <br />
-          {buildTaskAnchors(task)}
+          {this.getEndpoints()}
         </td>
         <td className={healthClassSet} title={this.props.taskHealthMessage}>
           {this.props.taskHealthMessage}

--- a/src/js/components/TaskListItemComponent.jsx
+++ b/src/js/components/TaskListItemComponent.jsx
@@ -85,8 +85,7 @@ var TaskListItemComponent = React.createClass({
           let port = serviceDiscoveryPorts[0].number;
           return (
             <span className="text-muted" key={`${ipAddress}:${port}`}>
-              <a className="text-muted"
-                  href={`//${ipAddress}:${port}`}>
+              <a className="text-muted" href={`//${ipAddress}:${port}`}>
                 {`${ipAddress}:${port}`}
               </a>
               {trailingComma ? ", " : ""}
@@ -97,8 +96,7 @@ var TaskListItemComponent = React.createClass({
         let portNodes = serviceDiscoveryPorts.map((port, j) => {
           return (
             <span key={port.number}>
-              <a className="text-muted"
-                  href={`//${ipAddress}:${port.number}`}>
+              <a className="text-muted" href={`//${ipAddress}:${port.number}`}>
                 {port.number}
               </a>
               {j < serviceDiscoveryPorts.length - 1 ? ", " : ""}

--- a/src/js/components/TaskListItemComponent.jsx
+++ b/src/js/components/TaskListItemComponent.jsx
@@ -1,4 +1,5 @@
 var classNames = require("classnames");
+var objectPath = require("object-path");
 var React = require("react/addons");
 var Moment = require("moment");
 
@@ -69,9 +70,7 @@ var TaskListItemComponent = React.createClass({
     var task = props.task;
     var app = AppsStore.getCurrentApp(props.appId);
 
-    if (app.ipAddress != null &&
-        app.ipAddress.discovery != null &&
-        app.ipAddress.discovery.ports != null &&
+    if (objectPath.get(app, "ipAddress.discovery.ports") != null &&
         task.ipAddresses != null &&
         task.ipAddresses.length > 0) {
 

--- a/src/js/components/TaskListItemComponent.jsx
+++ b/src/js/components/TaskListItemComponent.jsx
@@ -95,7 +95,7 @@ var TaskListItemComponent = React.createClass({
 
         let portNodes = serviceDiscoveryPorts.map((port, j) => {
           return (
-            <span key={port.number}>
+            <span key={`//${ipAddress}:${port.number}`}>
               <a className="text-muted" href={`//${ipAddress}:${port.number}`}>
                 {port.number}
               </a>

--- a/src/js/components/TaskListItemComponent.jsx
+++ b/src/js/components/TaskListItemComponent.jsx
@@ -14,7 +14,7 @@ function joinNodes(nodes, separator = ", ") {
       separator = null;
     }
     return (
-      <span className="text-muted">
+      <span className="text-muted" key={i}>
         {node}{separator}
       </span>
     );

--- a/src/js/components/TaskListItemComponent.jsx
+++ b/src/js/components/TaskListItemComponent.jsx
@@ -7,6 +7,20 @@ var AppsStore = require("../stores/AppsStore");
 var HealthStatus = require("../constants/HealthStatus");
 var TaskStatus = require("../constants/TaskStatus");
 
+function joinNodes(nodes, separator = ", ") {
+  var lastIndex = nodes.length - 1;
+  return nodes.map((node, i) => {
+    if (lastIndex === i) {
+      separator = null;
+    }
+    return (
+      <span className="text-muted">
+        {node}{separator}
+      </span>
+    );
+  });
+}
+
 var TaskListItemComponent = React.createClass({
   displayName: "TaskListItemComponent",
 
@@ -42,14 +56,13 @@ var TaskListItemComponent = React.createClass({
             <a className="text-muted" href={`//${task.host}:${port}`}>
               {port}
             </a>
-            {index < ports.length - 1 ? ", " : ""}
           </span>
         );
       });
 
       return (
         <span className="text-muted">
-          {task.host}:[{portNodes}]
+          {task.host}:[{joinNodes(portNodes)}]
         </span>
       );
     }
@@ -76,10 +89,8 @@ var TaskListItemComponent = React.createClass({
 
       let serviceDiscoveryPorts = app.ipAddress.discovery.ports;
 
-      let endpoints = task.ipAddresses.map((address, i) => {
+      let endpoints = task.ipAddresses.map((address) => {
         let ipAddress = address.ipAddress;
-        let trailingComma = i < task.ipAddresses.length - 1;
-
         if (serviceDiscoveryPorts.length === 1) {
           let port = serviceDiscoveryPorts[0].number;
           return (
@@ -87,7 +98,6 @@ var TaskListItemComponent = React.createClass({
               <a className="text-muted" href={`//${ipAddress}:${port}`}>
                 {`${ipAddress}:${port}`}
               </a>
-              {trailingComma ? ", " : ""}
             </span>
           );
         }
@@ -98,22 +108,20 @@ var TaskListItemComponent = React.createClass({
               <a className="text-muted" href={`//${ipAddress}:${port.number}`}>
                 {port.number}
               </a>
-              {j < serviceDiscoveryPorts.length - 1 ? ", " : ""}
             </span>
           );
         });
 
         return (
           <span key={address.ipAddress} className="text-muted">
-            {address.ipAddress}:[{portNodes}]
-            {trailingComma ? ", " : ""}
+            {address.ipAddress}:[{joinNodes(portNodes)}]
           </span>
         );
       });
 
       return (
         <span className="text-muted">
-          {endpoints}
+          {joinNodes(endpoints)}
         </span>
       );
     }

--- a/src/js/components/TaskListItemComponent.jsx
+++ b/src/js/components/TaskListItemComponent.jsx
@@ -38,7 +38,7 @@ var TaskListItemComponent = React.createClass({
     if (ports != null && ports.length > 1) {
       let portNodes = ports.map(function (port, index) {
         return (
-          <span key={port}>
+          <span key={`${task.host}:${port}`}>
             <a className="text-muted" href={`//${task.host}:${port}`}>
               {port}
             </a>
@@ -94,7 +94,7 @@ var TaskListItemComponent = React.createClass({
 
         let portNodes = serviceDiscoveryPorts.map((port, j) => {
           return (
-            <span key={`//${ipAddress}:${port.number}`}>
+            <span key={`${ipAddress}:${port.number}`}>
               <a className="text-muted" href={`//${ipAddress}:${port.number}`}>
                 {port.number}
               </a>
@@ -104,7 +104,7 @@ var TaskListItemComponent = React.createClass({
         });
 
         return (
-          <span className="text-muted">
+          <span key={address.ipAddress} className="text-muted">
             {address.ipAddress}:[{portNodes}]
             {trailingComma ? ", " : ""}
           </span>

--- a/src/js/components/TaskListItemComponent.jsx
+++ b/src/js/components/TaskListItemComponent.jsx
@@ -52,11 +52,10 @@ var TaskListItemComponent = React.createClass({
     if (ports != null && ports.length > 1) {
       let portNodes = ports.map(function (port, index) {
         return (
-          <span key={`${task.host}:${port}`}>
-            <a className="text-muted" href={`//${task.host}:${port}`}>
-              {port}
-            </a>
-          </span>
+          <a key={`${task.host}:${port}`}
+              className="text-muted" href={`//${task.host}:${port}`}>
+            {port}
+          </a>
         );
       });
 
@@ -94,21 +93,19 @@ var TaskListItemComponent = React.createClass({
         if (serviceDiscoveryPorts.length === 1) {
           let port = serviceDiscoveryPorts[0].number;
           return (
-            <span className="text-muted" key={`${ipAddress}:${port}`}>
-              <a className="text-muted" href={`//${ipAddress}:${port}`}>
-                {`${ipAddress}:${port}`}
-              </a>
-            </span>
+            <a key={`${ipAddress}:${port}`}
+                className="text-muted" href={`//${ipAddress}:${port}`}>
+              {`${ipAddress}:${port}`}
+            </a>
           );
         }
 
         let portNodes = serviceDiscoveryPorts.map((port, j) => {
           return (
-            <span key={`${ipAddress}:${port.number}`}>
-              <a className="text-muted" href={`//${ipAddress}:${port.number}`}>
-                {port.number}
-              </a>
-            </span>
+            <a key={`${ipAddress}:${port.number}`}
+                className="text-muted" href={`//${ipAddress}:${port.number}`}>
+              {port.number}
+            </a>
           );
         });
 

--- a/src/js/components/TaskListItemComponent.jsx
+++ b/src/js/components/TaskListItemComponent.jsx
@@ -50,7 +50,7 @@ var TaskListItemComponent = React.createClass({
     }
 
     if (ports != null && ports.length > 1) {
-      let portNodes = ports.map(function (port, index) {
+      let portNodes = ports.map(function (port) {
         return (
           <a key={`${task.host}:${port}`}
               className="text-muted" href={`//${task.host}:${port}`}>
@@ -100,7 +100,7 @@ var TaskListItemComponent = React.createClass({
           );
         }
 
-        let portNodes = serviceDiscoveryPorts.map((port, j) => {
+        let portNodes = serviceDiscoveryPorts.map((port) => {
           return (
             <a key={`${ipAddress}:${port.number}`}
                 className="text-muted" href={`//${ipAddress}:${port.number}`}>


### PR DESCRIPTION
This fixes https://github.com/mesosphere/marathon/issues/2727

**Preamble**

The user can specify IP-per-container settings via the REST API, which will be accepted only if the `host` and `ports` fields are left blank. Providing any of these together with the newly introduced `ipAddress` property (since Marathon 0.14) will result in a serverside validation error.

**UI Changes**
This PR updates the Task detail view and the Task list item components to be able to handle the `ipAddresses` property found in a task when the user has previously specified the `ipAddress` in the app definition. Please refer to https://github.com/mesosphere/marathon/issues/2727 for a more specific description.

The "Host" field is notably replaced by a more generic "IP Address" which is populated in all cases. The "Ports" field can now be empty. A new field "Service Discovery" holds the IP per container service discovery info, if present.

cc @aquamatthias @leemunroe 

The resulting UI changes will look like this:

**Case 1**
========
 
Task Detail view with the following app definition:

```
 "ipAddress": {
    "labels": {
      "pool": "10.1.2.0/24"
    },
    "discovery": {
      "ports": [
        { "number": 80, "name": "http", "protocol": "tcp" },
        { "number": 81, "name": "http", "protocol": "tcp" }
      ]
    }
  }
```

and an imaginary Task response with the following:
```
{
  "host": "slave1.local",
  "id": "marathon",
  "ipAddresses": [
    {
      "protocol": "IPv4",
      "ipAddress": "192.168.0.2"
    }
  ]
  ...
}
```
Screenshot:

![screen shot 2015-11-27 at 17 43 03](https://cloud.githubusercontent.com/assets/1078545/11446284/d63112a8-9534-11e5-92fb-c50e0d24ba03.png)

**Case 2**
========
 
Task List Item with the following app definition:

```
 "ipAddress": {
    "labels": {
      "pool": "10.1.2.0/24"
    },
    "discovery": {
      "ports": [
        { "number": 8080, "name": "http", "protocol": "tcp" },
        { "number": 1080, "name": "http", "protocol": "tcp" }
      ]
    }
  }
```

and an imaginary Task response with the following:
```
{
  "host": "slave1.local",
  "id": "marathon",
  "ipAddresses": [
    {
      "protocol": "IPv4",
      "ipAddress": "192.168.0.2"
    },
   {
      "protocol": "IPv4",
      "ipAddress": "192.168.0.21"
    }
  ]
  ...
}
```
Screenshot:

![screen shot 2015-11-27 at 17 41 55](https://cloud.githubusercontent.com/assets/1078545/11446346/b45a98ce-9535-11e5-80ef-3c3926b79e77.png)

The endpoint anchors behave exactly like with normal host:[port] endpoints (ie click on the port to open the link).