### PR TITLE
Feature - 2775 highlight json nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unversioned
 ### Added
 - \#2772 - URI fields should be links
+- \#2775 - Syntax highlighting for JSON fragments in configuration
 
 ### Fixed
 - \#2755 - Memory leak in Marathon UI

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -14196,6 +14196,10 @@
         }
       }
     },
+    "highlight.js": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.0.0.tgz"
+    },
     "iconv-lite": {
       "version": "0.4.13",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "eslint": "^1.10.1",
     "eslint-plugin-react": "^3.10.0",
     "flux": "^2.0.3",
+    "highlight.js": "^9.0.0",
     "isomorphic-fetch": "^2.2.0",
     "lazy.js": "^0.4.0",
     "moment": "^2.9.0",

--- a/src/css/layout/base.less
+++ b/src/css/layout/base.less
@@ -36,7 +36,7 @@ code {
 
 pre {
   color: #fff;
-  background-color: #323539;
+  background-color: transparent;
   border-style: none;
 }
 

--- a/src/css/layout/overrides.less
+++ b/src/css/layout/overrides.less
@@ -6,3 +6,10 @@
   border-width: 5px;
 }
 
+/* ==============
+ * Highlight.js overrides
+ * ==============
+ */
+ .hljs {
+  background: transparent;
+}

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1,6 +1,7 @@
 @import (inline) "vendor/bootstrap-3.1.0.css";
 @import (inline) "vendor/ionicons.css";
 @import (inline) "vendor/tooltip.less";
+@import (inline) "../../node_modules/highlight.js/styles/monokai.css";
 
 @import "variables.less";
 

--- a/src/js/components/AppVersionComponent.jsx
+++ b/src/js/components/AppVersionComponent.jsx
@@ -1,4 +1,5 @@
 var classNames = require("classnames");
+var highlight = require("highlight.js");
 var Link = require("react-router").Link;
 var React = require("react/addons");
 var url = require("url");
@@ -19,6 +20,16 @@ function invalidateValue(value, suffix) {
       <dd>{value} {suffix}</dd>
     );
   }
+}
+
+function getHighlightNode(data) {
+  return (
+    <dd>
+      <pre className="highlight">
+        {JSON.stringify(data, null, 2)}
+      </pre>
+    </dd>
+  );
 }
 
 var AppVersionComponent = React.createClass({
@@ -61,6 +72,14 @@ var AppVersionComponent = React.createClass({
     }
   },
 
+  componentDidMount: function () {
+    this.highlightNodes();
+  },
+
+  componentDidUpdate: function () {
+    this.highlightNodes();
+  },
+
   onAppApplySettingsRequest: function () {
     this.setState({isStale: true});
   },
@@ -86,6 +105,15 @@ var AppVersionComponent = React.createClass({
     return classNames({
       "btn btn-sm btn-default pull-right": true,
       "disabled": this.state.isStale || this.props.appVersion.version == null
+    });
+  },
+
+  highlightNodes: function () {
+    var highlightNodes =
+      React.findDOMNode(this).getElementsByClassName("highlight");
+
+    [...highlightNodes].forEach(node => {
+      highlight.highlightBlock(node);
     });
   },
 
@@ -140,7 +168,7 @@ var AppVersionComponent = React.createClass({
 
     var containerNode = (appVersion.container == null)
       ? <UnspecifiedNodeComponent />
-      : <dd><pre>{JSON.stringify(appVersion.container, null, 2)}</pre></dd>;
+      : getHighlightNode(appVersion.container);
 
     var dependenciesNode = (appVersion.dependencies.length === 0)
       ? <UnspecifiedNodeComponent />
@@ -168,11 +196,11 @@ var AppVersionComponent = React.createClass({
     var healthChecksNode = (appVersion.healthChecks == null
         || appVersion.healthChecks.length === 0)
       ? <UnspecifiedNodeComponent />
-      : <dd><pre>{JSON.stringify(appVersion.healthChecks, null, 2)}</pre></dd>;
+      : getHighlightNode(appVersion.healthChecks);
 
     var ipAddressNode = (appVersion.ipAddress == null)
       ? <UnspecifiedNodeComponent />
-      : <dd><pre>{JSON.stringify(appVersion.ipAddress, null, 2)}</pre></dd>;
+      : getHighlightNode(appVersion.ipAddress);
 
     var labelsNode = (appVersion.labels == null ||
         Object.keys(appVersion.labels).length === 0)


### PR DESCRIPTION
This closes https://github.com/mesosphere/marathon/issues/2775

![highlight](https://cloud.githubusercontent.com/assets/859154/11718000/040633d8-9f54-11e5-96ab-480ad47f7c8b.png)

I've used the Monokai style because it fits good on dark backgrounds.
And is the Sublime default.. ;)