### PR TITLE
Form update preservers unknown properties tests

### DIFF
--- a/src/test/appForm.test.js
+++ b/src/test/appForm.test.js
@@ -67,6 +67,41 @@ describe("App Form", function () {
         FormActions.update("appId", "/app-1");
       });
 
+      it("preserves unknown properties", function (done) {
+        AppFormStore.app = {
+          id: "/app-1",
+          unknownProperty: "unknown"
+        };
+
+        AppFormStore.once(FormEvents.CHANGE, function () {
+          expectAsync(function () {
+            expect(AppFormStore.app.id).to.equal("/app-2");
+            expect(AppFormStore.app.unknownProperty).to.equal("unknown");
+          }, done);
+        });
+
+        FormActions.update("appId", "/app-2");
+      });
+
+      it("preserves unknown nested properties", function (done) {
+        AppFormStore.app = {
+          container: {
+            docker: {
+              unknownProperty: "unknown"
+            }
+          }
+        };
+
+        AppFormStore.once(FormEvents.CHANGE, function () {
+          expectAsync(function () {
+            expect(AppFormStore.app.container.docker.unknownProperty)
+              .to.equal("unknown");
+          }, done);
+        });
+
+        FormActions.update("appId", "docker-app");
+      });
+
       describe("the cpus field", function () {
 
         it("updates correctly", function (done) {


### PR DESCRIPTION
This brought me to write some tests
https://github.com/mesosphere/marathon/issues/2693

Issue could be closed I think.

@philipnrmn You couldn't reproduce the above issue either?