### PR TITLE
Add more AJAX tests

### DIFF
--- a/src/test/ajaxWrapper.test.js
+++ b/src/test/ajaxWrapper.test.js
@@ -147,35 +147,28 @@ describe("ajaxWrapper", function () {
 
   describe("on POST request", function () {
 
+    beforeEach(function () {
+      this.server = server
+        .setup(null, 200, true)
+        .start();
+    });
+
+    afterEach(function (done) {
+      this.server.stop(done);
+    });
+
     it("sends the correct payload", function (done) {
-      var response = {body: ""};
-      var request = {method: null};
       var payload = {"key": "value"};
-
-      this.server.on("request", function (req) {
-        request.method = req.method;
-
-        req.addListener("data", function (chunk) {
-          response.body += chunk;
-        });
-
-        req.addListener("end", function (chunk) {
-          if (chunk) {
-            response.body += chunk;
-          }
-        });
-
-      });
 
       ajaxWrapper({
         method: "POST",
         url: config.apiURL,
         data: payload
       })
-        .success(function () {
+        .success(function (response) {
           expectAsync(function () {
-            expect(request.method).to.equal("POST");
-            expect(response.body).to.equal(JSON.stringify(payload));
+            expect(response.body.method).to.equal("POST");
+            expect(response.body.payload).to.equal(JSON.stringify(payload));
           }, done);
         })
         .error(function () {

--- a/src/test/ajaxWrapper.test.js
+++ b/src/test/ajaxWrapper.test.js
@@ -39,6 +39,20 @@ describe("ajaxWrapper", function () {
       });
     });
 
+    it("defaults to GET when no method is supplied", function (done) {
+      ajaxWrapper({
+        url: config.apiURL
+      })
+      .success(function (response) {
+        expectAsync(function () {
+          expect(response.body.name).to.equal("Marathon");
+        }, done);
+      })
+      .error(function () {
+        done(new Error("I should not be called"));
+      });
+    });
+
     it("handles failure gracefully", function (done) {
       this.server.setup({message: "Guru Meditation"}, 404);
 

--- a/src/test/ajaxWrapper.test.js
+++ b/src/test/ajaxWrapper.test.js
@@ -198,4 +198,68 @@ describe("ajaxWrapper", function () {
 
   });
 
+  describe("on PUT request", function () {
+
+    beforeEach(function () {
+      this.server = server
+        .setup(null, 200, true)
+        .start();
+    });
+
+    afterEach(function (done) {
+      this.server.stop(done);
+    });
+
+    it("sends the correct payload with a PUT", function (done) {
+
+      var payload = {"key": "value"};
+
+      ajaxWrapper({
+        method: "PUT",
+        url: config.apiURL,
+        data: payload
+      })
+        .success(response => {
+          expectAsync(() => {
+            expect(response.body.method).to.equal("PUT");
+            expect(response.body.payload).to.equal(JSON.stringify(payload));
+          }, done);
+        })
+        .error(() => {
+          done(new Error("I should not be called"));
+        });
+    });
+
+  });
+
+  describe("on DELETE request", function () {
+
+    beforeEach(function () {
+      this.server = server
+        .setup(null, 200, true)
+        .start();
+    });
+
+    afterEach(function (done) {
+      this.server.stop(done);
+    });
+
+    it("returns the right response for a DELETE", function (done) {
+
+      ajaxWrapper({
+        method: "DELETE",
+        url: config.apiURL + "/foo/bar",
+        data: null
+      })
+        .success(response => {
+          expectAsync(() => {
+            expect(response.body.method).to.equal("DELETE");
+          }, done);
+        })
+        .error(() => {
+          done(new Error("I should not be called"));
+        });
+    });
+  })
+
 });

--- a/src/test/ajaxWrapper.test.js
+++ b/src/test/ajaxWrapper.test.js
@@ -10,19 +10,19 @@ config.apiURL = "http://" + server.address + ":" + server.port + "/";
 
 describe("ajaxWrapper", function () {
 
-  beforeEach(function () {
-    this.server = server
-      .setup({
-        "name": "Marathon"
-      }, 200)
-      .start();
-  });
-
-  afterEach(function (done) {
-    this.server.stop(done);
-  });
-
   describe("on GET request", function () {
+
+    beforeEach(function () {
+      this.server = server
+        .setup({
+          "name": "Marathon"
+        }, 200)
+        .start();
+    });
+
+    afterEach(function (done) {
+      this.server.stop(done);
+    });
 
     it("returns a JSON object on success", function (done) {
       ajaxWrapper({
@@ -73,6 +73,18 @@ describe("ajaxWrapper", function () {
   });
 
   describe("on concurrent request", function () {
+
+    beforeEach(function () {
+      this.server = server
+        .setup({
+          "name": "Marathon"
+        }, 200)
+        .start();
+    });
+
+    afterEach(function (done) {
+      this.server.stop(done);
+    });
 
     it("should timeout on second request", function (done) {
       var responses = 0;

--- a/src/test/helpers/HttpServer.js
+++ b/src/test/helpers/HttpServer.js
@@ -23,6 +23,10 @@ HttpServer.prototype.setup = function (data, resCode) {
   return this;
 };
 
+HttpServer.prototype.on = function (event, fn) {
+  this.server.on(event, fn);
+};
+
 HttpServer.prototype.stop = function (fn) {
   this.server.close();
   if (fn) {

--- a/src/test/helpers/HttpServer.js
+++ b/src/test/helpers/HttpServer.js
@@ -5,26 +5,54 @@ function HttpServer(config) {
   this.address = config.address || "localhost";
   this.options = {
     data: null,
+    headers: {"Content-Type": "application/json"},
+    returnPayload: false,
     resCode: 200
   };
 }
 
 HttpServer.prototype.start = function (fn) {
-  this.server = http.createServer(function (req, res) {
-    res.writeHead(this.options.resCode, {"Content-Type": "application/json"});
-    res.end(JSON.stringify(this.options.data));
-  }.bind(this)).listen(this.port, this.address, fn);
-  return this;
-};
 
-HttpServer.prototype.setup = function (data, resCode) {
-  this.options.data = data;
-  this.options.resCode = resCode || 200;
+  this.server = http.createServer();
+
+  this.server.on("request", (req, res) => {
+
+    if (this.options.returnPayload === true) {
+      this.options.data = {
+        payload: "",
+        method: req.method
+      };
+
+      req.addListener("data", chunk => {
+        this.options.data.payload += chunk;
+      });
+
+      req.addListener("end", chunk => {
+        if (chunk) {
+          this.options.data.payload += chunk;
+        }
+        res.writeHead(this.options.resCode, this.options.headers);
+        res.end(JSON.stringify(this.options.data));
+      });
+    } else {
+      res.writeHead(this.options.resCode, this.options.headers);
+      res.end(JSON.stringify(this.options.data));
+    }
+  }).listen(this.port, this.address, fn);
+
   return this;
 };
 
 HttpServer.prototype.on = function (event, fn) {
   this.server.on(event, fn);
+};
+
+HttpServer.prototype.setup = function (data, resCode, returnPayload = false) {
+  this.options.data = data;
+  this.options.resCode = resCode || 200;
+  this.options.returnPayload = returnPayload;
+
+  return this;
 };
 
 HttpServer.prototype.stop = function (fn) {


### PR DESCRIPTION
This partially fixes https://github.com/mesosphere/marathon/issues/2795 and is meant to be merged into  https://github.com/mesosphere/marathon-ui/pull/476.


I'd like to hear your opinion on the POST approach taken in this PR before applying similar criteria to the other verbs.

As you can see I had to "hack" my way into adding an `.on("request")` response listener in order to be able to parse the POST request payload and verify it's what the user meant to send.

Your thoughts on this are more than welcome!