### PR TITLE
Remove links if no service discovery ports are present

### DIFF
--- a/src/js/components/TaskListItemComponent.jsx
+++ b/src/js/components/TaskListItemComponent.jsx
@@ -109,9 +109,17 @@ var TaskListItemComponent = React.createClass({
           );
         });
 
+        if (portNodes.length) {
+          return (
+            <span key={address.ipAddress} className="text-muted">
+              {address.ipAddress}:[{joinNodes(portNodes)}]
+            </span>
+          );
+        }
+
         return (
           <span key={address.ipAddress} className="text-muted">
-            {address.ipAddress}:[{joinNodes(portNodes)}]
+            {address.ipAddress}
           </span>
         );
       });


### PR DESCRIPTION
This fixes https://github.com/mesosphere/marathon/issues/2767

With the following app definition for service discovery:
```
"ipAddress": {
        "labels": {},
        "discovery": {
          "ports": []
        }
      }
```

the task list now displays:

![screen shot 2015-12-04 at 16 01 09](https://cloud.githubusercontent.com/assets/1078545/11592663/40492a66-9aa0-11e5-9aaf-6f2dc2260dee.png)
