### PR TITLE
Replace progress bar with updated styles in Deployments page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
  -\#2529 - The Health checks close button (x) is misleading
 - \#2566 - Port mappings do make sense when container is in net=host mode
 - \#2047 - Tasks/Instances column rewording
+- \#2715 - Deployment loading bar should have new style
 
 ### Fixed
 - \#2720 - Disabled button has wrong colour

--- a/src/css/components/deployments.less
+++ b/src/css/components/deployments.less
@@ -1,0 +1,14 @@
+/* ==============
+ * Deployments page
+ * ==============
+ */
+
+.text-right.deployment-buttons {
+  vertical-align: middle;
+
+  .loading-bar {
+    height: 10px;
+    display: inline-block;
+    width: 100%;
+  }
+}

--- a/src/css/components/health-bar.less
+++ b/src/css/components/health-bar.less
@@ -25,7 +25,6 @@
   height: @base-spacing-unit;
   margin-bottom: 2px;
   background-color: @health-bar-inner-color;
-  border-radius: 4px;
 
   .loading-bar {
     position: relative;

--- a/src/css/components/health-bar.less
+++ b/src/css/components/health-bar.less
@@ -26,6 +26,15 @@
   margin-bottom: 2px;
   background-color: @health-bar-inner-color;
   border-radius: 4px;
+
+  .loading-bar {
+    position: relative;
+    top: 50%;
+    left: 50%;
+    width: @health-bar-width;
+    margin-top: @base-spacing-unit*-0.5;
+    margin-left: @health-bar-width*-0.5;
+  }
 }
 .health-bar-column .health-bar {
   max-width: @health-bar-width;
@@ -59,30 +68,4 @@
   background-color: @health-bar-inner-color;
 }
 
-.loading-bar {
-    position: relative;
-    top: 50%;
-    left: 50%;
-    height: @base-spacing-unit;
-    width: @health-bar-width;
-    margin-top: @base-spacing-unit*-0.5;
-    margin-left: @health-bar-width*-0.5;
-    background-image: linear-gradient(
-      -45deg,
-      @health-bar-inner-color 25%,
-      rgba(42, 44, 49, 0) 25%,
-      rgba(42, 44, 49, 0) 50%,
-      @health-bar-inner-color 50%,
-      @health-bar-inner-color 75%,
-      rgba(42, 44, 49, 0) 75%
-    );
-    background-color: @health-bar-running-color;
-    background-size: 12px 12px;
-    box-shadow: inset 0 10px 0 rgba(255, 255, 255, 0.2);
-    animation: move 2s linear infinite;
-    -ms-animation-name: move;
-}
 
-@keyframes move {
-    to { background-position: 12px 12px; }
-}

--- a/src/css/components/loading-bar.less
+++ b/src/css/components/loading-bar.less
@@ -1,0 +1,27 @@
+/* ==============
+ * Loading bar
+ * ==============
+ */
+.loading-bar {
+  height: @base-spacing-unit ;
+  max-width: @health-bar-width;
+
+  background-image: linear-gradient(
+          -45deg,
+          @health-bar-inner-color 25%,
+          rgba(42, 44, 49, 0) 25%,
+          rgba(42, 44, 49, 0) 50%,
+          @health-bar-inner-color 50%,
+          @health-bar-inner-color 75%,
+          rgba(42, 44, 49, 0) 75%
+  );
+  background-color: @health-bar-running-color;
+  background-size: 12px 12px;
+  box-shadow: inset 0 10px 0 rgba(255, 255, 255, 0.2);
+  animation: move 2s linear infinite;
+  -ms-animation-name: move;
+}
+
+@keyframes move {
+  to { background-position: 12px 12px; }
+}

--- a/src/css/components/loading-bar.less
+++ b/src/css/components/loading-bar.less
@@ -3,6 +3,7 @@
  * ==============
  */
 .loading-bar {
+  border-radius: 4px;
   height: @base-spacing-unit ;
   max-width: @health-bar-width;
 

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -21,6 +21,7 @@
 @import "components/dropdown.less";
 @import "components/duplicable-row.less";
 @import "components/filter-box.less";
+@import "components/loading-bar.less";
 @import "components/health-bar.less";
 @import "components/icons.less";
 @import "components/labels.less";

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -18,6 +18,7 @@
 @import "components/app-status.less";
 @import "components/badge.less";
 @import "components/breadcrumb.less";
+@import "components/deployments.less";
 @import "components/dropdown.less";
 @import "components/duplicable-row.less";
 @import "components/filter-box.less";

--- a/src/js/components/DeploymentComponent.jsx
+++ b/src/js/components/DeploymentComponent.jsx
@@ -5,12 +5,9 @@ var React = require("react/addons");
 var DeploymentActions = require("../actions/DeploymentActions");
 var DialogActions = require("../actions/DialogActions");
 var DialogStore = require("../stores/DialogStore");
-var TooltipMixin = require("../mixins/TooltipMixin");
 
 var DeploymentComponent = React.createClass({
   displayName: "DeploymentComponent",
-
-  mixins: [TooltipMixin],
 
   propTypes: {
     model: React.PropTypes.object.isRequired
@@ -56,31 +53,9 @@ var DeploymentComponent = React.createClass({
     }.bind(this));
   },
 
-  handleMouseOverHealthBar: function (ref) {
-    var el = this.refs[ref].getDOMNode();
-    this.tip_showTip(el);
-  },
-
-  handleMouseOutHealthBar: function (ref) {
-    var el = this.refs[ref].getDOMNode();
-    this.tip_hideTip(el);
-  },
-
   getButtons: function () {
     if (this.state.loading) {
-      return (
-        <div className="loading-bar"
-          ref="loadingBar"
-          key="loadingBar"
-          data-behavior="show-tip"
-          data-tip-type-class="default"
-          data-tip-place="top"
-          data-tip-content="deploying"
-          onMouseOver=
-            {this.handleMouseOverHealthBar.bind(null, "loadingBar")}
-          onMouseOut=
-            {this.handleMouseOutHealthBar.bind(null, "loadingBar")} />
-      );
+      return (<div className="loading-bar" />);
     } else {
       return (
         <ul className="list-inline">

--- a/src/js/components/DeploymentComponent.jsx
+++ b/src/js/components/DeploymentComponent.jsx
@@ -5,9 +5,12 @@ var React = require("react/addons");
 var DeploymentActions = require("../actions/DeploymentActions");
 var DialogActions = require("../actions/DialogActions");
 var DialogStore = require("../stores/DialogStore");
+var TooltipMixin = require("../mixins/TooltipMixin");
 
 var DeploymentComponent = React.createClass({
   displayName: "DeploymentComponent",
+
+  mixins: [TooltipMixin],
 
   propTypes: {
     model: React.PropTypes.object.isRequired
@@ -53,17 +56,30 @@ var DeploymentComponent = React.createClass({
     }.bind(this));
   },
 
+  handleMouseOverHealthBar: function (ref) {
+    var el = this.refs[ref].getDOMNode();
+    this.tip_showTip(el);
+  },
+
+  handleMouseOutHealthBar: function (ref) {
+    var el = this.refs[ref].getDOMNode();
+    this.tip_hideTip(el);
+  },
+
   getButtons: function () {
     if (this.state.loading) {
       return (
-        <div className="progress progress-striped active pull-right"
-            style={{"width": "140px"}}>
-          <span className="progress-bar progress-bar-info" role="progressbar"
-              aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"
-              style={{"width": "100%"}}>
-            <span className="sr-only">Rolling back deployment</span>
-          </span>
-        </div>
+        <div className="loading-bar"
+          ref="loadingBar"
+          key="loadingBar"
+          data-behavior="show-tip"
+          data-tip-type-class="default"
+          data-tip-place="top"
+          data-tip-content="deploying"
+          onMouseOver=
+            {this.handleMouseOverHealthBar.bind(null, "loadingBar")}
+          onMouseOut=
+            {this.handleMouseOutHealthBar.bind(null, "loadingBar")} />
       );
     } else {
       return (
@@ -127,7 +143,7 @@ var DeploymentComponent = React.createClass({
             {progressStep}
           </span> / {model.totalSteps}
         </td>
-        <td className="text-right">
+        <td className="text-right deployment-buttons">
           {this.getButtons()}
         </td>
       </tr>


### PR DESCRIPTION
This fixes https://github.com/mesosphere/marathon/issues/2715

Here's a before/after gif

![progress-bar](https://cloud.githubusercontent.com/assets/1078545/11506506/0f08ebc8-9850-11e5-9ac9-4b9485efc2ef.gif)
