### PR TITLE
Change default td and th vertical alignment to middle

### DIFF
--- a/src/css/layout/table.less
+++ b/src/css/layout/table.less
@@ -13,6 +13,7 @@
   border-bottom: 1px solid @table-border-color;
   line-height: inherit;
   padding: @base-spacing-unit*2 @base-spacing-unit;
+  vertical-align: middle;
 }
 
 .table > thead > tr > th,


### PR DESCRIPTION
Previously table cells were aligned to top which looked odd.

Before
![image](https://cloud.githubusercontent.com/assets/15963/11579406/b3736fa6-99e2-11e5-90db-7e25699c69f7.png)


After
![image](https://cloud.githubusercontent.com/assets/15963/11579396/9bf287cc-99e2-11e5-844a-35dcb5764c1f.png)
