### PR TITLE
Always show host field in task detail view

### DIFF
--- a/src/js/components/TaskDetailComponent.jsx
+++ b/src/js/components/TaskDetailComponent.jsx
@@ -86,12 +86,15 @@ var TaskDetailComponent = React.createClass({
   getIpAddresses: function () {
     var props = this.props;
     var task = props.task;
+    var ipAddresses = task.ipAddresses;
 
-    var ipAddresses = (task.ipAddresses != null && task.ipAddresses.length > 0)
-      ? task.ipAddresses.map(address => address.ipAddress)
-      : [task.host];
+    if (ipAddresses == null) {
+      return null;
+    }
 
-    return ipAddresses.map(ipAddress => (<dd key={ipAddress}>{ipAddress}</dd>));
+    return ipAddresses.map(address => (
+      <dd key={address.ipAddress}>{address.ipAddress}</dd>
+    ));
   },
 
   getPorts: function () {
@@ -164,11 +167,17 @@ var TaskDetailComponent = React.createClass({
       );
     });
 
+    var ipAddressFields = this.getIpAddresses();
+    if (ipAddressFields != null && ipAddressFields.length > 0) {
+      ipAddressFields.unshift(<dt key="ip-addresses">IP Addresses</dt>)
+    }
+
     return (
       <div>
         <dl className="dl-horizontal task-details">
-          <dt>IP Addresses</dt>
-          {this.getIpAddresses()}
+          <dt>Host</dt>
+          <dd>{task.host}</dd>
+          {ipAddressFields}
           <dt>Ports</dt>
           {this.getPorts()}
           <dt>Endpoints</dt>

--- a/src/test/tasks.test.js
+++ b/src/test/tasks.test.js
@@ -256,19 +256,19 @@ describe("Task Detail component", function () {
   });
 
   it("has the correct status", function () {
-    var content = ShallowUtils.getText(this.taskDetails.props.children[9]);
+    var content = ShallowUtils.getText(this.taskDetails.props.children[10]);
     expect(content).to.equal("status-0");
   });
 
   it("has the correct timefields", function () {
-    var stagedAt = this.taskDetails.props.children[10][0].props;
-    var startedAt = this.taskDetails.props.children[10][1].props;
+    var stagedAt = this.taskDetails.props.children[11][0].props;
+    var startedAt = this.taskDetails.props.children[11][1].props;
     expect(stagedAt.time).to.equal("2015-06-29T14:11:58.709Z");
     expect(startedAt.time).to.equal("2015-06-29T14:11:58.709Z");
   });
 
   it("has the correct version", function () {
-    var version = this.taskDetails.props.children[12].props.children.props;
+    var version = this.taskDetails.props.children[13].props.children.props;
     expect(version.dateTime).to.equal("2015-06-29T13:54:24.171Z");
   });
 
@@ -308,17 +308,17 @@ describe("Task Detail component", function () {
     });
 
     it("has the correct host", function () {
-      var content = ShallowUtils.getText(this.taskDetails.props.children[1][0]);
+      var content = ShallowUtils.getText(this.taskDetails.props.children[1]);
       expect(content).to.equal("host-1");
     });
 
     it("has the correct ports", function () {
-      var content = ShallowUtils.getText(this.taskDetails.props.children[3]);
+      var content = ShallowUtils.getText(this.taskDetails.props.children[4]);
       expect(content).to.equal("[1,2,3]");
     });
 
     it("has the correct endpoints", function () {
-      var list = this.taskDetails.props.children[5];
+      var list = this.taskDetails.props.children[6];
       var endpoints = [
         ShallowUtils.getText(list[0].props.children),
         ShallowUtils.getText(list[1].props.children),
@@ -331,6 +331,7 @@ describe("Task Detail component", function () {
   describe("with IP per container", function () {
     before(function () {
       this.model = Object.assign({}, baseModel, {
+        "host": "example.com",
         "ipAddresses": [
           {
             "protocol": "IPv4",
@@ -366,18 +367,23 @@ describe("Task Detail component", function () {
       delete AppsStore.currentApp.ipAddress;
     });
 
+    it("has the correct host", function () {
+      var content = ShallowUtils.getText(this.taskDetails.props.children[1]);
+      expect(content).to.equal("example.com");
+    });
+
     it("has the correct ip address", function () {
-      var content = ShallowUtils.getText(this.taskDetails.props.children[1][0]);
+      var content = ShallowUtils.getText(this.taskDetails.props.children[2][1]);
       expect(content).to.equal("127.0.0.1");
     });
 
     it("has the correct ports", function () {
-      var content = ShallowUtils.getText(this.taskDetails.props.children[3]);
+      var content = ShallowUtils.getText(this.taskDetails.props.children[4]);
       expect(content).to.equal("[]");
     });
 
     it("has the correct endpoints", function () {
-      var list = this.taskDetails.props.children[5];
+      var list = this.taskDetails.props.children[6];
       var endpoints = [
         ShallowUtils.getText(list[0].props.children),
         ShallowUtils.getText(list[1].props.children)


### PR DESCRIPTION
Fixes mesosphere/marathon#2779

The host field is always returned in the task information and should always be shown in the task detail component. This PR ensures that the host field is always shown, and the IP Addresses field is shown only when a task has IP addresses present. 

With IP addresses:
<img alt="2779-with-ip-addresses" src="https://cloud.githubusercontent.com/assets/2989362/11688653/32ff1f22-9e8e-11e5-92df-12222e774ba3.png">

Without IP addresses:
<img alt="2779-without-ip-addresses" src="https://cloud.githubusercontent.com/assets/2989362/11688663/3c0746da-9e8e-11e5-8d7c-18627d1b3672.png">
