### PR TITLE
Fix - HEAD or GET Request cannot have a body.

### DIFF
--- a/src/js/helpers/ajaxWrapper.js
+++ b/src/js/helpers/ajaxWrapper.js
@@ -33,13 +33,20 @@ var ajaxWrapper = function (opts = {}) {
   };
 
   var makeRequest = function (options) {
-    return fetch(options.url, {
+    var fetchOptions = {
       method: options.method,
-      headers: options.headers,
-      body: options.data != null
-        ? JSON.stringify(options.data)
-        : null
-    });
+      headers: options.headers
+    };
+
+    if (options.method !== "GET" && options.method !== "HEAD") {
+      Object.assign(fetchOptions, {
+        body: options.data != null
+          ? JSON.stringify(options.data)
+          : null
+      });
+    }
+
+    return fetch(options.url, fetchOptions);
   };
 
   var parseResponse = function (xhr, callback) {


### PR DESCRIPTION
Firefox complains that a GET or HEAD cannot have a body, which is true actually.

This PR fixes this.

![noget](https://cloud.githubusercontent.com/assets/859154/11715957/8d5029fe-9f46-11e5-8da1-51ae9cfb5261.png)

