### PR TITLE
Refactor-2856 AppListItemLabelsComponent to make use of new PopoverComponent

### DIFF
--- a/src/css/components/labels.less
+++ b/src/css/components/labels.less
@@ -42,31 +42,23 @@
       display: block;
     }
 
-    > h5 {
+    h5 {
       color: @table-text-color;
-      padding: @base-spacing-unit * 2;
+      padding: 0 0 @base-spacing-unit * 2;
       margin: 0;
     }
 
-    > .left-arrow {
-      display: block;
-      border-top: @base-spacing-unit solid transparent;
-      border-bottom: @base-spacing-unit solid transparent;
-      border-right: @base-spacing-unit solid @navbar-bg-color;
-      height: 0;
-      margin-left: -@base-spacing-unit;
-      margin-top: @base-spacing-unit * 2;
-      position: absolute;
-      top: 0;
-      width: 0;
-    }
-
-    > ul {
-      padding: 0 @base-spacing-unit * 2;
+    ul {
+      padding: 0;
+      margin: 0;
 
       li {
         display: block;
         margin: 0 0 @base-spacing-unit 0;
+        
+        &:last-child {
+          margin: 0;
+        }
 
         .badge {
           margin: 0;

--- a/src/css/components/popover.less
+++ b/src/css/components/popover.less
@@ -22,7 +22,7 @@
     z-index: 1;
   }
 
-  &.default, &.top, &.bottom {
+  &.default, &.top, &.bottom, &.right {
     margin: 0;
 
     .content:before, .content:after {
@@ -53,6 +53,23 @@
     &:after {
       border-bottom-color: @navbar-bg-color;
       bottom: 100%;
+      content: " ";
+    }
+  }
+
+  &.right .content {
+    top: 0;
+    left: 100%;
+    bottom: auto;
+    transform: none;
+    margin-top: -@base-spacing-unit*2;
+    margin-left: @base-spacing-unit*2;
+
+    &:before {
+      border-right-color: @navbar-bg-color;
+      right: 100%;
+      left: auto;
+      top: @base-spacing-unit*2;
       content: " ";
     }
   }

--- a/src/js/components/AppListItemLabelsComponent.jsx
+++ b/src/js/components/AppListItemLabelsComponent.jsx
@@ -1,6 +1,8 @@
 var classNames = require("classnames");
 var React = require("react/addons");
 
+var PopoverComponent = require("./PopoverComponent");
+
 var OnClickOutsideMixin = require("react-onclickoutside");
 var Util = require("../helpers/Util");
 
@@ -75,7 +77,6 @@ var AppListItemLabelsComponent = React.createClass({
     }
 
     let dropdownNode = React.findDOMNode(this.refs.labelsDropdown);
-    let leftArrowNode = React.findDOMNode(this.refs.leftArrow);
 
     let id = dropdownNode.attributes["data-reactid"].value;
 
@@ -97,12 +98,10 @@ var AppListItemLabelsComponent = React.createClass({
     if (offsetTop >= viewportHeight) {
       const marginTop = height - _initialTopMargins[id] * 2;
       dropdownNode.style.marginTop = `-${marginTop}px`;
-      leftArrowNode.style.marginTop = `${marginTop}px`;
       _reversedDropdowns[id] = true;
     } else {
       const marginTop = _initialTopMargins[id];
       dropdownNode.style.marginTop = `-${marginTop}px`;
-      leftArrowNode.style.marginTop = `${marginTop}px`;
       _reversedDropdowns[id] = false;
     }
   },
@@ -147,19 +146,19 @@ var AppListItemLabelsComponent = React.createClass({
       ));
     });
 
-    let labelsDropdownClassName = classNames("labels-dropdown", {
-      "visible": this.state.isDropdownVisible &&
-        numberOfVisibleLabels < labelNodes.length
-    });
+    let labelsDropdownVisible = this.state.isDropdownVisible &&
+      numberOfVisibleLabels < labelNodes.length;
 
     let labelsDropdown = (
-      <div className={labelsDropdownClassName} ref="labelsDropdown">
-        <span className="left-arrow" ref="leftArrow"></span>
-        <h5>All Labels</h5>
-        <ul>
-          {dropdownNodes}
-        </ul>
-      </div>
+      <PopoverComponent className="labels-dropdown"
+          alignment="right"
+          ref="labelsDropdown"
+          visible={labelsDropdownVisible}>
+          <h5>All Labels</h5>
+          <ul>
+            {dropdownNodes}
+          </ul>
+      </PopoverComponent>
     );
 
     // Keep the parent's ref for measurements, but handle events internally
@@ -172,6 +171,7 @@ var AppListItemLabelsComponent = React.createClass({
         {labelNodes}
         {showMore}
         {labelsDropdown}
+
       </div>
     );
   }

--- a/src/js/components/AppListItemLabelsComponent.jsx
+++ b/src/js/components/AppListItemLabelsComponent.jsx
@@ -154,10 +154,10 @@ var AppListItemLabelsComponent = React.createClass({
           alignment="right"
           ref="labelsDropdown"
           visible={labelsDropdownVisible}>
-          <h5>All Labels</h5>
-          <ul>
-            {dropdownNodes}
-          </ul>
+        <h5>All Labels</h5>
+        <ul>
+          {dropdownNodes}
+        </ul>
       </PopoverComponent>
     );
 
@@ -171,7 +171,6 @@ var AppListItemLabelsComponent = React.createClass({
         {labelNodes}
         {showMore}
         {labelsDropdown}
-
       </div>
     );
   }

--- a/src/js/components/PopoverComponent.js
+++ b/src/js/components/PopoverComponent.js
@@ -6,11 +6,13 @@ var Util = require("../helpers/Util");
 const DEFAULT_ALIGNED = "default";
 const TOP_ALIGNED = "top";
 const BOTTOM_ALIGNED = "bottom";
+const RIGHT_ALIGNED = "right";
 
 var PopoverComponent = React.createClass({
   displayName: "PopoverComponent",
 
   propTypes: {
+    alignment: React.PropTypes.string,
     children: React.PropTypes.node,
     className: React.PropTypes.string,
     visible: React.PropTypes.bool
@@ -44,6 +46,11 @@ var PopoverComponent = React.createClass({
     let componentPosition = componentNode.getBoundingClientRect();
     let contentHeight = contentNode.clientHeight;
 
+    if (this.props.alignment === RIGHT_ALIGNED) {
+      this.setState({alignment: RIGHT_ALIGNED});
+      return;
+    }
+
     if (componentPosition.top <= contentHeight) {
       this.setState({alignment: BOTTOM_ALIGNED});
       return;
@@ -65,7 +72,8 @@ var PopoverComponent = React.createClass({
       "visible": props.visible,
       "default": alignment === DEFAULT_ALIGNED,
       "top": alignment === TOP_ALIGNED,
-      "bottom": alignment === BOTTOM_ALIGNED
+      "bottom": alignment === BOTTOM_ALIGNED,
+      "right": alignment === RIGHT_ALIGNED,
     });
 
     return (


### PR DESCRIPTION
Change the dropdown in the AppListItemLabelsComponent to use the generic popover component. Add some CSS and add a right align capability to the component.

This closes mesosphere/marathon#2856

![image](https://cloud.githubusercontent.com/assets/156010/12144730/0657932a-b48a-11e5-8338-8a3434f1bf11.png)
