### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+docker/node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# can't use 5 https://github.com/npm/npm/issues/9863
+FROM node:4.2.3
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY package.json /usr/src/app/
+RUN npm install
+
+RUN npm install -g \
+  corsproxy \
+  gulp
+
+COPY docker/package.json /usr/src/app/docker/
+RUN cd docker && \
+  npm install .
+
+COPY . /usr/src/app
+
+# ENV MARATHON_API_URL
+COPY src/js/config/config.docker.js src/js/config/config.dev.js
+
+EXPOSE 1337 4200
+ENV CORSPROXY_HOST 0.0.0.0
+ENTRYPOINT [ "./docker/entrypoint.sh" ]
+CMD [ "npm", "run", "serve" ]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,33 @@
+# corsproxy
+
+> standalone CORS proxy
+
+[![Build Status](https://travis-ci.org/gr2m/CORS-Proxy.svg?branch=master)](https://travis-ci.org/gr2m/CORS-Proxy)
+[![Dependency Status](https://david-dm.org/gr2m/CORS-Proxy.svg)](https://david-dm.org/gr2m/CORS-Proxy)
+[![devDependency Status](https://david-dm.org/gr2m/CORS-Proxy/dev-status.svg)](https://david-dm.org/gr2m/CORS-Proxy#info=devDependencies)
+
+[![NPM](https://nodei.co/npm/corsproxy.png?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/corsproxy/)
+
+
+## Setup
+
+```
+npm install -g corsproxy
+corsproxy
+# with custom port: CORSPROXY_PORT=1234 corsproxy
+# with custom host: CORSPROXY_HOST=localhost corsproxy
+# with debug server: DEBUG=1 corsproxy
+```
+
+## Usage
+
+The cors proxy will start at http://localhost:1337.
+To access another domain, use the domain name (including port) as the first folder, e.g.
+
+- http://localhost:1337/localhost:3000/sign_in
+- http://localhost:1337/my.domain.com/path/to/resource
+- etc etc
+
+## License
+
+MIT

--- a/docker/bin/corsproxy
+++ b/docker/bin/corsproxy
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+var Hapi = require('hapi')
+var plugin = require('../index')
+var good = require('good')
+var loggerOptions = require('../lib/logger-options')
+
+var server = new Hapi.Server({})
+var port = parseInt(process.env.CORSPROXY_PORT || process.env.PORT || 1337, 10)
+var host = (process.env.CORSPROXY_HOST || 'localhost');
+var proxy = server.connection({ port: port, labels: ['proxy'], host: host})
+
+server.register(require('inert'), function () {})
+server.register(require('h2o2'), function () {})
+
+// cors plugin
+server.register(plugin, {
+  select: ['proxy']
+}, function (error) {
+  if (error) server.log('error', error)
+})
+
+// logger plugin
+server.register({
+  register: good,
+  options: loggerOptions
+}, function (error) {
+  if (error) server.log('error', error)
+})
+
+var proxyServices = process.env.CORSPROXY_SERVICE
+proxyServices = proxyServices ? proxyServices.split(" ") : process.argv.slice(2)
+console.log("proxyServices: ", proxyServices)
+
+// proxy route
+proxy.route({
+  method: '*',
+  path: '/{host}/{path*}',
+  handler: {
+    proxy: {
+      passThrough: true,
+      mapUri: function (request, callback) {
+        if (proxyServices.indexOf(request.params.host) > -1) {
+          request.host = request.params.host
+          request.path = request.path.substr(request.params.host.length + 1)
+        } else {
+          request.host = proxyServices[0]
+        }
+        request.headers['host'] = request.host
+        var query = request.url.search ? request.url.search : ''
+        console.log('proxy to http://' + request.host + request.path)
+        callback(null, 'http://' + request.host + request.path + query, request.headers)
+      }
+    }
+  }
+})
+
+if (process.env.DEBUG) {
+  var testport = port + 1
+  var test = server.connection({ port: testport, labels: ['test'], host: host })
+
+  server.register(require('vision'), function (error) {
+    if (error) {
+      throw error
+    }
+
+    server.views({
+      engines: { ejs: require('ejs') },
+      path: 'public/test'
+    })
+  })
+
+  test.route({
+    method: 'GET',
+    path: '/favicon.ico',
+    handler: {
+      file: 'public/favicon.ico'
+    }
+  })
+  test.route({
+    method: 'GET',
+    path: '/test.json',
+    handler: {
+      file: 'public/test/test.json'
+    }
+  })
+
+  test.route({
+    method: 'GET',
+    path: '/',
+    handler: function (request, reply) {
+      reply.view('index', {
+        proxyPort: proxy.info.port,
+        testPort: test.info.port
+      })
+    }
+  })
+
+  server.log('info', 'Debug server starting at: ' + test.info.uri)
+}
+
+server.start(function (error) {
+  if (error) server.log('error', error)
+
+  server.log('info', 'CORS Proxy running at: ' + server.info.uri)
+})

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+{ cd docker; ./bin/corsproxy; } &
+exec $@

--- a/docker/index.js
+++ b/docker/index.js
@@ -1,0 +1,12 @@
+var addCorsHeaders = require('hapi-cors-headers')
+var pkg = require('./package.json')
+
+function corsPlugin (server, options, next) {
+  server.ext('onPreResponse', addCorsHeaders)
+  next()
+}
+
+corsPlugin.attributes = {
+  pkg: pkg
+}
+module.exports = corsPlugin

--- a/docker/lib/logger-options.js
+++ b/docker/lib/logger-options.js
@@ -1,0 +1,12 @@
+var goodConsole = require('good-console')
+module.exports = {
+  opsInterval: 1000,
+  reporters: [{
+    reporter: goodConsole,
+    events: {
+      log: '*',
+      request: '*',
+      response: '*'
+    }
+  }]
+}

--- a/docker/package.json
+++ b/docker/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "corsproxy",
+  "description": "standalone CORS proxy",
+  "main": "./index.js",
+  "author": {
+    "name": "Gregor Martynus",
+    "email": "gregor@martynus.net"
+  },
+  "dependencies": {
+    "ejs": "^2.3.3",
+    "good": "^6.3.0",
+    "good-console": "^5.0.3",
+    "h2o2": "^4.0.1",
+    "hapi": "^9.0.2",
+    "hapi-cors-headers": "^1.0.0",
+    "http-proxy": "~1.11",
+    "inert": "^3.0.1",
+    "vision": "^3.0.0"
+  },
+  "devDependencies": {
+    "chai": "^3.2.0",
+    "chai-as-promised": "^5.1.0",
+    "colors": "^1.1.2",
+    "mocha": "^2.2.5",
+    "request": "^2.60.0",
+    "sauce-connect-launcher": "^0.12.0",
+    "semantic-release": "^4.0.3",
+    "standard": "^5.1.0",
+    "sv-selenium": "^0.2.6",
+    "wd": "^0.3.12"
+  },
+  "bin": {
+    "corsproxy": "./bin/corsproxy"
+  },
+  "scripts": {
+    "install_selenium_and_chromedriver": "install_chromedriver && install_selenium",
+    "kill_selenium": "kill_selenium",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
+    "start": "./bin/corsproxy",
+    "start_app": "./bin/start-app",
+    "start_selenium_with_chromedriver": "start_selenium_with_chromedriver",
+    "test": "standard && ./bin/test-background",
+    "test:mocha": "mocha test/test-*.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gr2m/CORS-Proxy"
+  },
+  "license": "MIT"
+}

--- a/src/js/config/config.docker.js
+++ b/src/js/config/config.docker.js
@@ -1,0 +1,8 @@
+var configDev = {
+  // Defines the Marathon API URL,
+  // leave empty to use the same as the UI is served.
+  apiURL: process.env.MARATHON_API_URL,
+  // If the UI is served through a proxied URL, this can be set here.
+  rootUrl: ""
+};
+module.exports = configDev;


### PR DESCRIPTION
Example usage:

  $ docker build .
  $ docker run --rm -it -p 1337:1337 -p 4200:4200 -e CORSPROXY_SERVICE="localhost:4200 $MARATHON_URL" -e MARATHON_API_URL="/$MARATHON_URL/" <docker_build_sha>

Had to use node 4 due to a known issue (see Dockerfile)

decided to vendor corsproxy because I wanted to be able to access
http://localhost:1337/#/apps instead of http://localhost:1337/localhost:4200/#/apps

Changes made to corsproxy including changing the proxy hosts to a
whitelist.

usage:

  $ corsproxy <default_proxy_host> [<any_other_host>...]

This makes it so that http://localhost:1337 will proxy to the first host
in the list.