### PR TITLE
Break lengthy strings so they don't overflow

### DIFF
--- a/src/css/components/modal.less
+++ b/src/css/components/modal.less
@@ -21,6 +21,8 @@
 }
 
 .modal-body {
+  word-wrap: break-word;
+
   .row.full-bleed {
     margin-left: -20px;
     margin-right: -20px;


### PR DESCRIPTION
This fixes https://github.com/mesosphere/marathon/issues/2658

Thanks to @philipnrmn for the [wise tip](https://github.com/mesosphere/marathon-ui/pull/452#issuecomment-160780862)!

Tested on Chrome, Firefox, IE11

![screen shot 2015-12-01 at 10 26 48](https://cloud.githubusercontent.com/assets/1078545/11496985/2890495e-9816-11e5-9bea-7f83ed38102b.png)