### PR TITLE
Update breadcrumb width calculation for Babel 6

### DIFF
--- a/src/js/components/BreadcrumbComponent.jsx
+++ b/src/js/components/BreadcrumbComponent.jsx
@@ -126,7 +126,8 @@ var BreadcrumbComponent = React.createClass({
     var listItems = this.getDOMNode().children;
     var collapsed = this.state.collapsed;
 
-    return Object.values(listItems)
+    // array/splat casts NodeList to array
+    return [...listItems]
       .map((item, n) => {
         var isFirstItem = n === 0;
         var isLastItem = n === listItems.length - 1;


### PR DESCRIPTION
Fixes mesosphere/marathon#2757

Since #435 was merged, `Object.values` no longer casts NodeLists to arrays, hence the width calculation wasn't working correctly. Thanks to @pierlo-upitup for the `[...nodeList]` technique tip!