### PR TITLE
Fix - 2720 Disabled button has wrong colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
 - \#2566 - Port mappings do make sense when container is in net=host mode
 - \#2047 - Tasks/Instances column rewording
 
+### Fixed
+- \#2720 - Disabled button has wrong colour
+
 ## 0.13.6 - 2015-11-25
 ### Fixed
 - \#2719 - Show correct button label when creating inside group

--- a/src/css/layout/button.less
+++ b/src/css/layout/button.less
@@ -56,6 +56,7 @@
 .btn-success:focus,
 .btn-success:active,
 .btn-success.active,
+.btn-success.disabled,
 .open .dropdown-toggle.btn-success {
   background-color: lighten(@brand-primary, 10%);
   border-color: lighten(@brand-primary, 10%);


### PR DESCRIPTION
This closes https://github.com/mesosphere/marathon/issues/2720

The create button has the correct colour now in disabled state:
![button-colour](https://cloud.githubusercontent.com/assets/859154/11501803/3a04c16c-9837-11e5-9d47-1ba3d2923cd9.png)
