### PR TITLE
Change/count apps not tasks

### DIFF
--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -193,7 +193,9 @@ var AppListComponent = React.createClass({
     nodesSequence.each(app => {
       filterCounts.appsStatusesCount[app.status]++;
       app.health.forEach(health => {
-        filterCounts.appsHealthCount[health.state] += health.quantity;
+        if (health.quantity) {
+          filterCounts.appsHealthCount[health.state]++;
+        }
       });
     });
 
@@ -247,7 +249,9 @@ var AppListComponent = React.createClass({
     appsInGroup.forEach(app => {
       filterCounts.appsStatusesCount[app.status]++;
       app.health.forEach(health => {
-        filterCounts.appsHealthCount[health.state] += health.quantity;
+        if (health.quantity) {
+          filterCounts.appsHealthCount[health.state]++;
+        }
       });
     });
 


### PR DESCRIPTION
The health sidebar filter badge have the apps count instead of the tasks count now.
As discussed with @leemunroe and @orlandohohmeier .

![health](https://cloud.githubusercontent.com/assets/859154/11815713/4b12a070-a34d-11e5-86f7-dcec6259535c.png)
