### PR TITLE
Fix-2892 version not localised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Changed
 - \#2651 - Improve ui scale error messages
 
+### Fixed
+- \#2892 - Version in task detail component shouldn't be localised
+
 ## 0.14.1 - 2015-12-17
 ### Added
 - \#2772 - URI fields should be links

--- a/src/js/components/TaskDetailComponent.jsx
+++ b/src/js/components/TaskDetailComponent.jsx
@@ -191,7 +191,7 @@ var TaskDetailComponent = React.createClass({
           <dt>Version</dt>
           <dd>
             <time dateTime={task.version}>
-              {new Date(task.version).toLocaleString()}
+              {task.version}
             </time>
           </dd>
           <dt>Health</dt>


### PR DESCRIPTION
For better copy & paste purposes. 

This closes mesosphere/marathon#2892

![image](https://cloud.githubusercontent.com/assets/156010/12111694/a3b301de-b397-11e5-8781-43854c1e44c7.png)