### PR TITLE
Use latest stable Node version in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_script:
   - npm cache clear
   - npm install -g gulp
 node_js:
-  - "5.0.0"
+  - "5.2.0"
 script: npm install && npm run dist
 notifications:
   slack:


### PR DESCRIPTION
Unfortunately travis doesn't support semver style version numbering, so either we maintain the node version manually, or we use the `node` value which means "latest stable". See https://github.com/creationix/nvm#usage for more info.

I think this is better than sticking an arbitrary 5.x version. Please share your thoughts!
cc @philipnrmn @orlandohohmeier 

