### PR TITLE
Refactor .badge class for reuse

### DIFF
--- a/src/css/components/badge.less
+++ b/src/css/components/badge.less
@@ -3,18 +3,22 @@
  * ==============
  */
 .badge {
-   position: absolute;
-   top: 5px;
-   left: 1px;
-   font-size: .7em;
-   background-color: @primary-bg-color;
-   color: #2a2d2f;
-   background: #e4f342;
-   min-width: 18px;
-   height: 18px;
-   text-align: center;
-   line-height: 18px;
-   border-radius: 50%;
-   box-shadow: 0 1px 1px #333;
-   padding: 0 2px;
+  background-color: @badge-bg-color;
+  color: @breadcrumb-text-color;
+  display: inline-block;
+  font-size: @small-font-size;
+  font-weight: normal;
+  line-height: @horizontal-spacing-unit*3;
+  min-width: @horizontal-spacing-unit*3;
+  padding: @horizontal-spacing-unit*0.25 @base-spacing-unit*1.25;
+  position: absolute;
+  text-align: center;
+
+  &.indicator {
+    background-color: @badge-indicator-bg-color;
+    box-shadow: 0 1px 1px #333;
+    color: @badge-indicator-text-color;
+    font-size: @xsmall-font-size;
+    padding: 0 @horizontal-spacing-unit*0.5;
+  }
 }

--- a/src/css/components/filters.less
+++ b/src/css/components/filters.less
@@ -25,13 +25,8 @@
     }
   }
 
-  .label {
-    color: @breadcrumb-text-color;
-    width: auto;
-    background-color: @table-header-color;
-    padding: @horizontal-spacing-unit*0.25 @base-spacing-unit*1.25;
-    margin-left: 0px;
-    flex-shrink: 0;
+  .badge {
+    right:0;
   }
 
   li:hover {
@@ -50,7 +45,7 @@
       color: @btn-default-text-color;
     }
 
-    & > .label {
+    & .badge {
       color: @btn-default-text-color;
     }
   }

--- a/src/css/components/filters.less
+++ b/src/css/components/filters.less
@@ -26,6 +26,7 @@
   }
 
   .badge {
+    line-height: @base-line-height;
     right:0;
   }
 

--- a/src/css/components/labels.less
+++ b/src/css/components/labels.less
@@ -57,16 +57,12 @@
 .label, .more {
   position: fixed;
   transform: translateX(-1vw);
-  display: inline-block;
   visibility: hidden;
   white-space: nowrap;
-  padding: @horizontal-spacing-unit*0.25 @base-spacing-unit*1.5;
   margin-left: @horizontal-spacing-unit;
   background-color: @sidebar-bg-color;
   border-radius: @base-spacing-unit*2;
   color: @navbar-inactive-color;
-  font-size: @small-font-size;
-  font-weight: normal;
   line-height: inherit;
   max-width: @horizontal-spacing-unit * 64;
   overflow: hidden;

--- a/src/css/components/labels.less
+++ b/src/css/components/labels.less
@@ -6,6 +6,28 @@
   display: inline-block;
   position: absolute;
 
+  .badge, .more {
+    display: inline-block;
+    position: fixed;
+    transform: translateX(-1vw);
+    visibility: hidden;
+    white-space: nowrap;
+    margin-left: @horizontal-spacing-unit;
+    background-color: @sidebar-bg-color;
+    border-radius: @base-spacing-unit*2;
+    color: @navbar-inactive-color;
+    line-height: inherit;
+    max-width: @horizontal-spacing-unit * 64;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    &.visible {
+      position: relative;
+      transform: translateX(0);
+      visibility: inherit;
+    }
+  }
+
   .labels-dropdown {
     background-color: @navbar-bg-color;
     display: none;
@@ -46,32 +68,11 @@
         display: block;
         margin: 0 0 @base-spacing-unit 0;
 
-        .label {
+        .badge {
           margin: 0;
         }
       }
     }
-  }
-}
-
-.label, .more {
-  position: fixed;
-  transform: translateX(-1vw);
-  visibility: hidden;
-  white-space: nowrap;
-  margin-left: @horizontal-spacing-unit;
-  background-color: @sidebar-bg-color;
-  border-radius: @base-spacing-unit*2;
-  color: @navbar-inactive-color;
-  line-height: inherit;
-  max-width: @horizontal-spacing-unit * 64;
-  overflow: hidden;
-  text-overflow: ellipsis;
-
-  &.visible {
-    position: relative;
-    transform: translateX(0);
-    visibility: inherit;
   }
 }
 

--- a/src/css/components/navigation.less
+++ b/src/css/components/navigation.less
@@ -44,6 +44,11 @@
 .nav-tabs {
   border-bottom: 2px solid #2a2d2f;
   margin-top: 0;
+
+  .indicator {
+    top: 5px;
+    left: 1px;
+  }
 }
 
 .nav-tabs-unbordered {

--- a/src/css/variables.less
+++ b/src/css/variables.less
@@ -13,6 +13,9 @@
 @btn-default-text-color: #FFFFFF;
 @btn-default-active-bg-color: #5E646C;
 @btn-default-active-text-color: #FFFFFF;
+@badge-bg-color: #46494D;
+@badge-indicator-bg-color: #E4F342;
+@badge-indicator-text-color: #2A2D2F;
 @breadcrumb-text-color: #C3C9D7;
 @checkbox-active-color: #2568F5;
 @link-color: #FFFFFF;
@@ -60,6 +63,7 @@
 @font-size-h3: 14px;
 @font-size-icon: 16px;
 @small-font-size: 12px;
+@xsmall-font-size: 10px;
 
 /* ==============
  * Misc

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -103,7 +103,7 @@ var AppListItemComponent = React.createClass({
 
     let labelsWidth = 0;
     let numberOfVisibleLabels = 0;
-    let labelNodes = React.findDOMNode(refs.labels).querySelectorAll(".label");
+    let labelNodes = React.findDOMNode(refs.labels).querySelectorAll(".badge");
 
     // labelNodes is not an Array, but a NodeList
     [...labelNodes].forEach(label => {

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -131,7 +131,7 @@ var AppListItemComponent = React.createClass({
       return null;
     }
 
-    var moreLabelClassName = classNames("more", {
+    var moreLabelClassName = classNames("badge more", {
       "visible": Object.keys(labels).length > this.state.numberOfVisibleLabels
     });
 

--- a/src/js/components/AppListItemLabelsComponent.jsx
+++ b/src/js/components/AppListItemLabelsComponent.jsx
@@ -129,7 +129,7 @@ var AppListItemLabelsComponent = React.createClass({
         labelText = `${key}:${labels[key]}`;
       }
 
-      let labelClassName = classNames("label", {
+      let labelClassName = classNames("badge label", {
         "visible": i < numberOfVisibleLabels
       });
 
@@ -142,7 +142,7 @@ var AppListItemLabelsComponent = React.createClass({
 
       dropdownNodes.push((
         <li key={i} title={labelText}>
-          <span className="label visible">{labelText}</span>
+          <span className="badge label visible">{labelText}</span>
         </li>
       ));
     });

--- a/src/js/components/AppListItemLabelsComponent.jsx
+++ b/src/js/components/AppListItemLabelsComponent.jsx
@@ -129,7 +129,7 @@ var AppListItemLabelsComponent = React.createClass({
         labelText = `${key}:${labels[key]}`;
       }
 
-      let labelClassName = classNames("badge label", {
+      let labelClassName = classNames("badge", {
         "visible": i < numberOfVisibleLabels
       });
 
@@ -142,7 +142,7 @@ var AppListItemLabelsComponent = React.createClass({
 
       dropdownNodes.push((
         <li key={i} title={labelText}>
-          <span className="badge label visible">{labelText}</span>
+          <span className="badge visible">{labelText}</span>
         </li>
       ));
     });

--- a/src/js/components/AppListStatusFilterComponent.jsx
+++ b/src/js/components/AppListStatusFilterComponent.jsx
@@ -110,9 +110,9 @@ var AppListStatusFilterComponent = React.createClass({
     }
 
     return (
-      <label htmlFor={id} className="label visible">
+      <span className="badge">
         {state.appsStatusesCount[appStatus].toLocaleString()}
-      </label>
+      </span>
     );
   },
 
@@ -138,8 +138,8 @@ var AppListStatusFilterComponent = React.createClass({
               onChange={this.handleChange.bind(this, key)} />
             <label htmlFor={`status-${key}-${i}`} className={labelClassName}>
               {optionText}
+              {this.getStatusCountBadge(`status-${key}-${i}`, key)}
             </label>
-            {this.getStatusCountBadge(`status-${key}-${i}`, key)}
         </li>
       );
     });

--- a/src/js/components/NavTabsComponent.jsx
+++ b/src/js/components/NavTabsComponent.jsx
@@ -43,7 +43,7 @@ var NavTabsComponent = React.createClass({
     if (tab.id !== "/deployments" || state.activeDeployments < 1 ) {
       return null;
     }
-    return <span className="badge">{state.activeDeployments}</span>;
+    return <span className="badge indicator">{state.activeDeployments}</span>;
   },
 
   render: function () {

--- a/src/test/deployments.test.js
+++ b/src/test/deployments.test.js
@@ -197,7 +197,6 @@ describe("Deployments navigation badge", function () {
 
   it("has the correct amount of deployments", function () {
     var badge = this.component.props.children[1].props.children[1];
-    expect(badge.props.className).to.equal("badge");
     expect(badge.props.children).to.equal(2);
   });
 


### PR DESCRIPTION
This PR introduces a base ".badge" class that is now re-used across the Nav Tabs (for the Deployment indicator), the sidebar filter counters and the labels in the app list.

Tested in Chrome, FF, IE11.

Result:
![screen shot 2015-12-01 at 14 09 52](https://cloud.githubusercontent.com/assets/1078545/11501920/ebfa0c1a-9837-11e5-9cb3-46f453d79c47.png)


IE11:
![screen shot 2015-12-01 at 14 21 02](https://cloud.githubusercontent.com/assets/1078545/11501924/f2911064-9837-11e5-86ab-ebbddb459493.png)


This fixes https://github.com/mesosphere/marathon/issues/2740 and https://github.com/mesosphere/marathon/issues/2748.

