### PR TITLE
Fix/2821 tooltip content update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - \#2755 - Memory leak in Marathon UI
 - \#2845 - Misleading error feedback in app creation modal on port conflict
 - \#2812 - Cannot change configuration of Marathon app after deployment
+- \#2821 - Tooltip content update issue
 
 ## 0.14.0 - 2015-12-07
 ### Added

--- a/src/css/components/app-health-detail.less
+++ b/src/css/components/app-health-detail.less
@@ -32,7 +32,11 @@
   color: @text-color-muted;
 }
 
-.tooltip {
+.app-health-detail-popover {
+  .health-breakdown {
+    margin: 0;
+  }
+
   .health-breakdown-item {
     margin: @base-spacing-unit / 2 0;
     font-size: @base-font-size;
@@ -44,6 +48,31 @@
 
   .health-breakdown-item-empty.health-breakdown-item-impermanent {
     display: none;
+  }
+
+  &.popover {
+    &.default, &.top, &.bottom {
+      margin: 0;
+
+      .content {
+        right:0;
+        white-space: nowrap;
+
+        &:before, &:after {
+          left:auto;
+          right: @base-spacing-unit;
+        }
+
+      }
+    }
+
+    &.default .content, &.top .content {
+      bottom: @base-spacing-unit;
+    }
+
+    &.bottom .content {
+      top: @base-spacing-unit*2.5;
+    }
   }
 }
 

--- a/src/css/components/app-list.less
+++ b/src/css/components/app-list.less
@@ -105,7 +105,36 @@
             }
           }
         }
+      }
+    }
 
+    &.health-bar-column {
+
+      .popover {
+
+        &.default, &.top, &.bottom {
+          margin: 0;
+
+          .content {
+            min-width: @base-spacing-unit*10;
+            right:0;
+            white-space: nowrap;
+
+            &:before, &:after {
+              left:auto;
+              right: @base-spacing-unit*3;
+            }
+
+          }
+        }
+
+        &.default .content, &.top .content {
+          bottom: @base-spacing-unit;
+        }
+
+        &.bottom .content {
+          top: @base-spacing-unit*2.5;
+        }
       }
     }
   }

--- a/src/css/components/app-list.less
+++ b/src/css/components/app-list.less
@@ -107,35 +107,5 @@
         }
       }
     }
-
-    &.health-bar-column {
-
-      .popover {
-
-        &.default, &.top, &.bottom {
-          margin: 0;
-
-          .content {
-            min-width: @base-spacing-unit*10;
-            right:0;
-            white-space: nowrap;
-
-            &:before, &:after {
-              left:auto;
-              right: @base-spacing-unit*3;
-            }
-
-          }
-        }
-
-        &.default .content, &.top .content {
-          bottom: @base-spacing-unit;
-        }
-
-        &.bottom .content {
-          top: @base-spacing-unit*2.5;
-        }
-      }
-    }
   }
 }

--- a/src/css/components/popover.less
+++ b/src/css/components/popover.less
@@ -1,0 +1,55 @@
+.popover {
+
+  border: none;
+  display: none;
+  margin: 0;
+  max-width: none;
+  padding: 0;
+  position: relative;
+
+  &.visible {
+    display: block;
+  }
+
+  .content {
+    background-color: @navbar-bg-color;
+    padding: .8em 1em;
+    position: absolute;
+    z-index: 1;
+  }
+
+  &.default, &.top, &.bottom {
+    margin: 0;
+
+    .content:before, .content:after {
+      border: solid transparent;
+      border-width: @base-spacing-unit;
+      left: 50%;
+      height: 0;
+      margin-left: -@base-spacing-unit;
+      pointer-events: none;
+      position: absolute;
+      width: 0;
+    }
+  }
+
+  &.default .content, &.top .content {
+    bottom: 0;
+
+    &:before {
+      border-top-color: @navbar-bg-color;
+      top: 100%;
+      content: " ";
+    }
+  }
+
+  &.bottom .content {
+    top: 0;
+
+    &:after {
+      border-bottom-color: @navbar-bg-color;
+      bottom: 100%;
+      content: " ";
+    }
+  }
+}

--- a/src/css/components/popover.less
+++ b/src/css/components/popover.less
@@ -13,7 +13,7 @@
 
   .content {
     background-color: @navbar-bg-color;
-    padding: .8em 1em;
+    padding: @base-spacing-unit*2;
     position: absolute;
     z-index: 1;
   }

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -34,6 +34,7 @@
 @import "components/pagination.less";
 @import "components/pane.less";
 @import "components/panel.less";
+@import "components/popover.less";
 @import "components/task-list.less";
 @import "components/task-file-list.less";
 @import "components/tooltip.less";

--- a/src/js/components/AppHealthBarWithTooltipComponent.jsx
+++ b/src/js/components/AppHealthBarWithTooltipComponent.jsx
@@ -24,7 +24,7 @@ var AppHealthBarWithTooltipComponent = React.createClass({
       !Util.compareArrays(this.props.model.health, nextProps.model.health);
   },
 
-  handleMouseOverHealthBar: function (e) {
+  handleMouseOverHealthBar: function () {
     this.setState({
       isPopoverVisible: true
     });

--- a/src/js/components/AppHealthBarWithTooltipComponent.jsx
+++ b/src/js/components/AppHealthBarWithTooltipComponent.jsx
@@ -42,7 +42,8 @@ var AppHealthBarWithTooltipComponent = React.createClass({
     return (
       <div onMouseOver={this.handleMouseOverHealthBar}
            onMouseOut={this.handleMouseOutHealthBar}>
-        <PopoverComponent visible={this.state.isPopoverVisible}>
+        <PopoverComponent visible={this.state.isPopoverVisible}
+            className="app-health-detail-popover">
           <AppHealthDetailComponent
             className="list-unstyled"
             fields={[

--- a/src/js/components/AppHealthBarWithTooltipComponent.jsx
+++ b/src/js/components/AppHealthBarWithTooltipComponent.jsx
@@ -1,15 +1,13 @@
 var React = require("react/addons");
 
-var TooltipMixin = require("../mixins/TooltipMixin");
 var AppHealthBarComponent = require("./AppHealthBarComponent");
 var AppHealthDetailComponent = require("./AppHealthDetailComponent");
+var PopoverComponent = require("./PopoverComponent");
 var Util = require("../helpers/Util");
 var HealthStatus = require("../constants/HealthStatus");
 
 var AppHealthBarWithTooltipComponent = React.createClass({
   displayName: "AppHealthBarWithTooltipComponent",
-
-  mixins: [TooltipMixin],
 
   propTypes: {
     model: React.PropTypes.object.isRequired
@@ -17,68 +15,47 @@ var AppHealthBarWithTooltipComponent = React.createClass({
 
   getInitialState: function () {
     return {
-      tipContent: this.getAppHealthBreakdown(this.props.model)
+      isPopoverVisible: false
     };
   },
 
   shouldComponentUpdate: function (nextProps, nextState) {
-    // Ensure that the health bar does not update before the tipContent was
-    // updated (`setState` is not guaranteed to complete before `render`)
-    if (this.state.tipContent !== nextState.tipContent) {
-      return true;
-    }
-    var healthWasUpdated =
+    return  this.state.isPopoverVisible !== nextState.isPopoverVisible ||
       !Util.compareArrays(this.props.model.health, nextProps.model.health);
-    if (healthWasUpdated) {
-      this.setState({
-        tipContent: this.getAppHealthBreakdown(nextProps.model)
-      });
-    }
-    return false;
   },
 
-  handleMouseOverHealthBar: function () {
-    var el = this.refs.healthBar.getDOMNode();
-    this.tip_showTip(el);
+  handleMouseOverHealthBar: function (e) {
+    this.setState({
+      isPopoverVisible: true
+    });
   },
 
   handleMouseOutHealthBar: function () {
-    var el = this.refs.healthBar.getDOMNode();
-    this.tip_hideTip(el);
-  },
-
-  getAppHealthBreakdown: function (model) {
-    let component = (
-      <AppHealthDetailComponent
-        className="list-unstyled"
-        fields={[
-          HealthStatus.HEALTHY,
-          HealthStatus.UNHEALTHY,
-          HealthStatus.UNKNOWN,
-          HealthStatus.STAGED,
-          HealthStatus.OVERCAPACITY,
-          HealthStatus.UNSCHEDULED
-        ]}
-        model={model} />
-    );
-    return React.renderToString(component);
+    this.setState({
+      isPopoverVisible: false
+    });
   },
 
   render: function () {
-    // Extra <div> nesting is necessary here because of the way the TooltipMixin
-    // searches for elements - it finds children
+    var model = this.props.model;
+
     return (
-      <div>
-        <div ref="healthBar"
-          data-behavior="show-tip"
-          data-tip-type-class="default"
-          data-tip-place="top-left"
-          data-tip-content={this.state.tipContent}
-          onMouseOver={this.handleMouseOverHealthBar}
-          onMouseOut={this.handleMouseOutHealthBar}>
-          <AppHealthBarComponent
-            model={this.props.model}/>
-        </div>
+      <div onMouseOver={this.handleMouseOverHealthBar}
+           onMouseOut={this.handleMouseOutHealthBar}>
+        <PopoverComponent visible={this.state.isPopoverVisible}>
+          <AppHealthDetailComponent
+            className="list-unstyled"
+            fields={[
+              HealthStatus.HEALTHY,
+              HealthStatus.UNHEALTHY,
+              HealthStatus.UNKNOWN,
+              HealthStatus.STAGED,
+              HealthStatus.OVERCAPACITY,
+              HealthStatus.UNSCHEDULED
+            ]}
+            model={model} />
+        </PopoverComponent>
+        <AppHealthBarComponent model={model}/>
       </div>
     );
   }

--- a/src/js/components/PopoverComponent.js
+++ b/src/js/components/PopoverComponent.js
@@ -1,0 +1,81 @@
+var React = require("react/addons");
+var classNames = require("classnames");
+
+var Util = require("../helpers/Util");
+
+const DEFAULT_ALIGNED = "default";
+const TOP_ALIGNED = "top";
+const BOTTOM_ALIGNED = "bottom";
+
+var PopoverComponent = React.createClass({
+  displayName: "PopoverComponent",
+
+  propTypes: {
+    children: React.PropTypes.node,
+    className: React.PropTypes.string,
+    visible: React.PropTypes.bool
+  },
+
+  getInitialState: function () {
+    return {
+      alignment: DEFAULT_ALIGNED
+    };
+  },
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return this.state.alignment !== nextState.alignment ||
+      !Util.compareProperties(this.props,
+        nextProps,  "children", "className", "visible");
+  },
+
+  componentDidUpdate: function () {
+    if (this.props.visible === true) {
+      this.recalculatePosition();
+    }
+  },
+
+  recalculatePosition: function () {
+    if (global.window == null) {
+      return;
+    }
+
+    let componentNode = React.findDOMNode(this.refs.component);
+    let contentNode = React.findDOMNode(this.refs.content);
+    let componentPosition = componentNode.getBoundingClientRect();
+    let contentHeight = contentNode.clientHeight;
+
+    if (componentPosition.top <= contentHeight) {
+      this.setState({alignment: BOTTOM_ALIGNED});
+      return;
+    }
+
+    if (componentPosition.bottom + contentHeight >=
+        document.documentElement.clientHeight) {
+      this.setState({alignment: TOP_ALIGNED});
+      return;
+    }
+
+    this.setState({alignment: DEFAULT_ALIGNED});
+  },
+
+  render: function () {
+    var props = this.props;
+    var alignment = this.state.alignment;
+    var className = classNames("popover", props.className, {
+      "visible": props.visible,
+      "default": alignment === DEFAULT_ALIGNED,
+      "top": alignment === TOP_ALIGNED,
+      "bottom": alignment === BOTTOM_ALIGNED
+    });
+
+    return (
+      <div className={className} ref="component">
+        <div className="content" ref="content">
+          {props.children}
+        </div>
+      </div>
+    );
+  }
+});
+
+module.exports = PopoverComponent;

--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -30,6 +30,8 @@ var AppHealthBarComponent =
   require("../js/components/AppHealthBarComponent");
 var AppHealthBarWithTooltipComponent =
   require("../js/components/AppHealthBarWithTooltipComponent");
+var AppHealthDetailComponent =
+  require("../js/components/AppHealthDetailComponent");
 var AppPageComponent = require("../js/components/AppPageComponent");
 var AppStatusComponent = require("../js/components/AppStatusComponent");
 var appScheme = require("../js/stores/schemes/appScheme");
@@ -1045,28 +1047,58 @@ describe("App Health Bar", function () {
     expect(width).to.equal("20%");
   });
 
-  describe("tooltip", function () {
+  describe("detail", function () {
+
+    beforeEach(function () {
+      this.renderer = TestUtils.createRenderer();
+      this.renderer.render(
+        <AppHealthDetailComponent
+          className="list-unstyled"
+          fields={[
+            HealthStatus.HEALTHY,
+            HealthStatus.UNHEALTHY,
+            HealthStatus.UNKNOWN,
+            HealthStatus.STAGED,
+            HealthStatus.OVERCAPACITY,
+            HealthStatus.UNSCHEDULED
+          ]}
+          model={this.model} />
+      );
+      this.content = this.renderer.getRenderOutput().props.children;
+    });
+
+    it("Healthy tasks are reported correctly", function () {
+      expect(this.content[0].props.children[1]).to.equal(2);
+    });
+
+    it("Unhealthy tasks are reported correctly", function () {
+      expect(this.content[1].props.children[1]).to.equal(2);
+    });
+
+    it("Unknown tasks are reported correctly", function () {
+      expect(this.content[2].props.children[1]).to.equal(1);
+    });
+
+  });
+
+  describe("with tooltip", function () {
 
     beforeEach(function () {
       this.renderer = TestUtils.createRenderer();
       this.renderer.render(
         <AppHealthBarWithTooltipComponent
           model={this.model}/>);
-      var component = this.renderer.getRenderOutput();
-      this.content = component._store.props.children.props["data-tip-content"];
+      this.content = this.renderer.getRenderOutput().props.children;
     });
 
-    it("Healthy tasks are reported correctly", function () {
-      // Regexp matching because the content is a string of html
-      expect(this.content).to.match(/2.*Healthy.*\(.*40.*%\).*/);
+    it("has  health details", function () {
+      expect(this.content[0].props.children.type.displayName)
+        .to.equal("AppHealthDetailComponent");
     });
 
-    it("Unhealthy tasks are reported correctly", function () {
-      expect(this.content).to.match(/2.*Unhealthy.*\(.*40.*%\).*/);
-    });
-
-    it("Unknown tasks are reported correctly", function () {
-      expect(this.content).to.match(/1.*Unknown.*\(.*20.*%\).*/);
+    it("has healthbar", function () {
+      expect(this.content[1].type.displayName)
+        .to.equal("AppHealthBarComponent");
     });
 
   });

--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -1090,8 +1090,8 @@ describe("App Health Bar", function () {
     beforeEach(function () {
       this.renderer = TestUtils.createRenderer();
       this.renderer.render(
-        <AppHealthBarWithTooltipComponent
-          model={this.model}/>);
+        <AppHealthBarWithTooltipComponent model={this.model}/>
+      );
       this.content = this.renderer.getRenderOutput().props.children;
     });
 

--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -1067,6 +1067,10 @@ describe("App Health Bar", function () {
       this.content = this.renderer.getRenderOutput().props.children;
     });
 
+    afterEach(function () {
+      this.renderer.unmount();
+    });
+
     it("Healthy tasks are reported correctly", function () {
       expect(this.content[0].props.children[1]).to.equal(2);
     });
@@ -1089,6 +1093,10 @@ describe("App Health Bar", function () {
         <AppHealthBarWithTooltipComponent
           model={this.model}/>);
       this.content = this.renderer.getRenderOutput().props.children;
+    });
+
+    afterEach(function () {
+      this.renderer.unmount();
     });
 
     it("has  health details", function () {


### PR DESCRIPTION
![health-popover](https://cloud.githubusercontent.com/assets/647035/11866727/3cf1999a-a4ad-11e5-9d79-fd1fd2f6e540.gif)
Render the app list health details using a new, native react, popover component instead of the "buggy" tooltip plugin.

Closes mesosphere/marathon#2821