### PR TITLE
Refactor - Rename app list filter to sidebar filters

### DIFF
--- a/src/js/components/SidebarComponent.jsx
+++ b/src/js/components/SidebarComponent.jsx
@@ -1,13 +1,13 @@
 var Link = require("react-router").Link;
 var React = require("react/addons");
 
-var AppListHealthFilterComponent =
-  require("../components/AppListHealthFilterComponent");
-var AppListLabelsFilterComponent =
-  require("../components/AppListLabelsFilterComponent");
-var AppListStatusFilterComponent =
-  require("../components/AppListStatusFilterComponent");
 var FilterTypes = require("../constants/FilterTypes");
+var SidebarHealthFilterComponent =
+  require("../components/SidebarHealthFilterComponent");
+var SidebarLabelsFilterComponent =
+  require("../components/SidebarLabelsFilterComponent");
+var SidebarStatusFilterComponent =
+  require("../components/SidebarStatusFilterComponent");
 
 var QueryParamsMixin = require("../mixins/QueryParamsMixin");
 
@@ -69,19 +69,19 @@ var SidebarComponent = React.createClass({
           <h3 className="small-caps">Status</h3>
           {this.getClearLinkForFilter(FilterTypes.STATUS)}
         </div>
-        <AppListStatusFilterComponent
+        <SidebarStatusFilterComponent
           onChange={this.updateFilter.bind(null, FilterTypes.STATUS)} />
         <div className="flex-row">
           <h3 className="small-caps">Health</h3>
           {this.getClearLinkForFilter(FilterTypes.HEALTH)}
         </div>
-        <AppListHealthFilterComponent
+        <SidebarHealthFilterComponent
           onChange={this.updateFilter.bind(null, FilterTypes.HEALTH)} />
         <div className="flex-row">
           <h3 className="small-caps">Label</h3>
           {this.getClearLinkForFilter(FilterTypes.LABELS)}
         </div>
-        <AppListLabelsFilterComponent
+        <SidebarLabelsFilterComponent
           onChange={this.updateFilter.bind(null, FilterTypes.LABELS)} />
       </nav>
     );

--- a/src/js/components/SidebarHealthFilterComponent.jsx
+++ b/src/js/components/SidebarHealthFilterComponent.jsx
@@ -17,8 +17,8 @@ var healthNameMapping = {
 /**
  * Health is wealth, peace of mind is happiness.
  */
-var AppListHealthFilterComponent = React.createClass({
-  displayName: "AppListHealthFilterComponent",
+var SidebarHealthFilterComponent = React.createClass({
+  displayName: "SidebarHealthFilterComponent",
 
   mixins: [QueryParamsMixin],
 
@@ -155,4 +155,4 @@ var AppListHealthFilterComponent = React.createClass({
 
 });
 
-module.exports = AppListHealthFilterComponent;
+module.exports = SidebarHealthFilterComponent;

--- a/src/js/components/SidebarLabelsFilterComponent.jsx
+++ b/src/js/components/SidebarLabelsFilterComponent.jsx
@@ -9,8 +9,8 @@ var FilterTypes = require("../constants/FilterTypes");
 
 var QueryParamsMixin = require("../mixins/QueryParamsMixin");
 
-var AppListLabelsFilterComponent = React.createClass({
-  displayName: "AppListLabelsFilterComponent",
+var SidebarLabelsFilterComponent = React.createClass({
+  displayName: "SidebarLabelsFilterComponent",
 
   mixins: [OnClickOutsideMixin, QueryParamsMixin],
 
@@ -259,4 +259,4 @@ var AppListLabelsFilterComponent = React.createClass({
 
 });
 
-module.exports = AppListLabelsFilterComponent;
+module.exports = SidebarLabelsFilterComponent;

--- a/src/js/components/SidebarStatusFilterComponent.jsx
+++ b/src/js/components/SidebarStatusFilterComponent.jsx
@@ -9,8 +9,8 @@ var QueryParamsMixin = require("../mixins/QueryParamsMixin");
 
 var statusNameMapping = require("../constants/LabelMapping").statusNameMapping;
 
-var AppListStatusFilterComponent = React.createClass({
-  displayName: "AppListStatusFilterComponent",
+var SidebarStatusFilterComponent = React.createClass({
+  displayName: "SidebarStatusFilterComponent",
 
   mixins: [QueryParamsMixin],
 
@@ -147,4 +147,4 @@ var AppListStatusFilterComponent = React.createClass({
 
 });
 
-module.exports = AppListStatusFilterComponent;
+module.exports = SidebarStatusFilterComponent;


### PR DESCRIPTION
This components are used in the sidebar not in the app list,
so I've renamed them.

These filter component don't have knowledge of the app list at all, they are only emitting filter events.