### PR TITLE
Add overflow ellipsis on last item in breadcrumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - \#2705 - Link groupId in search results to individual groups
 - \#2729 - Expose IP-per-container app definition in App Details page
 - \#2727 - Integrate IP-Per-Container ipAddresses into task detail view
+- \#2714 - Global ellipsis in breadcrumbs
 
 ### Changed
 - Adjust the task list column order

--- a/src/css/components/breadcrumb.less
+++ b/src/css/components/breadcrumb.less
@@ -81,5 +81,11 @@
 
       }
     }
+    li:last-child {
+      flex: 1;
+      a {
+        text-overflow: ellipsis;
+      }
+    }
   }
 }

--- a/src/css/components/breadcrumb.less
+++ b/src/css/components/breadcrumb.less
@@ -83,6 +83,9 @@
     }
     li:last-child {
       flex: 1;
+      // min-width is necessary to resolve Firefox flexbox bug
+      // (https://bugzilla.mozilla.org/show_bug.cgi?id=823483)
+      min-width: 0;
       a {
         text-overflow: ellipsis;
       }

--- a/src/js/components/BreadcrumbComponent.jsx
+++ b/src/js/components/BreadcrumbComponent.jsx
@@ -6,6 +6,7 @@ var PathUtil = require("../helpers/PathUtil");
 
 const COLLAPSE_BUFFER = 12;
 const PADDED_ICON_WIDTH = 24; // 16px icon + 8px padding
+const LAST_ITEM_OFFSET = 96; // Difference between scrollWidth and outerWidth
 
 var BreadcrumbComponent = React.createClass({
   displayName: "BreadcrumbComponent",
@@ -128,6 +129,7 @@ var BreadcrumbComponent = React.createClass({
 
     // array/splat casts NodeList to array
     return [...listItems]
+      .slice(0, -1)
       .map((item, n) => {
         var isFirstItem = n === 0;
         var isLastItem = n === listItems.length - 1;
@@ -136,7 +138,13 @@ var BreadcrumbComponent = React.createClass({
         }
         return this.getWidthFromCollapsedItem(item);
       })
-      .reduce((memo, width) => memo + width, 0);
+      .reduce((memo, width) => memo + width, this.getLastItemWidth());
+  },
+
+  getLastItemWidth: function () {
+    var lastItem = this.getDOMNode().lastChild;
+    var lastItemLink = lastItem.firstChild;
+    return lastItemLink.scrollWidth + LAST_ITEM_OFFSET;
   },
 
   shouldCollapse: function (availableWidth, expandedWidth) {


### PR DESCRIPTION
Fixes mesosphere/marathon#2714

*NB: Please note this relies on the fix in #462*

A small PR with wide-ranging effects. Please be sure to test on breadcrumbs in tasks, apps, groups, and search results. 

See a gif of it in action [here](http://cl.ly/3i0o1J2s1h0X) - not inline as it's very wide. 