### PR TITLE
Trigger health bar render after tooltip update

### DIFF
--- a/src/js/components/AppHealthBarWithTooltipComponent.jsx
+++ b/src/js/components/AppHealthBarWithTooltipComponent.jsx
@@ -21,15 +21,20 @@ var AppHealthBarWithTooltipComponent = React.createClass({
     };
   },
 
-  shouldComponentUpdate: function (nextProps) {
-    var shouldUpdate =
+  shouldComponentUpdate: function (nextProps, nextState) {
+    // Ensure that the health bar does not update before the tipContent was
+    // updated (`setState` is not guaranteed to complete before `render`)
+    if (this.state.tipContent !== nextState.tipContent) {
+      return true;
+    }
+    var healthWasUpdated =
       !Util.compareArrays(this.props.model.health, nextProps.model.health);
-    if (shouldUpdate) {
+    if (healthWasUpdated) {
       this.setState({
         tipContent: this.getAppHealthBreakdown(nextProps.model)
       });
     }
-    return shouldUpdate;
+    return false;
   },
 
   handleMouseOverHealthBar: function () {


### PR DESCRIPTION
Fixes mesosphere/marathon#2808

The issue turned out to be a a race condition between `setState` and `render` in `AppHealthBarWithTooltipComponent`. I worked around this by triggering a component update only after the tooltip html in the state changes. 