### PR TITLE
Prevent overflow in long dialog strings

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7324,6 +7324,16 @@
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/react/-/react-0.13.3.tgz"
     },
+    "react-gemini-scrollbar": {
+      "version": "1.1.1",
+      "resolved": "http://registry.npmjs.org/react-gemini-scrollbar/-/react-gemini-scrollbar-1.1.1.tgz",
+      "dependencies": {
+        "gemini-scrollbar": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/gemini-scrollbar/-/gemini-scrollbar-1.3.0.tgz"
+        }
+      }
+    },
     "react-onclickoutside": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-0.3.1.tgz"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "object-path": "^0.9.2",
     "qajax": "^1.3.0",
     "react": "^0.13.2",
+    "react-gemini-scrollbar": "^1.1.1",
     "react-onclickoutside": "^0.3.1",
     "react-router": "^0.13.3",
     "react-tools": "^0.13.2",

--- a/src/css/components/modal.less
+++ b/src/css/components/modal.less
@@ -23,9 +23,15 @@
 }
 
 .modal-body {
-  .gm-scroll-view {
-    overflow: hidden;
+  height: 100%;
+
+  .gm-scrollbar-container .gm-scroll-view {
+    overflow-x: hidden;
   }
+  .gm-prevented .gm-scroll-view {
+    overflow-x: scroll;
+  }
+
   .row.full-bleed {
     margin-left: -20px;
     margin-right: -20px;

--- a/src/css/components/modal.less
+++ b/src/css/components/modal.less
@@ -2,6 +2,8 @@
  * Modal
  * ==============
  */
+@import (inline) "../../node_modules/react-gemini-scrollbar/node_modules/gemini-scrollbar/gemini-scrollbar.css";
+
 .modal {
   display: block;
 }
@@ -21,6 +23,9 @@
 }
 
 .modal-body {
+  .gm-scroll-view {
+    overflow: hidden;
+  }
   .row.full-bleed {
     margin-left: -20px;
     margin-right: -20px;

--- a/src/js/components/modals/AlertModalComponent.jsx
+++ b/src/js/components/modals/AlertModalComponent.jsx
@@ -36,7 +36,7 @@ var AlertModalComponent = React.createClass({
           size="sm"
           onDestroy={this.props.onDestroy}>
         <div className="modal-body reduced-padding">
-          <GeminiScrollbar autoshow={true}>
+          <GeminiScrollbar>
             {this.props.message}
           </GeminiScrollbar>
           <div className="modal-controls fixed-height">

--- a/src/js/components/modals/AlertModalComponent.jsx
+++ b/src/js/components/modals/AlertModalComponent.jsx
@@ -1,3 +1,4 @@
+var GeminiScrollbar = require("react-gemini-scrollbar");
 var React = require("react/addons");
 var Util = require("../../helpers/Util");
 
@@ -35,7 +36,9 @@ var AlertModalComponent = React.createClass({
           size="sm"
           onDestroy={this.props.onDestroy}>
         <div className="modal-body reduced-padding">
-          {this.props.message}
+          <GeminiScrollbar autoshow={true}>
+            {this.props.message}
+          </GeminiScrollbar>
           <div className="modal-controls fixed-height">
             <button
                 className="btn btn-sm btn-default pull-right"

--- a/src/js/components/modals/ConfirmModalComponent.jsx
+++ b/src/js/components/modals/ConfirmModalComponent.jsx
@@ -1,3 +1,4 @@
+var GeminiScrollbar = require("react-gemini-scrollbar");
 var React = require("react/addons");
 var Util = require("../../helpers/Util");
 
@@ -41,7 +42,9 @@ var ConfirmModalComponent = React.createClass({
           size="sm"
           onDestroy={this.props.onDestroy}>
         <div className="modal-body reduced-padding">
-          {this.props.message}
+          <GeminiScrollbar autoshow={true}>
+            {this.props.message}
+          </GeminiScrollbar>
           <div className="modal-controls fixed-height">
             <button
                 className="btn btn-sm  btn-success pull-right"

--- a/src/js/components/modals/ConfirmModalComponent.jsx
+++ b/src/js/components/modals/ConfirmModalComponent.jsx
@@ -42,7 +42,7 @@ var ConfirmModalComponent = React.createClass({
           size="sm"
           onDestroy={this.props.onDestroy}>
         <div className="modal-body reduced-padding">
-          <GeminiScrollbar autoshow={true}>
+          <GeminiScrollbar>
             {this.props.message}
           </GeminiScrollbar>
           <div className="modal-controls fixed-height">

--- a/src/js/components/modals/PromptModalComponent.jsx
+++ b/src/js/components/modals/PromptModalComponent.jsx
@@ -52,7 +52,7 @@ var PromptModalComponent = React.createClass({
           size="sm"
           onDestroy={this.props.onDestroy}>
         <div className="modal-body reduced-padding">
-          <GeminiScrollbar autoshow={true}>
+          <GeminiScrollbar>
             <label>{this.props.message}</label>
           </GeminiScrollbar>
           <input className="form-control"

--- a/src/js/components/modals/PromptModalComponent.jsx
+++ b/src/js/components/modals/PromptModalComponent.jsx
@@ -1,3 +1,4 @@
+var GeminiScrollbar = require("react-gemini-scrollbar");
 var React = require("react/addons");
 var Util = require("../../helpers/Util");
 
@@ -51,7 +52,9 @@ var PromptModalComponent = React.createClass({
           size="sm"
           onDestroy={this.props.onDestroy}>
         <div className="modal-body reduced-padding">
-          <label>{this.props.message}</label>
+          <GeminiScrollbar autoshow={true}>
+            <label>{this.props.message}</label>
+          </GeminiScrollbar>
           <input className="form-control"
             type="text"
             ref="textInput"


### PR DESCRIPTION
https://github.com/mesosphere/marathon/issues/2658

How about this? I can't think of any better solution.

![modal-overflow](https://cloud.githubusercontent.com/assets/1078545/11474310/98f1fb38-9777-11e5-9fff-e2c077cc7226.gif)


