### PR TITLE
Get rid of unnecessary TestUtil

### DIFF
--- a/src/test/appVersions.test.js
+++ b/src/test/appVersions.test.js
@@ -16,8 +16,6 @@ var AppVersionListComponent =
 var AppVersionListItemComponent =
   require("../js/components/AppVersionListItemComponent");
 
-var TestUtil = require("./helpers/TestUtil");
-
 var server = config.localTestserverURI;
 config.apiURL = `http://${server.address}:${server.port}/`;
 
@@ -210,7 +208,7 @@ describeWithDOM("App Version List component", function () {
   });
 
   after(function () {
-    TestUtil.getComponentDOMInstance(this.component).componentWillUnmount();
+    this.component.instance().componentWillUnmount();
   });
 
   it("has correct AppVersionListItemComponents", function () {
@@ -287,7 +285,7 @@ describeWithDOM("App Version component", function () {
   });
 
   after(function () {
-    TestUtil.getComponentDOMInstance(this.component).componentWillUnmount();
+    this.component.instance().componentWillUnmount();
   });
 
   it("shows the app ID", function () {

--- a/src/test/helpers/TestUtil.js
+++ b/src/test/helpers/TestUtil.js
@@ -1,7 +1,0 @@
-var TestUtil = {
-  getComponentDOMInstance: function (component) {
-    return component.component.getInstance();
-  }
-};
-
-module.exports = TestUtil;


### PR DESCRIPTION
The ugly way to access a component’s instance was a leftover from
initial tests.