### PR TITLE
Handle empty ports in service discover for task details page

### DIFF
--- a/src/js/components/TaskDetailComponent.jsx
+++ b/src/js/components/TaskDetailComponent.jsx
@@ -62,11 +62,15 @@ var TaskDetailComponent = React.createClass({
         return memo;
       }, []);
 
-      return endpoints.map(endpoint => (
-        <dd key={endpoint} className="overflow-ellipsis">
-          <a href={`//${endpoint}`} target="_blank">{endpoint}</a>
-        </dd>
-      ));
+      if (endpoints.length) {
+        return endpoints.map(endpoint => (
+          <dd key={endpoint} className="overflow-ellipsis">
+            <a href={`//${endpoint}`} target="_blank">{endpoint}</a>
+          </dd>
+        ));
+      }
+
+      return (<dd>n/a</dd>);
     }
 
     return task.ports.map((port) => {


### PR DESCRIPTION
This fixes https://github.com/mesosphere/marathon/issues/2778

And produces:

![screen shot 2015-12-04 at 16 40 33](https://cloud.githubusercontent.com/assets/1078545/11593667/c61dc2a0-9aa5-11e5-8fb2-df66ca7565e3.png)
