### PR TITLE
Feature - 2733 Add port type select dropdown box for Health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unversioned
 ### Added
 - \#2814 - Add contextual dropdown menu to Application List items
+- \#2733 - Allow configuration of "port" instead of "portIndex" for HTTP/TCP
+  health checks
 
 ### Changed
 - \#2651 - Improve ui scale error messages

--- a/src/js/components/HealthChecksComponent.jsx
+++ b/src/js/components/HealthChecksComponent.jsx
@@ -84,6 +84,11 @@ var HealthChecksComponent = React.createClass({
         row.portType === HealthCheckPortTypes.PORT_INDEX
     });
 
+    var portTypeClassSet = classNames({
+      "col-sm-3": true,
+      "hidden": row.protocol === HealthCheckProtocols.COMMAND
+    });
+
     return (
       <div key={row.consecutiveKey} className={rowClassSet}>
         <button type="button" className="close"
@@ -209,7 +214,7 @@ var HealthChecksComponent = React.createClass({
                 <input ref={`port${i}`} {...numberInputAttributes} />
               </FormGroupComponent>
             </div>
-            <div className="col-sm-3">
+            <div className={portTypeClassSet}>
               <FormGroupComponent
                 errorMessage={
                   getErrorMessage(`${fieldsetId}.${i}.portType`)

--- a/src/js/components/HealthChecksComponent.jsx
+++ b/src/js/components/HealthChecksComponent.jsx
@@ -4,6 +4,7 @@ var React = require("react/addons");
 var DuplicableRowsMixin = require("../mixins/DuplicableRowsMixin");
 var FormGroupComponent = require("../components/FormGroupComponent");
 var HealthCheckProtocols = require("../constants/HealthCheckProtocols");
+var HealthCheckPortTypes = require("../constants/HealthCheckPortTypes");
 
 const healthChecksRowScheme =
   require("../stores/schemes/healthChecksRowScheme");
@@ -73,7 +74,14 @@ var HealthChecksComponent = React.createClass({
 
     var portIndexClassSet = classNames({
       "col-sm-2": true,
-      "hidden": row.protocol === HealthCheckProtocols.COMMAND
+      "hidden": row.protocol === HealthCheckProtocols.COMMAND ||
+        row.portType === HealthCheckPortTypes.PORT_NUMBER
+    });
+
+    var portClassSet = classNames({
+      "col-sm-2": true,
+      "hidden": row.protocol === HealthCheckProtocols.COMMAND ||
+        row.portType === HealthCheckPortTypes.PORT_INDEX
     });
 
     return (
@@ -165,6 +173,8 @@ var HealthChecksComponent = React.createClass({
                 <input ref={`timeoutSeconds${i}`} {...numberInputAttributes} />
               </FormGroupComponent>
             </div>
+          </div>
+          <div className="row">
             <div className="col-sm-4">
               <FormGroupComponent
                 errorMessage={
@@ -186,6 +196,35 @@ var HealthChecksComponent = React.createClass({
                 label="Port Index"
                 value={row.portIndex}>
                 <input ref={`portIndex${i}`} {...numberInputAttributes} />
+              </FormGroupComponent>
+            </div>
+            <div className={portClassSet}>
+              <FormGroupComponent
+                errorMessage={
+                  getErrorMessage(`${fieldsetId}.${i}.port`)
+                }
+                fieldId={`${fieldsetId}.${i}.port`}
+                label="Port Number"
+                value={row.port}>
+                <input ref={`port${i}`} {...numberInputAttributes} />
+              </FormGroupComponent>
+            </div>
+            <div className="col-sm-3">
+              <FormGroupComponent
+                errorMessage={
+                  getErrorMessage(`${fieldsetId}.${i}.portType`)
+                }
+                fieldId={`${fieldsetId}.${i}.portType`}
+                label="Port Type"
+                value={row.portType}>
+                <select defaultValue={row.portType} ref={`portType${i}`}>
+                  <option value={HealthCheckPortTypes.PORT_INDEX}>
+                    Port Index
+                  </option>
+                  <option value={HealthCheckPortTypes.PORT_NUMBER}>
+                    Port Number
+                  </option>
+                </select>
               </FormGroupComponent>
             </div>
           </div>

--- a/src/js/components/HealthChecksComponent.jsx
+++ b/src/js/components/HealthChecksComponent.jsx
@@ -194,7 +194,7 @@ var HealthChecksComponent = React.createClass({
                 }
                 fieldId={`${fieldsetId}.${i}.portIndex`}
                 label="Port Index"
-                value={row.portIndex}>
+                value={row.portIndex || 0}>
                 <input ref={`portIndex${i}`} {...numberInputAttributes} />
               </FormGroupComponent>
             </div>
@@ -205,7 +205,7 @@ var HealthChecksComponent = React.createClass({
                 }
                 fieldId={`${fieldsetId}.${i}.port`}
                 label="Port Number"
-                value={row.port}>
+                value={row.port || 0}>
                 <input ref={`port${i}`} {...numberInputAttributes} />
               </FormGroupComponent>
             </div>

--- a/src/js/components/HealthChecksComponent.jsx
+++ b/src/js/components/HealthChecksComponent.jsx
@@ -78,7 +78,7 @@ var HealthChecksComponent = React.createClass({
         row.portType === HealthCheckPortTypes.PORT_NUMBER
     });
 
-    var portClassSet = classNames({
+    var portNumberClassSet = classNames({
       "col-sm-2": true,
       "hidden": row.protocol === HealthCheckProtocols.COMMAND ||
         row.portType === HealthCheckPortTypes.PORT_INDEX
@@ -198,7 +198,7 @@ var HealthChecksComponent = React.createClass({
                 <input ref={`portIndex${i}`} {...numberInputAttributes} />
               </FormGroupComponent>
             </div>
-            <div className={portClassSet}>
+            <div className={portNumberClassSet}>
               <FormGroupComponent
                 errorMessage={
                   getErrorMessage(`${fieldsetId}.${i}.port`)

--- a/src/js/constants/AppFormErrorMessages.js
+++ b/src/js/constants/AppFormErrorMessages.js
@@ -38,6 +38,7 @@ const applicationFieldValidationErrors = Util.deepFreeze({
     "Command must not be emtpy",
     "Path must not be emtpy",
     "Port Index must be a non-negative number",
+    "Port Number must be a valid port between 0 - 65535",
     "Grace Period must be a non-negative number",
     "Interval must be a non-negative number",
     "Timeout must be a non-negative number",

--- a/src/js/constants/HealthCheckPortTypes.js
+++ b/src/js/constants/HealthCheckPortTypes.js
@@ -1,0 +1,6 @@
+const HealthCheckPortTypes = {
+  PORT_INDEX: "PORT_INDEX",
+  PORT_NUMBER: "PORT_NUMBER"
+};
+
+module.exports = Object.freeze(HealthCheckPortTypes);

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -65,6 +65,7 @@ const validationRules = {
     AppFormValidators.healthChecksCommandNotEmpty,
     AppFormValidators.healthChecksPathNotEmpty,
     AppFormValidators.healthChecksPortIndex,
+    AppFormValidators.healthChecksPort,
     AppFormValidators.healthChecksGracePeriod,
     AppFormValidators.healthChecksInterval,
     AppFormValidators.healthChecksTimeout,
@@ -150,6 +151,8 @@ const responseAttributePathToFieldIdMap = {
     "healthChecks.{INDEX}.path",
   "/healthChecks({INDEX})/intervalSeconds":
     "healthChecks.{INDEX}.intervalSeconds",
+  "/healthChecks({INDEX})/port":
+    "healthChecks.{INDEX}.port",
   "/healthChecks({INDEX})/portIndex":
     "healthChecks.{INDEX}.portIndex",
   "/healthChecks({INDEX})/timeoutSeconds":

--- a/src/js/stores/schemes/healthChecksRowScheme.js
+++ b/src/js/stores/schemes/healthChecksRowScheme.js
@@ -1,12 +1,15 @@
 var Util = require("../../helpers/Util");
 
 var HealthCheckProtocols = require("../../constants/HealthCheckProtocols");
+var HealthCheckPortTypes = require("../../constants/HealthCheckPortTypes");
 
 const healthChecksRowScheme = {
   protocol: HealthCheckProtocols.HTTP,
   command: null,
   path: null,
+  port: 0,
   portIndex: 0,
+  portType: HealthCheckPortTypes.PORT_INDEX,
   gracePeriodSeconds: 300,
   intervalSeconds: 60,
   timeoutSeconds: 20,

--- a/src/js/stores/transforms/AppFormFieldToModelTransforms.js
+++ b/src/js/stores/transforms/AppFormFieldToModelTransforms.js
@@ -91,6 +91,7 @@ const AppFormFieldToModelTransforms = {
       if (row.protocol === HealthCheckProtocols.COMMAND) {
         delete row.path;
         delete row.portIndex;
+        delete row.port;
 
         row.command = {
           value: row.command
@@ -109,7 +110,8 @@ const AppFormFieldToModelTransforms = {
       "intervalSeconds",
       "maxConsecutiveFailures",
       "timeoutSeconds",
-      "portIndex"]
+      "portIndex",
+      "port"]
         .forEach((key) => {
           if (row[key] != null &&
               !Util.isStringAndEmpty(row[key].toString().trim())) {

--- a/src/js/stores/transforms/AppFormModelPostProcess.js
+++ b/src/js/stores/transforms/AppFormModelPostProcess.js
@@ -1,6 +1,7 @@
 var Util = require("../../helpers/Util");
 
 var HealthCheckProtocols = require("../../constants/HealthCheckProtocols");
+var HealthCheckPortTypes = require("../../constants/HealthCheckPortTypes");
 
 const healthChecksRowScheme = require("../schemes/healthChecksRowScheme");
 
@@ -58,12 +59,20 @@ const AppFormModelPostProcess = {
     let isEmpty = hc.protocol === HealthCheckProtocols.HTTP &&
       hc.path == null || Util.isStringAndEmpty(healthChecks.path) &&
       ["portIndex",
+      "port",
       "gracePeriodSeconds",
       "intervalSeconds",
       "timeoutSeconds",
       "maxConsecutiveFailures",
       "ignoreHttp1xx"]
         .every((key) => hc[key] === healthChecksRowScheme[key]);
+
+    if (hc.portType === HealthCheckPortTypes.PORT_INDEX) {
+      delete hc.port;
+    } else if (hc.portType === HealthCheckPortTypes.PORT_NUMBER) {
+      delete hc.portIndex;
+    }
+    delete hc.portType;
 
     if (isEmpty) {
       app.healthChecks = [];

--- a/src/js/stores/transforms/AppFormModelToFieldTransforms.js
+++ b/src/js/stores/transforms/AppFormModelToFieldTransforms.js
@@ -1,4 +1,5 @@
 var HealthCheckProtocols = require("../../constants/HealthCheckProtocols");
+var HealthCheckPortTypes = require("../../constants/HealthCheckPortTypes");
 var Util = require("../../helpers/Util");
 
 const AppFormModelToFieldTransforms = {
@@ -57,6 +58,12 @@ const AppFormModelToFieldTransforms = {
     return healthChecks
       .map((row, i) => {
         row.consecutiveKey = i;
+
+        if (row.portIndex != null) {
+          row.portType = HealthCheckPortTypes.PORT_INDEX;
+        } else if (row.port != null) {
+          row.portType = HealthCheckPortTypes.PORT_NUMBER;
+        }
 
         if (row.protocol === HealthCheckProtocols.COMMAND) {
           if (Util.isObject(row.command)) {

--- a/src/js/stores/validators/AppFormValidators.js
+++ b/src/js/stores/validators/AppFormValidators.js
@@ -1,5 +1,6 @@
 var Util = require("../../helpers/Util");
 var HealthCheckProtocols = require("../../constants/HealthCheckProtocols");
+var HealthCheckPortTypes = require("../../constants/HealthCheckPortTypes");
 var ValidConstraints = require("../../constants/ValidConstraints");
 
 function isValidPort(value) {
@@ -111,8 +112,16 @@ const AppFormValidators = {
 
   healthChecksPortIndex: (obj) => {
     return obj.protocol !== HealthCheckProtocols.HTTP &&
-        obj.protocol !== HealthCheckProtocols.TCP ||
+      obj.protocol !== HealthCheckProtocols.TCP ||
+      obj.portType !== HealthCheckPortTypes.PORT_INDEX ||
       !!obj.portIndex.toString().match(/^[0-9]+$/);
+  },
+
+  healthChecksPort: (obj) => {
+    return obj.protocol !== HealthCheckProtocols.HTTP &&
+      obj.protocol !== HealthCheckProtocols.TCP ||
+      obj.portType !== HealthCheckPortTypes.PORT_NUMBER ||
+      isValidPort(obj.port);
   },
 
   healthChecksGracePeriod: (obj) => {

--- a/src/test/appFormModelPostProcess.test.js
+++ b/src/test/appFormModelPostProcess.test.js
@@ -111,6 +111,77 @@ describe("App Form Model Post Process", function () {
       expect(app.healthChecks).to.deep.equal(app.healthChecks);
     });
 
+    describe("only contains the specified port field", function () {
+      it("Port Number", function () {
+        var healthCheckWithPortNumber = {
+          healthChecks: [{
+            "path": "/",
+            "protocol": "HTTP",
+            "portIndex": 0,
+            "port": 8080,
+            "portType": "PORT_NUMBER",
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "ignoreHttp1xx": false
+          }]
+        };
+
+        var expectedObjectWithoutPortIndex = {
+          "path": "/",
+          "protocol": "HTTP",
+          "port": 8080,
+          "gracePeriodSeconds": 300,
+          "intervalSeconds": 60,
+          "timeoutSeconds": 20,
+          "maxConsecutiveFailures": 3,
+          "ignoreHttp1xx": false
+        };
+
+        AppFormModelPostProcess.healthChecks(healthCheckWithPortNumber);
+
+        expect(healthCheckWithPortNumber.healthChecks[0])
+          .to.deep.equal(expectedObjectWithoutPortIndex);
+      });
+
+      it("Port Index", function () {
+        var healthCheckWithPortIndex = {
+          healthChecks: [{
+            "path": "/",
+            "protocol": "HTTP",
+            "portIndex": 1,
+            "port": 8080,
+            "portType": "PORT_INDEX",
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "ignoreHttp1xx": false
+          }]
+        };
+
+        var expectedObjectWithoutPortNumber = {
+          "path": "/",
+          "protocol": "HTTP",
+          "portIndex": 1,
+          "gracePeriodSeconds": 300,
+          "intervalSeconds": 60,
+          "timeoutSeconds": 20,
+          "maxConsecutiveFailures": 3,
+          "ignoreHttp1xx": false
+        };
+
+        AppFormModelPostProcess.healthChecks(healthCheckWithPortIndex);
+
+        expect(healthCheckWithPortIndex.healthChecks[0])
+          .to.deep.equal(expectedObjectWithoutPortNumber);
+      });
+
+    });
+
+
+
   });
 
 });

--- a/src/test/appFormTransforms.test.js
+++ b/src/test/appFormTransforms.test.js
@@ -414,6 +414,7 @@ describe("App Form Model To Field Transform", function () {
             "path": "/",
             "protocol": "COMMAND",
             "portIndex": 0,
+            "portType": "PORT_INDEX",
             "command": "true",
             "gracePeriodSeconds": 300,
             "intervalSeconds": 60,
@@ -422,6 +423,70 @@ describe("App Form Model To Field Transform", function () {
             "ignoreHttp1xx": false
           }]);
       });
+
+      describe("only contains the specified port field", function () {
+        it("Port Number", function () {
+          var expectedHealthCheckWithPortNumberType = [{
+            "consecutiveKey": 0,
+            "path": "/",
+            "protocol": "HTTP",
+            "port": 8080,
+            "portType": "PORT_NUMBER",
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "ignoreHttp1xx": false
+          }];
+
+          var ObjectWithoutPortNumberType = [{
+            "path": "/",
+            "protocol": "HTTP",
+            "port": 8080,
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "ignoreHttp1xx": false
+          }];
+
+          expect(AppFormTransforms.ModelToField.healthChecks(
+            ObjectWithoutPortNumberType
+          )).to.deep.equal(expectedHealthCheckWithPortNumberType);
+        });
+
+        it("Port Index", function () {
+          var expectedHealthCheckWithPortIndexType = [{
+            "consecutiveKey": 0,
+            "path": "/",
+            "protocol": "HTTP",
+            "portIndex": 1,
+            "portType": "PORT_INDEX",
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "ignoreHttp1xx": false
+          }];
+
+          var objectWithoutPortIndexType = [{
+            "path": "/",
+            "protocol": "HTTP",
+            "portIndex": 1,
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "ignoreHttp1xx": false
+          }];
+
+          expect(AppFormTransforms.ModelToField.healthChecks(
+            objectWithoutPortIndexType
+          )).to.deep.equal(expectedHealthCheckWithPortIndexType);
+        });
+
+      });
+
     });
 
     it("ports array to string", function () {

--- a/src/test/appFormValidators.test.js
+++ b/src/test/appFormValidators.test.js
@@ -459,7 +459,7 @@ describe("App Form Validators", function () {
         expect(healthChecksPort({
           protocol: "HTTP",
           portType: HealthCheckPortTypes.PORT_NUMBER,
-          port: "70000"
+          port: "65536"
         })).to.be.false;
         expect(healthChecksPort({
           protocol: "HTTP",

--- a/src/test/appFormValidators.test.js
+++ b/src/test/appFormValidators.test.js
@@ -1,12 +1,13 @@
 var expect = require("chai").expect;
 
 var AppFormValidators = require("../js/stores/validators/AppFormValidators");
+var HealthCheckPortTypes = require("../js/constants/HealthCheckPortTypes");
 
 describe("App Form Validators", function () {
 
   describe("expects", function () {
 
-    before(function() {
+    before(function () {
       this.v = AppFormValidators;
     })
 
@@ -402,29 +403,79 @@ describe("App Form Validators", function () {
       it("port index to be valid", function () {
         expect(this.v.healthChecksPortIndex({
           protocol: "TCP",
+          portType: HealthCheckPortTypes.PORT_INDEX,
           portIndex: 1
         }))
           .to.be.true;
         expect(this.v.healthChecksPortIndex({
           protocol: "HTTP",
+          portType: HealthCheckPortTypes.PORT_INDEX,
           portIndex: 0
         }))
           .to.be.true;
         expect(this.v.healthChecksPortIndex({
           protocol: "HTTP",
+          portType: HealthCheckPortTypes.PORT_INDEX,
           portIndex: "abc"
         }))
           .to.be.false;
         expect(this.v.healthChecksPortIndex({
           protocol: "TCP",
+          portType: HealthCheckPortTypes.PORT_INDEX,
           portIndex: 0.5
         }))
           .to.be.false;
         expect(this.v.healthChecksPortIndex({
           protocol: "COMMAND",
+          portType: HealthCheckPortTypes.PORT_INDEX,
           portIndex: "abc"
         }))
           .to.be.true;
+      });
+
+      it("port number to be a valid port", function () {
+        let healthChecksPort = this.v.healthChecksPort;
+
+        expect(healthChecksPort({
+          protocol: "HTTP",
+          portType: HealthCheckPortTypes.PORT_NUMBER,
+          port: "NaN 666"
+        })).to.be.false;
+        expect(healthChecksPort({
+          protocol: "HTTP",
+          portType: HealthCheckPortTypes.PORT_NUMBER,
+          port: -5
+        })).to.be.false;
+        expect(healthChecksPort({
+          protocol: "HTTP",
+          portType: HealthCheckPortTypes.PORT_NUMBER,
+          port: 0.1
+        })).to.be.false;
+        expect(healthChecksPort({
+          protocol: "HTTP",
+          portType: HealthCheckPortTypes.PORT_NUMBER,
+          port: "0.0001"
+        })).to.be.false;
+        expect(healthChecksPort({
+          protocol: "HTTP",
+          portType: HealthCheckPortTypes.PORT_NUMBER,
+          port: "70000"
+        })).to.be.false;
+        expect(healthChecksPort({
+          protocol: "HTTP",
+          portType: HealthCheckPortTypes.PORT_NUMBER,
+          port: 0
+        })).to.be.true;
+        expect(healthChecksPort({
+          protocol: "HTTP",
+          portType: HealthCheckPortTypes.PORT_NUMBER,
+          port: "2"
+        })).to.be.true;
+        expect(healthChecksPort({
+          protocol: "HTTP",
+          portType: HealthCheckPortTypes.PORT_NUMBER,
+          port: ""
+        })).to.be.true;
       });
 
       it("grace period to be valid", function () {


### PR DESCRIPTION
Introduces a new dropdown field on the application health check form, which makes it possible to select a port number or a port index.

If port number is selected the object which is send to the server does contain a `port` field else if port Index is selected the object which is send to the server will contain a `portIndex` field. 

This enables a freshly introduced api functionality which makes it possible to set a port or an port index for the health checks.

![image](https://cloud.githubusercontent.com/assets/156010/12174356/5d26a70e-b55c-11e5-938f-cc6fc3bed4d7.png)

![image](https://cloud.githubusercontent.com/assets/156010/12174378/7e1ee340-b55c-11e5-8283-f533d771bb0c.png)

![image](https://cloud.githubusercontent.com/assets/156010/12174396/87ba3f76-b55c-11e5-8de9-7c813730ad3d.png)

mesosphere/marathon#2733
