### PR TITLE
Fix - 2893 App health status display to display correct amount of tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 - \#2892 - Version in task detail component shouldn't be localised
+- \#2893 - App page component should display the right number of tasks
 
 ## 0.14.1 - 2015-12-17
 ### Added

--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -81,7 +81,6 @@ function getAppHealth(app) {
   for (let i = 0; i < healthData.length; i++) {
     let capacityLeft = Math.max(0, app.instances - tasksSum);
     tasksSum += healthData[i].quantity;
-    healthData[i].quantity = Math.min(capacityLeft, healthData[i].quantity);
   }
 
   var overCapacity = Math.max(0, tasksSum - app.instances);

--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -87,7 +87,7 @@ function getAppHealth(app) {
   });
 
   healthData.push({
-    quantity: Math.max(0, (app.instances - tasksSum)),
+    quantity: Math.max(0, app.instances - tasksSum),
     state: HealthStatus.UNSCHEDULED
   });
 

--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -77,18 +77,17 @@ function getAppHealth(app) {
     {quantity: app.tasksStaged || 0, state: HealthStatus.STAGED}
   ];
 
-  var tasksSum = 0;
-  for (let i = 0; i < healthData.length; i++) {
-    let capacityLeft = Math.max(0, app.instances - tasksSum);
-    tasksSum += healthData[i].quantity;
-  }
+  var tasksSum = healthData.reduce((sum, healthNode) => {
+    return sum + healthNode.quantity;
+  }, 0);
 
-  var overCapacity = Math.max(0, tasksSum - app.instances);
-  healthData.push({quantity: overCapacity, state: HealthStatus.OVERCAPACITY});
-
-  var unscheduled = Math.max(0, (app.instances - tasksSum));
   healthData.push({
-    quantity: unscheduled,
+    quantity: Math.max(0, tasksSum - app.instances),
+    state: HealthStatus.OVERCAPACITY
+  });
+
+  healthData.push({
+    quantity: Math.max(0, (app.instances - tasksSum)),
     state: HealthStatus.UNSCHEDULED
   });
 

--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -286,14 +286,14 @@ describe("Apps", function () {
       });
 
       it("has correct health weight", function () {
-        expect(AppsStore.apps[0].healthWeight).to.equal(16);
+        expect(AppsStore.apps[0].healthWeight).to.equal(18);
       });
 
       it("has correct health data object", function () {
         expect(AppsStore.apps[0].health).to.deep.equal([
           {quantity: 0, state: HealthStatus.HEALTHY},
           {quantity: 0, state: HealthStatus.UNHEALTHY},
-          {quantity: 0, state: HealthStatus.UNKNOWN},
+          {quantity: 1, state: HealthStatus.UNKNOWN},
           {quantity: 0, state: HealthStatus.STAGED},
           {quantity: 1, state: HealthStatus.OVERCAPACITY},
           {quantity: 0, state: HealthStatus.UNSCHEDULED}
@@ -1465,4 +1465,3 @@ describe("Breadcrumb Component", function () {
   });
 
 });
-


### PR DESCRIPTION
This fixes a old misbehavioural from 2014 which was never realized, because
we didn't had any health detail display.

This closes mesosphere/marathon#2893

![image](https://cloud.githubusercontent.com/assets/156010/12119691/60191b94-b3cd-11e5-8781-d3a863fb0424.png)
