### PR TITLE
Feature - Show all health states on application health detail view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - \#2814 - Add contextual dropdown menu to Application List items
 - \#2733 - Allow configuration of "port" instead of "portIndex" for HTTP/TCP
   health checks
+- \#2906 - Show health status bar breakdown on application detail view
 
 ### Changed
 - \#2651 - Improve ui scale error messages

--- a/src/css/components/app-health-detail.less
+++ b/src/css/components/app-health-detail.less
@@ -22,8 +22,14 @@
   &.health-breakdown-item-unknown {
     color: @task-health-unknown-color;
   }
-  &.health-breakdown-item-empty .health-percentage {
-    display: none;
+  &.health-breakdown-item-empty {
+    .health-percentage {
+      display: none;
+    }
+
+    &.health-breakdown-item-impermanent {
+      display: none;
+    }
   }
 }
 
@@ -44,10 +50,6 @@
   }
   .health-dot {
     margin-right: @base-spacing-unit;
-  }
-
-  .health-breakdown-item-empty.health-breakdown-item-impermanent {
-    display: none;
   }
 
   &.popover {

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -317,7 +317,10 @@ var AppPageComponent = React.createClass({
                 fields={[
                   HealthStatus.HEALTHY,
                   HealthStatus.UNHEALTHY,
-                  HealthStatus.UNKNOWN
+                  HealthStatus.UNKNOWN,
+                  HealthStatus.STAGED,
+                  HealthStatus.OVERCAPACITY,
+                  HealthStatus.UNSCHEDULED
                 ]}
                 model={model} />
             </div>


### PR DESCRIPTION
This closes https://github.com/mesosphere/marathon/issues/2906

Because of the excellent work on the AppHealthDetailComponent by @philipnrmn, I hadn't to adjust much.

The additional states (staged, over-capacity, unscheduled) are only showing up, if they are greater then 0.

![health-extend](https://cloud.githubusercontent.com/assets/859154/12195424/5f543a8c-b5f7-11e5-84e0-675c80e57b67.png)
