### PR TITLE
Feature - 2814 contextual actions menu for app list item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Unversioned
+### Added
+- \#2814 - Add contextual dropdown menu to Application List items
+
 ### Changed
 - \#2651 - Improve ui scale error messages
 - \#2832 - Convert all confirm dialogs to have meaningful action button labels

--- a/src/css/components/app-list.less
+++ b/src/css/components/app-list.less
@@ -111,12 +111,17 @@
     &.actions-cell {
       .dropdown {
         margin: 0;
+
+        .dropdown-menu {
+          left: 100%;
+          transform: translateX(-100%);
+        }
+
+        &.top .dropdown-menu {
+          transform: translate(-100%, calc(-100% - @base-spacing-unit*2));
+        }
       }
 
-      .dropdown-menu {
-        left: 100%;
-        transform: translateX(-100%);
-      }
     }
   }
 }

--- a/src/css/components/app-list.less
+++ b/src/css/components/app-list.less
@@ -107,5 +107,16 @@
         }
       }
     }
+
+    &.actions-cell {
+      .dropdown {
+        margin: 0;
+      }
+
+      .dropdown-menu {
+        left: 100%;
+        transform: translateX(-100%);
+      }
+    }
   }
 }

--- a/src/css/components/app-list.less
+++ b/src/css/components/app-list.less
@@ -36,7 +36,7 @@
     }
 
     &.actions-col {
-      width: @base-spacing-unit*8;
+      width: @base-spacing-unit*4;
     }
 
   }

--- a/src/css/components/icons.less
+++ b/src/css/components/icons.less
@@ -72,6 +72,11 @@
       background-image: url("img/icons/icon-warning.svg");
       background-size: contain;
     }
+
+    &.dots {
+      background-image: url("img/icons/icon-mini-ellipse-white.svg");
+      background-size: contain;
+    }
   }
 
   &.icon-small {

--- a/src/img/icons/icon-mini-ellipse-white.svg
+++ b/src/img/icons/icon-mini-ellipse-white.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.3.3 (12072) - http://www.bohemiancoding.com/sketch -->
+    <title>icon-mini-ellipse</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Icons/Mini" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="icon-mini-ellipse" sketch:type="MSArtboardGroup" fill="#FFFFFF">
+            <circle id="Oval" sketch:type="MSShapeGroup" cx="1.60000002" cy="8.10000002" r="1.60000002"></circle>
+            <circle id="Oval" sketch:type="MSShapeGroup" cx="8" cy="8.10000002" r="1.60000002"></circle>
+            <circle id="Oval" sketch:type="MSShapeGroup" cx="14.4" cy="8.10000002" r="1.60000002"></circle>
+        </g>
+    </g>
+</svg>

--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -394,7 +394,7 @@ var AppListComponent = React.createClass({
         state.fetchState !== States.STATE_LOADING
     });
 
-    var totalColSpan = 8;
+    var totalColumnSpan = 8;
 
     return (
       <table className={tableClassSet}>
@@ -450,32 +450,32 @@ var AppListComponent = React.createClass({
         </thead>
         <tbody>
           <tr className={loadingClassSet}>
-            <td className="text-center text-muted" colSpan={totalColSpan}>
+            <td className="text-center text-muted" colSpan={totalColumnSpan}>
               Loading apps...
             </td>
           </tr>
           <tr className={noAppsClassSet}>
-            <td className="text-center" colSpan={totalColSpan}>
+            <td className="text-center" colSpan={totalColumnSpan}>
               No running apps.
             </td>
           </tr>
           <tr className={noRunningAppsClassSet}>
-            <td className="text-center" colSpan={totalColSpan}>
+            <td className="text-center" colSpan={totalColumnSpan}>
               No apps match your query.
             </td>
           </tr>
           <tr className={errorClassSet}>
-            <td className="text-center text-danger" colSpan={totalColSpan}>
+            <td className="text-center text-danger" colSpan={totalColumnSpan}>
               {`Error fetching apps. ${Messages.RETRY_REFRESH}`}
             </td>
           </tr>
           <tr className={unauthorizedClassSet}>
-            <td className="text-center text-danger" colSpan={totalColSpan}>
+            <td className="text-center text-danger" colSpan={totalColumnSpan}>
               {`Error fetching apps. ${Messages.UNAUTHORIZED}`}
             </td>
           </tr>
           <tr className={forbiddenClassSet}>
-            <td className="text-center text-danger" colSpan={totalColSpan}>
+            <td className="text-center text-danger" colSpan={totalColumnSpan}>
               {`Error fetching apps. ${Messages.FORBIDDEN}`}
             </td>
           </tr>

--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -394,6 +394,8 @@ var AppListComponent = React.createClass({
         state.fetchState !== States.STATE_LOADING
     });
 
+    var totalColSpan = 8;
+
     return (
       <table className={tableClassSet}>
         <colgroup>
@@ -404,6 +406,7 @@ var AppListComponent = React.createClass({
           <col className="status-col" />
           <col className="instances-col" />
           <col className="health-col" />
+          <col className="actions-col" />
         </colgroup>
         <thead>
           <tr>
@@ -437,7 +440,7 @@ var AppListComponent = React.createClass({
                 {this.getCaret("tasksRunning")} Running Instances
               </span>
             </th>
-            <th className="health-cell">
+            <th className="health-cell" colSpan="2">
               <span onClick={this.sortBy.bind(null, "healthWeight")}
                   className={headerClassSet}>
                 Health {this.getCaret("healthWeight")}
@@ -447,30 +450,32 @@ var AppListComponent = React.createClass({
         </thead>
         <tbody>
           <tr className={loadingClassSet}>
-            <td className="text-center text-muted" colSpan="7">
+            <td className="text-center text-muted" colSpan={totalColSpan}>
               Loading apps...
             </td>
           </tr>
           <tr className={noAppsClassSet}>
-            <td className="text-center" colSpan="7">No running apps.</td>
+            <td className="text-center" colSpan={totalColSpan}>
+              No running apps.
+            </td>
           </tr>
           <tr className={noRunningAppsClassSet}>
-            <td className="text-center" colSpan="7">
+            <td className="text-center" colSpan={totalColSpan}>
               No apps match your query.
             </td>
           </tr>
           <tr className={errorClassSet}>
-            <td className="text-center text-danger" colSpan="7">
+            <td className="text-center text-danger" colSpan={totalColSpan}>
               {`Error fetching apps. ${Messages.RETRY_REFRESH}`}
             </td>
           </tr>
           <tr className={unauthorizedClassSet}>
-            <td className="text-center text-danger" colSpan="7">
+            <td className="text-center text-danger" colSpan={totalColSpan}>
               {`Error fetching apps. ${Messages.UNAUTHORIZED}`}
             </td>
           </tr>
           <tr className={forbiddenClassSet}>
-            <td className="text-center text-danger" colSpan="7">
+            <td className="text-center text-danger" colSpan={totalColSpan}>
               {`Error fetching apps. ${Messages.FORBIDDEN}`}
             </td>
           </tr>

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -2,6 +2,7 @@ var classNames = require("classnames");
 var React = require("react/addons");
 var OnClickOutsideMixin = require("react-onclickoutside");
 
+var AppActionsHandlerMixin = require("../mixins/AppActionsHandlerMixin");
 var AppHealthBarWithTooltipComponent =
   require("./AppHealthBarWithTooltipComponent");
 var AppListItemLabelsComponent =
@@ -17,7 +18,10 @@ var DOMUtil = require("../helpers/DOMUtil");
 var AppListItemComponent = React.createClass({
   displayName: "AppListItemComponent",
 
-  mixins: [OnClickOutsideMixin],
+  mixins: [
+    AppActionsHandlerMixin,
+    OnClickOutsideMixin
+  ],
 
   contextTypes: {
     router: React.PropTypes.func
@@ -258,27 +262,27 @@ var AppListItemComponent = React.createClass({
       <div className="dropdown">
         <ul className="dropdown-menu">
           <li>
-            <a href="#" onClick="">
+            <a href="#" onClick={this.handleScaleApp}>
               Scale
             </a>
           </li>
           <li>
-            <a href="#" onClick="">
+            <a href="#" onClick={this.handleRestartApp}>
               Restart
             </a>
           </li>
           <li className={suspendAppClassSet}>
-            <a href="#" onClick="">
+            <a href="#" onClick={this.handleSuspendApp}>
               Suspend
             </a>
           </li>
           <li className={resetDelayClassSet}>
-            <a href="#" onClick="">
+            <a href="#" onClick={this.handleResetDelay}>
               Reset Delay
             </a>
           </li>
           <li>
-            <a href="#" onClick="">
+            <a href="#" onClick={this.handleDestroyApp}>
               <span className="text-danger">Destroy</span>
             </a>
           </li>

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -42,7 +42,8 @@ var AppListItemComponent = React.createClass({
   getInitialState: function () {
     return {
       isActionsDropdownActivated: false,
-      numberOfVisibleLabels: -1
+      numberOfVisibleLabels: -1,
+      actionsDropdownTopAligned: false
     };
   },
 
@@ -59,6 +60,8 @@ var AppListItemComponent = React.createClass({
     if (this.didPropsChange(prevProps)) {
       this.updateNumberOfVisibleLabels();
     }
+
+    this.recalculateDropdownPosition();
   },
 
   componentWillUnmount: function () {
@@ -80,6 +83,11 @@ var AppListItemComponent = React.createClass({
 
     if (this.state.isActionsDropdownActivated !==
         nextState.isActionsDropdownActivated) {
+      return true;
+    }
+
+    if (this.state.actionsDropdownTopAligned !==
+        nextState.actionsDropdownTopAligned) {
       return true;
     }
 
@@ -227,9 +235,13 @@ var AppListItemComponent = React.createClass({
       "hidden": model.status !== AppStatus.DELAYED
     });
 
+    let dropdownClassName = classNames({
+      top: this.state.actionsDropdownTopAligned
+    }, "dropdown");
+
     return (
-      <div className="dropdown">
-        <ul className="dropdown-menu">
+      <div className={dropdownClassName} ref="dropdown">
+        <ul className="dropdown-menu" ref="dropdown-menu">
           <li>
             <a href="#" onClick={this.handleScaleApp}>
               Scale
@@ -303,6 +315,33 @@ var AppListItemComponent = React.createClass({
         <AppStatusComponent model={this.props.model} />
       </td>
     );
+  },
+
+  recalculateDropdownPosition: function () {
+    if (global.window == null) {
+      return;
+    }
+
+    let componentNode = React.findDOMNode(this.refs.dropdown);
+
+    if (componentNode == null) {
+      return;
+    }
+
+    let topAligned = false;
+
+    let contentNode = React.findDOMNode(this.refs["dropdown-menu"]);
+    let componentPosition = componentNode.getBoundingClientRect();
+    let contentHeight = contentNode.clientHeight;
+
+    if (componentPosition.bottom + contentHeight >=
+        document.documentElement.clientHeight) {
+      topAligned = true;
+    }
+
+    if (topAligned !== this.state.actionsDropdownTopAligned) {
+      this.setState({actionsDropdownTopAligned: topAligned});
+    }
   },
 
   render: function () {

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -121,9 +121,9 @@ var AppListItemComponent = React.createClass({
   getIcon: function () {
     var model = this.props.model;
     if (model.isGroup) {
-      return (<i className="icon icon-small group"></i>);
+      return <i className="icon icon-small group"></i>;
     }
-    return (<i className="icon icon-small app" title="Application"></i>);
+    return <i className="icon icon-small app" title="Application"></i>;
   },
 
   getLabels: function () {
@@ -247,6 +247,9 @@ var AppListItemComponent = React.createClass({
           </span> of {model.instances}
         </td>
         {this.getHealthBar()}
+        <td className="text-right">
+          <i className="icon icon-mini dots"></i>
+        </td>
       </tr>
     );
   }

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -164,6 +164,20 @@ var AppListItemComponent = React.createClass({
     this.setState({numberOfVisibleLabels: numberOfVisibleLabels});
   },
 
+  getActionsCell: function () {
+    if (this.props.model.isGroup) {
+      return <td className="actions-cell"></td>;
+    }
+
+    return (
+      <td className="actions-cell"
+          onClick={this.handleActionsClick}>
+        <i className="icon icon-mini dots"></i>
+        {this.getDropdownMenu()}
+      </td>
+    );
+  },
+
   getAppName: function () {
     var props = this.props;
     var model = props.model;
@@ -295,13 +309,13 @@ var AppListItemComponent = React.createClass({
     var props = this.props;
     var model = props.model;
 
-    var className = classNames({
+    var rowTypeClassName = classNames({
       "group": model.isGroup,
       "app": !model.isGroup
     });
 
     return (
-      <tr onClick={this.handleAppRowClick} className={className}>
+      <tr onClick={this.handleAppRowClick} className={rowTypeClassName}>
         <td className="icon-cell">
           {this.getIcon()}
         </td>
@@ -321,11 +335,7 @@ var AppListItemComponent = React.createClass({
           </span> of {model.instances}
         </td>
         {this.getHealthBar()}
-        <td className="actions-cell"
-            onClick={this.handleActionsClick}>
-          <i className="icon icon-mini dots"></i>
-          {this.getDropdownMenu()}
-        </td>
+        {this.getActionsCell()}
       </tr>
     );
   }

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -301,8 +301,6 @@ var AppListItemComponent = React.createClass({
     });
 
     return (
-      // Set `title` on cells that potentially overflow so hovering on the
-      // cells will reveal their full contents.
       <tr onClick={this.handleAppRowClick} className={className}>
         <td className="icon-cell">
           {this.getIcon()}

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -147,11 +147,7 @@ var AppListItemComponent = React.createClass({
     );
   },
 
-  handleBreadcrumbClick: function (event) {
-    event.stopPropagation();
-  },
-
-  onClick: function () {
+  handleAppRowClick: function () {
     var model = this.props.model;
     var router = this.context.router;
     if (model.isGroup) {
@@ -163,6 +159,10 @@ var AppListItemComponent = React.createClass({
     } else {
       router.transitionTo("app", {appId: encodeURIComponent(model.id)});
     }
+  },
+
+  handleBreadcrumbClick: function (event) {
+    event.stopPropagation();
   },
 
   getHealthBar: function () {
@@ -227,7 +227,7 @@ var AppListItemComponent = React.createClass({
     return (
       // Set `title` on cells that potentially overflow so hovering on the
       // cells will reveal their full contents.
-      <tr onClick={this.onClick} className={className}>
+      <tr onClick={this.handleAppRowClick} className={className}>
         <td className="icon-cell">
           {this.getIcon()}
         </td>

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -248,14 +248,14 @@ var AppListItemComponent = React.createClass({
       return null;
     }
 
-    let props = this.props;
+    let model = this.props.model;
 
     let suspendAppClassSet = classNames({
-      "disabled": props.model.instances < 1
+      "disabled": model.instances < 1
     });
 
     let resetDelayClassSet = classNames({
-      "hidden": props.model.status !== AppStatus.DELAYED
+      "hidden": model.status !== AppStatus.DELAYED
     });
 
     return (

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -98,69 +98,6 @@ var AppListItemComponent = React.createClass({
     requestAnimationFrame(this.updateNumberOfVisibleLabels);
   },
 
-  updateNumberOfVisibleLabels: function () {
-    var labels = this.props.model.labels;
-
-    if (labels == null || Object.keys(labels).length === 0) {
-      this.setState({numberOfVisibleLabels: 0});
-      return;
-    }
-
-    let refs = this.refs;
-
-    let cellNode = React.findDOMNode(refs.nameCell);
-    let nameNode = React.findDOMNode(refs.nameNode);
-    let moreNode = React.findDOMNode(refs.moreLabel);
-
-    let availableWidth = DOMUtil.getInnerWidth(cellNode) -
-      DOMUtil.getOuterWidth(nameNode) -
-      DOMUtil.getOuterWidth(moreNode);
-
-    let labelsWidth = 0;
-    let numberOfVisibleLabels = 0;
-    let labelNodes = React.findDOMNode(refs.labels).querySelectorAll(".badge");
-
-    // labelNodes is not an Array, but a NodeList
-    [...labelNodes].forEach(label => {
-      labelsWidth += DOMUtil.getOuterWidth(label);
-      if (labelsWidth > availableWidth) {
-        return true;
-      }
-      numberOfVisibleLabels++;
-    });
-
-    this.setState({numberOfVisibleLabels: numberOfVisibleLabels});
-  },
-
-  getIcon: function () {
-    var model = this.props.model;
-    if (model.isGroup) {
-      return <i className="icon icon-small group"></i>;
-    }
-    return <i className="icon icon-small app" title="Application"></i>;
-  },
-
-  getLabels: function () {
-    var labels = this.props.model.labels;
-    if (labels == null || Object.keys(labels).length === 0) {
-      return null;
-    }
-
-    var moreLabelClassName = classNames("badge more", {
-      "visible": Object.keys(labels).length > this.state.numberOfVisibleLabels
-    });
-
-    return (
-     <AppListItemLabelsComponent ref="labels"
-          labels={this.props.model.labels}
-          numberOfVisibleLabels={this.state.numberOfVisibleLabels}>
-        <span className={moreLabelClassName} ref="moreLabel">
-          &hellip;
-        </span>
-     </AppListItemLabelsComponent>
-    );
-  },
-
   handleActionsClick: function (event) {
     event.stopPropagation();
 
@@ -193,20 +130,38 @@ var AppListItemComponent = React.createClass({
     });
   },
 
-  getHealthBar: function () {
-    return (
-      <td className="text-right health-bar-column">
-        <AppHealthBarWithTooltipComponent model={this.props.model} />
-      </td>
-    );
-  },
+  updateNumberOfVisibleLabels: function () {
+    var labels = this.props.model.labels;
 
-  getStatus: function () {
-    return (
-      <td className="text-right status">
-        <AppStatusComponent model={this.props.model} />
-      </td>
-    );
+    if (labels == null || Object.keys(labels).length === 0) {
+      this.setState({numberOfVisibleLabels: 0});
+      return;
+    }
+
+    let refs = this.refs;
+
+    let cellNode = React.findDOMNode(refs.nameCell);
+    let nameNode = React.findDOMNode(refs.nameNode);
+    let moreNode = React.findDOMNode(refs.moreLabel);
+
+    let availableWidth = DOMUtil.getInnerWidth(cellNode) -
+      DOMUtil.getOuterWidth(nameNode) -
+      DOMUtil.getOuterWidth(moreNode);
+
+    let labelsWidth = 0;
+    let numberOfVisibleLabels = 0;
+    let labelNodes = React.findDOMNode(refs.labels).querySelectorAll(".badge");
+
+    // labelNodes is not an Array, but a NodeList
+    [...labelNodes].forEach(label => {
+      labelsWidth += DOMUtil.getOuterWidth(label);
+      if (labelsWidth > availableWidth) {
+        return true;
+      }
+      numberOfVisibleLabels++;
+    });
+
+    this.setState({numberOfVisibleLabels: numberOfVisibleLabels});
   },
 
   getAppName: function () {
@@ -288,6 +243,51 @@ var AppListItemComponent = React.createClass({
           </li>
         </ul>
       </div>
+    );
+  },
+
+  getHealthBar: function () {
+    return (
+      <td className="text-right health-bar-column">
+        <AppHealthBarWithTooltipComponent model={this.props.model} />
+      </td>
+    );
+  },
+
+  getIcon: function () {
+    var model = this.props.model;
+    if (model.isGroup) {
+      return <i className="icon icon-small group"></i>;
+    }
+    return <i className="icon icon-small app" title="Application"></i>;
+  },
+
+  getLabels: function () {
+    var labels = this.props.model.labels;
+    if (labels == null || Object.keys(labels).length === 0) {
+      return null;
+    }
+
+    var moreLabelClassName = classNames("badge more", {
+      "visible": Object.keys(labels).length > this.state.numberOfVisibleLabels
+    });
+
+    return (
+     <AppListItemLabelsComponent ref="labels"
+          labels={this.props.model.labels}
+          numberOfVisibleLabels={this.state.numberOfVisibleLabels}>
+        <span className={moreLabelClassName} ref="moreLabel">
+          &hellip;
+        </span>
+     </AppListItemLabelsComponent>
+    );
+  },
+
+  getStatus: function () {
+    return (
+      <td className="text-right status">
+        <AppStatusComponent model={this.props.model} />
+      </td>
     );
   },
 

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -331,7 +331,7 @@ var AppPageComponent = React.createClass({
       return null;
     }
 
-    return (<AppPageControlsComponent app={state.app} appId={state.appId}/>);
+    return (<AppPageControlsComponent appId={state.appId} model={state.app} />);
   },
 
   getTaskDetailComponent: function () {

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -331,7 +331,7 @@ var AppPageComponent = React.createClass({
       return null;
     }
 
-    return (<AppPageControlsComponent appId={state.appId} model={state.app} />);
+    return (<AppPageControlsComponent model={state.app} />);
   },
 
   getTaskDetailComponent: function () {

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -2,7 +2,6 @@ var React = require("react/addons");
 
 var AppsActions = require("../actions/AppsActions");
 var AppsEvents = require("../events/AppsEvents");
-var TaskEvents = require("../events/TasksEvents");
 var AppsStore = require("../stores/AppsStore");
 var BreadcrumbComponent = require("../components/BreadcrumbComponent");
 var AppHealthBarComponent = require("./AppHealthBarComponent");
@@ -23,8 +22,6 @@ var AppHealthDetailComponent = require("./AppHealthDetailComponent");
 var TogglableTabsComponent = require("../components/TogglableTabsComponent");
 var Util = require("../helpers/Util");
 var PathUtil = require("../helpers/PathUtil");
-var QueueEvents = require("../events/QueueEvents");
-var QueueStore = require("../stores/QueueStore");
 var TasksActions = require("../actions/TasksActions");
 var TasksEvents = require("../events/TasksEvents");
 
@@ -100,14 +97,8 @@ var AppPageComponent = React.createClass({
   componentWillMount: function () {
     AppsStore.on(AppsEvents.CHANGE, this.onAppChange);
     AppsStore.on(AppsEvents.REQUEST_APP_ERROR, this.onAppRequestError);
-    AppsStore.on(AppsEvents.SCALE_APP_ERROR, this.onScaleAppError);
-    AppsStore.on(AppsEvents.RESTART_APP_ERROR, this.onRestartAppError);
-    AppsStore.on(AppsEvents.DELETE_APP_ERROR, this.onDeleteAppError);
-    AppsStore.on(TaskEvents.DELETE_ERROR, this.onKillTaskError);
     AppsStore.on(AppsEvents.DELETE_APP, this.onDeleteAppSuccess);
     AppsStore.on(TasksEvents.DELETE_ERROR, this.onDeleteTaskError);
-    QueueStore.on(QueueEvents.RESET_DELAY_ERROR, this.onResetDelayError);
-    QueueStore.on(QueueEvents.RESET_DELAY, this.onResetDelaySuccess);
   },
 
   componentWillUnmount: function () {
@@ -115,20 +106,10 @@ var AppPageComponent = React.createClass({
       this.onAppChange);
     AppsStore.removeListener(AppsEvents.REQUEST_APP_ERROR,
       this.onAppRequestError);
-    AppsStore.removeListener(AppsEvents.SCALE_APP_ERROR,
-      this.onScaleAppError);
-    AppsStore.removeListener(AppsEvents.RESTART_APP_ERROR,
-      this.onRestartAppError);
-    AppsStore.removeListener(AppsEvents.DELETE_APP_ERROR,
-      this.onDeleteAppError);
     AppsStore.removeListener(AppsEvents.DELETE_APP,
       this.onDeleteAppSuccess);
-    AppsStore.removeListener(TaskEvents.DELETE_ERROR,
-      this.onKillTaskError);
-    QueueStore.removeListener(QueueEvents.RESET_DELAY_ERROR,
-      this.onResetDelayError);
-    QueueStore.removeListener(QueueEvents.RESET_DELAY,
-      this.onResetDelaySuccess);
+    AppsStore.removeListener(TasksEvents.DELETE_ERROR,
+      this.onDeleteTaskError);
   },
 
   componentWillReceiveProps: function () {
@@ -178,62 +159,6 @@ var AppPageComponent = React.createClass({
     });
   },
 
-  onScaleAppError: function (errorMessage, statusCode, instances) {
-    if (statusCode === 409) {
-      let appId = this.state.appId;
-      const dialogId = DialogActions.
-        confirm(`There is a deployment in progress that changes ${appId}.
-          If you want to stop this deployment and force a new one to scale it,
-          press the 'Scale forcefully' button.`, "Scale forcefully");
-      DialogStore.handleUserResponse(dialogId, function () {
-        AppsActions.scaleApp(appId, instances, true);
-      });
-    } else if (statusCode === 401) {
-      DialogActions.alert(`Not scaling: ${Messages.UNAUTHORIZED}`);
-    } else if (statusCode === 403) {
-      DialogActions.alert(`Not scaling: ${Messages.FORBIDDEN}`);
-    } else {
-      DialogActions.alert(`Not scaling:
-          ${errorMessage.message || errorMessage}`);
-    }
-  },
-
-  onRestartAppError: function (errorMessage, statusCode) {
-    if (statusCode === 401) {
-      DialogActions.alert(`Error restarting app: ${Messages.UNAUTHORIZED}`);
-    } else if (statusCode === 403) {
-      DialogActions.alert(`Error restarting app: ${Messages.FORBIDDEN}`);
-    } else {
-      DialogActions.alert(
-        `Error restarting app: ${errorMessage.message || errorMessage}`
-      );
-    }
-  },
-
-  onDeleteAppError: function (errorMessage, statusCode) {
-    if (statusCode === 401) {
-      DialogActions.alert(`Error destroying app: ${Messages.UNAUTHORIZED}`);
-    } else if (statusCode === 403) {
-      DialogActions.alert(`Error destroying app: ${Messages.FORBIDDEN}`);
-    } else {
-      DialogActions.alert(
-        `Error destroying app: ${errorMessage.message || errorMessage}`
-      );
-    }
-  },
-
-  onKillTaskError: function (errorMessage, statusCode) {
-    if (statusCode === 401) {
-      DialogActions.alert(`Error killing task: ${Messages.UNAUTHORIZED}`);
-    } else if (statusCode === 403) {
-      DialogActions.alert(`Error killing task: ${Messages.FORBIDDEN}`);
-    } else {
-      DialogActions.alert(
-        `Error killing task: ${errorMessage.message || errorMessage}`
-      );
-    }
-  },
-
   onDeleteAppSuccess: function () {
     this.context.router.transitionTo("apps");
   },
@@ -256,24 +181,6 @@ var AppPageComponent = React.createClass({
     } else {
       DialogActions.alert(`Not scaling:
           ${errorMessage.message || errorMessage}`);
-    }
-  },
-
-  onResetDelaySuccess: function () {
-    DialogActions.alert("Delay reset succesfully");
-  },
-
-  onResetDelayError: function (errorMessage, statusCode) {
-    if (statusCode === 401) {
-      DialogActions.alert(`Error resetting delay on app:
-        ${Messages.UNAUTHORIZED}`);
-    } else if (statusCode === 403) {
-      DialogActions.alert(`Error resetting delay on app:
-        ${Messages.FORBIDDEN}`);
-    } else {
-      DialogActions.alert(
-        `Error resetting delay on app: ${errorMessage.message || errorMessage}`
-      );
     }
   },
 

--- a/src/js/components/AppPageControlsComponent.jsx
+++ b/src/js/components/AppPageControlsComponent.jsx
@@ -2,20 +2,19 @@ var classNames = require("classnames");
 var OnClickOutsideMixin = require("react-onclickoutside");
 var React = require("react");
 
+var AppActionsHandlerMixin = require("../mixins/AppActionsHandlerMixin");
 var AppStatus = require("../constants/AppStatus");
-var AppsActions = require("../actions/AppsActions");
-var DialogActions = require("../actions/DialogActions");
-var DialogStore = require("../stores/DialogStore");
-var QueueActions = require("../actions/QueueActions");
 
 var AppPageControlsComponent = React.createClass({
 
   displayName: "AppPageControlsComponent",
 
-  mixins: [OnClickOutsideMixin],
+  mixins: [
+    AppActionsHandlerMixin,
+    OnClickOutsideMixin
+  ],
 
   propTypes: {
-    appId: React.PropTypes.string.isRequired,
     model: React.PropTypes.object.isRequired
   },
 
@@ -43,73 +42,6 @@ var AppPageControlsComponent = React.createClass({
   handleClickOutside: function () {
     this.setState({
       isDropdownActivated: false
-    });
-  },
-
-  handleResetDelay: function () {
-    QueueActions.resetDelay(this.props.appId);
-  },
-
-  handleScaleApp: function () {
-    var props = this.props;
-
-    const dialogId =
-      DialogActions.prompt("Scale to how many instances?",
-          props.model.instances.toString(), {
-            type: "number",
-            min: "0"
-          }
-      );
-
-    DialogStore.handleUserResponse(dialogId, instancesString => {
-      if (instancesString != null && instancesString !== "") {
-        let instances = parseInt(instancesString, 10);
-
-        AppsActions.scaleApp(props.appId, instances);
-      }
-    });
-  },
-
-  handleSuspendApp: function (event) {
-    event.preventDefault();
-
-    var props = this.props;
-
-    if (props.model.instances < 1) {
-      return;
-    }
-
-    const dialogId =
-      DialogActions.confirm("Suspend app by scaling to 0 instances?",
-        "Suspend");
-
-    DialogStore.handleUserResponse(dialogId, () => {
-      AppsActions.scaleApp(props.appId, 0);
-    });
-  },
-
-  handleRestartApp: function () {
-    var appId = this.props.appId;
-
-    const dialogId =
-      DialogActions.confirm(`Restart app '${appId}'?`, "Restart");
-
-    DialogStore.handleUserResponse(dialogId, () => {
-      AppsActions.restartApp(appId);
-    });
-  },
-
-  handleDestroyApp: function (event) {
-    event.preventDefault();
-
-    var appId = this.props.appId;
-
-    const dialogId =
-      DialogActions.confirm(`Destroy app '${appId}'? This is irreversible.`,
-        "Destroy");
-
-    DialogStore.handleUserResponse(dialogId, () => {
-      AppsActions.deleteApp(appId);
     });
   },
 

--- a/src/js/components/AppPageControlsComponent.jsx
+++ b/src/js/components/AppPageControlsComponent.jsx
@@ -145,7 +145,7 @@ var AppPageControlsComponent = React.createClass({
           <button className="btn btn-lg btn-default"
               onClick={this.toggleDropdown}>
             <i className="icon icon-mini gear"></i>
-            <span className="caret"/>
+            <span className="caret" />
           </button>
           <ul className={dropdownClassSet}>
             <li className={suspendAppClassSet}>

--- a/src/js/components/AppPageControlsComponent.jsx
+++ b/src/js/components/AppPageControlsComponent.jsx
@@ -81,14 +81,12 @@ var AppPageControlsComponent = React.createClass({
           </button>
           <ul className={dropdownClassSet}>
             <li className={suspendAppClassSet}>
-              <a href="#"
-                  onClick={this.handleSuspendApp}>
+              <a href="#" onClick={this.handleSuspendApp}>
                 Suspend
               </a>
             </li>
             <li>
-              <a href="#"
-                  onClick={this.handleDestroyApp}>
+              <a href="#" onClick={this.handleDestroyApp}>
                 <span className="text-danger">Destroy</span>
               </a>
             </li>

--- a/src/js/components/AppPageControlsComponent.jsx
+++ b/src/js/components/AppPageControlsComponent.jsx
@@ -15,8 +15,8 @@ var AppPageControlsComponent = React.createClass({
   mixins: [OnClickOutsideMixin],
 
   propTypes: {
-    app: React.PropTypes.object.isRequired,
-    appId: React.PropTypes.string.isRequired
+    appId: React.PropTypes.string.isRequired,
+    model: React.PropTypes.object.isRequired
   },
 
   getInitialState: function () {
@@ -28,7 +28,7 @@ var AppPageControlsComponent = React.createClass({
   getResetDelayButton: function () {
     var props = this.props;
 
-    if (props.app.status !== AppStatus.DELAYED) {
+    if (props.model.status !== AppStatus.DELAYED) {
       return null;
     }
 
@@ -55,7 +55,7 @@ var AppPageControlsComponent = React.createClass({
 
     const dialogId =
       DialogActions.prompt("Scale to how many instances?",
-          props.app.instances.toString(), {
+          props.model.instances.toString(), {
             type: "number",
             min: "0"
           }
@@ -75,7 +75,7 @@ var AppPageControlsComponent = React.createClass({
 
     var props = this.props;
 
-    if (props.app.instances < 1) {
+    if (props.model.instances < 1) {
       return;
     }
 
@@ -127,7 +127,7 @@ var AppPageControlsComponent = React.createClass({
     }, "dropdown-menu");
 
     var suspendAppClassSet = classNames({
-      "disabled": props.app.instances < 1
+      "disabled": props.model.instances < 1
     });
 
     return (

--- a/src/js/mixins/AppActionsHandlerMixin.jsx
+++ b/src/js/mixins/AppActionsHandlerMixin.jsx
@@ -1,7 +1,12 @@
 var AppsActions = require("../actions/AppsActions");
+var AppsEvents = require("../events/AppsEvents");
+var AppsStore = require("../stores/AppsStore");
 var DialogActions = require("../actions/DialogActions");
 var DialogStore = require("../stores/DialogStore");
+var Messages = require("../constants/Messages");
 var QueueActions = require("../actions/QueueActions");
+var QueueEvents = require("../events/QueueEvents");
+var QueueStore = require("../stores/QueueStore");
 
 var AppActionsHandlerMixin = {
   componentWillMount: function () {
@@ -10,6 +15,28 @@ var AppActionsHandlerMixin = {
         "The AppActionsHandlerMixin needs a defined model-property"
       );
     }
+  },
+
+  addScaleAppListener: function () {
+    AppsStore.once(AppsEvents.SCALE_APP_ERROR,
+      this.onScaleAppError);
+  },
+
+  addRestartAppListener: function () {
+    AppsStore.once(AppsEvents.RESTART_APP_ERROR,
+      this.onRestartAppError);
+  },
+
+  addDeleteAppListener: function () {
+    AppsStore.once(AppsEvents.DELETE_APP_ERROR,
+      this.onDeleteAppError);
+  },
+
+  addResetDelayListener: function () {
+    AppsStore.once(AppsEvents.RESET_DELAY,
+      this.onResetDelaySuccess);
+    AppsStore.once(AppsEvents.RESET_DELAY_ERROR,
+      this.onResetDelayError);
   },
 
   handleDestroyApp: function (event) {
@@ -22,11 +49,15 @@ var AppActionsHandlerMixin = {
         "Destroy");
 
     DialogStore.handleUserResponse(dialogId, () => {
+      this.addDeleteAppListener();
+
       AppsActions.deleteApp(appId);
     });
   },
 
   handleResetDelay: function () {
+    this.addResetDelayListener();
+
     QueueActions.resetDelay(this.props.model.id);
   },
 
@@ -37,6 +68,8 @@ var AppActionsHandlerMixin = {
       DialogActions.confirm(`Restart app '${appId}'?`, "Restart");
 
     DialogStore.handleUserResponse(dialogId, () => {
+      this.addRestartAppListener();
+
       AppsActions.restartApp(appId);
     });
   },
@@ -55,6 +88,8 @@ var AppActionsHandlerMixin = {
     DialogStore.handleUserResponse(dialogId, instancesString => {
       if (instancesString != null && instancesString !== "") {
         let instances = parseInt(instancesString, 10);
+
+        this.addScaleAppListener();
 
         AppsActions.scaleApp(model.id, instances);
       }
@@ -75,9 +110,75 @@ var AppActionsHandlerMixin = {
         "Suspend");
 
     DialogStore.handleUserResponse(dialogId, () => {
+      this.addScaleAppListener();
+
       AppsActions.scaleApp(model.id, 0);
     });
   },
+
+  onScaleAppError: function (errorMessage, statusCode, instances) {
+    if (statusCode === 409) {
+      let appId = this.props.model.id;
+      const dialogId = DialogActions.
+        confirm(`There is a deployment in progress that changes ${appId}.
+          If you want to stop this deployment and force a new one to scale it,
+          press the 'Scale forcefully' button.`, "Scale forcefully");
+      DialogStore.handleUserResponse(dialogId, () => {
+        this.addScaleAppListener();
+
+        AppsActions.scaleApp(appId, instances, true);
+      });
+    } else if (statusCode === 401) {
+      DialogActions.alert(`Not scaling: ${Messages.UNAUTHORIZED}`);
+    } else if (statusCode === 403) {
+      DialogActions.alert(`Not scaling: ${Messages.FORBIDDEN}`);
+    } else {
+      DialogActions.alert(`Not scaling:
+          ${errorMessage.message || errorMessage}`);
+    }
+  },
+
+  onRestartAppError: function (errorMessage, statusCode) {
+    if (statusCode === 401) {
+      DialogActions.alert(`Error restarting app: ${Messages.UNAUTHORIZED}`);
+    } else if (statusCode === 403) {
+      DialogActions.alert(`Error restarting app: ${Messages.FORBIDDEN}`);
+    } else {
+      DialogActions.alert(
+        `Error restarting app: ${errorMessage.message || errorMessage}`
+      );
+    }
+  },
+
+  onDeleteAppError: function (errorMessage, statusCode) {
+    if (statusCode === 401) {
+      DialogActions.alert(`Error destroying app: ${Messages.UNAUTHORIZED}`);
+    } else if (statusCode === 403) {
+      DialogActions.alert(`Error destroying app: ${Messages.FORBIDDEN}`);
+    } else {
+      DialogActions.alert(
+        `Error destroying app: ${errorMessage.message || errorMessage}`
+      );
+    }
+  },
+
+  onResetDelayError: function (errorMessage, statusCode) {
+    if (statusCode === 401) {
+      DialogActions.alert(`Error resetting delay on app:
+        ${Messages.UNAUTHORIZED}`);
+    } else if (statusCode === 403) {
+      DialogActions.alert(`Error resetting delay on app:
+        ${Messages.FORBIDDEN}`);
+    } else {
+      DialogActions.alert(
+        `Error resetting delay on app: ${errorMessage.message || errorMessage}`
+      );
+    }
+  },
+
+  onResetDelaySuccess: function () {
+    DialogActions.alert("Delay reset succesfully");
+  }
 };
 
 module.exports = AppActionsHandlerMixin;

--- a/src/js/mixins/AppActionsHandlerMixin.jsx
+++ b/src/js/mixins/AppActionsHandlerMixin.jsx
@@ -119,10 +119,12 @@ var AppActionsHandlerMixin = {
   onScaleAppError: function (errorMessage, statusCode, instances) {
     if (statusCode === 409) {
       let appId = this.props.model.id;
+
       const dialogId = DialogActions.
         confirm(`There is a deployment in progress that changes ${appId}.
           If you want to stop this deployment and force a new one to scale it,
           press the 'Scale forcefully' button.`, "Scale forcefully");
+
       DialogStore.handleUserResponse(dialogId, () => {
         this.addScaleAppListener();
 

--- a/src/js/mixins/AppActionsHandlerMixin.jsx
+++ b/src/js/mixins/AppActionsHandlerMixin.jsx
@@ -1,0 +1,83 @@
+var AppsActions = require("../actions/AppsActions");
+var DialogActions = require("../actions/DialogActions");
+var DialogStore = require("../stores/DialogStore");
+var QueueActions = require("../actions/QueueActions");
+
+var AppActionsHandlerMixin = {
+  componentWillMount: function () {
+    if (this.props.model == null) {
+      throw new Error(
+        "The AppActionsHandlerMixin needs a defined model-property"
+      );
+    }
+  },
+
+  handleDestroyApp: function (event) {
+    event.preventDefault();
+
+    var appId = this.props.model.id;
+
+    const dialogId =
+      DialogActions.confirm(`Destroy app '${appId}'? This is irreversible.`,
+        "Destroy");
+
+    DialogStore.handleUserResponse(dialogId, () => {
+      AppsActions.deleteApp(appId);
+    });
+  },
+
+  handleResetDelay: function () {
+    QueueActions.resetDelay(this.props.model.id);
+  },
+
+  handleRestartApp: function () {
+    var appId = this.props.model.id;
+
+    const dialogId =
+      DialogActions.confirm(`Restart app '${appId}'?`, "Restart");
+
+    DialogStore.handleUserResponse(dialogId, () => {
+      AppsActions.restartApp(appId);
+    });
+  },
+
+  handleScaleApp: function () {
+    var model = this.props.model;
+
+    const dialogId =
+      DialogActions.prompt("Scale to how many instances?",
+          model.instances.toString(), {
+            type: "number",
+            min: "0"
+          }
+      );
+
+    DialogStore.handleUserResponse(dialogId, instancesString => {
+      if (instancesString != null && instancesString !== "") {
+        let instances = parseInt(instancesString, 10);
+
+        AppsActions.scaleApp(model.id, instances);
+      }
+    });
+  },
+
+  handleSuspendApp: function (event) {
+    event.preventDefault();
+
+    var model = this.props.model;
+
+    if (model.instances < 1) {
+      return;
+    }
+
+    const dialogId =
+      DialogActions.confirm("Suspend app by scaling to 0 instances?",
+        "Suspend");
+
+    DialogStore.handleUserResponse(dialogId, () => {
+      AppsActions.scaleApp(model.id, 0);
+    });
+  },
+};
+
+module.exports = AppActionsHandlerMixin;


### PR DESCRIPTION
This closes https://github.com/mesosphere/marathon/issues/2814

![actions-dropdown](https://cloud.githubusercontent.com/assets/859154/12146107/2ae6cfdc-b492-11e5-9381-3e0e5913ec12.png)

This adds an additional column in the app list item with three white dots. On click a dropdown menu opens with performable actions on the specific application.
"Reset Delay" also appears in the list, if available.

I've refactored the click handler and response listener into a mixin for reuse.
These handlers are used in the AppListItemComponent and in the AppPageControlsComponent, so it makes sense to generalize them.
Also the listeners are only added now, if they are really needed, once.

cc @orlandohohmeier You could take a second review round after @Poltergeist has finished.