### PR TITLE
Fix - Don't display file download link if file not available

### DIFF
--- a/src/js/components/TaskFileDownloadComponent.jsx
+++ b/src/js/components/TaskFileDownloadComponent.jsx
@@ -70,16 +70,20 @@ var TaskFileDownloadComponent = React.createClass({
     var props = this.props;
     var name = props.fileName;
     var file = state.file;
-    var href = "";
-    if (file) {
-      href = file.downloadURI;
+
+    if (!file || !file.downloadURI) {
+      return (
+        <span>&ndash;</span>
+      );
     }
-    var className = classNames("task-file-download", props.className, {
+
+    let className = classNames("task-file-download", props.className, {
       "loading": state.fileIsRequestedByUser
     });
+
     return (
       <a className={className}
-          href={href}
+          href={file.downloadURI}
           onClick={this.handleClick}
           ref="download"
           download={name}>


### PR DESCRIPTION
Preliminary quickfix.
This could be easily extended later with the loading state.

![filelinks](https://cloud.githubusercontent.com/assets/859154/11657114/77b97c9a-9dba-11e5-9dbd-f94331f2f81f.png)


**Update**
Related issue: https://github.com/mesosphere/marathon/issues/2777