### PR TITLE
Fix - 2912 Label popover alignment isn't working anymore

### DIFF
--- a/src/css/components/labels.less
+++ b/src/css/components/labels.less
@@ -55,13 +55,46 @@
       li {
         display: block;
         margin: 0 0 @base-spacing-unit 0;
-        
+
         &:last-child {
           margin: 0;
         }
 
         .badge {
           margin: 0;
+        }
+      }
+    }
+
+    &.popover {
+
+      & .content {
+        left: 100%;
+        transform: none;
+        margin-top: -@base-spacing-unit*2;
+        margin-left: @base-spacing-unit*2;
+
+        &:before {
+          border-right-color: @navbar-bg-color;
+          border-top-color: transparent;
+          right: 100%;
+          left: auto;
+          top: @base-spacing-unit*2;
+          content: " ";
+        }
+      }
+
+      &.default .content {
+        top: 0;
+        bottom: auto;
+      }
+
+      &.top .content{
+        margin-bottom: -@base-spacing-unit*4;
+
+        &:before {
+          bottom: @base-spacing-unit*2;
+          top: auto;
         }
       }
     }

--- a/src/css/components/popover.less
+++ b/src/css/components/popover.less
@@ -56,21 +56,4 @@
       content: " ";
     }
   }
-
-  &.right .content {
-    top: 0;
-    left: 100%;
-    bottom: auto;
-    transform: none;
-    margin-top: -@base-spacing-unit*2;
-    margin-left: @base-spacing-unit*2;
-
-    &:before {
-      border-right-color: @navbar-bg-color;
-      right: 100%;
-      left: auto;
-      top: @base-spacing-unit*2;
-      content: " ";
-    }
-  }
 }

--- a/src/js/components/AppListItemLabelsComponent.jsx
+++ b/src/js/components/AppListItemLabelsComponent.jsx
@@ -151,7 +151,6 @@ var AppListItemLabelsComponent = React.createClass({
 
     let labelsDropdown = (
       <PopoverComponent className="labels-dropdown"
-          alignment="right"
           ref="labelsDropdown"
           visible={labelsDropdownVisible}>
         <h5>All Labels</h5>

--- a/src/js/components/PopoverComponent.js
+++ b/src/js/components/PopoverComponent.js
@@ -6,13 +6,11 @@ var Util = require("../helpers/Util");
 const DEFAULT_ALIGNED = "default";
 const TOP_ALIGNED = "top";
 const BOTTOM_ALIGNED = "bottom";
-const RIGHT_ALIGNED = "right";
 
 var PopoverComponent = React.createClass({
   displayName: "PopoverComponent",
 
   propTypes: {
-    alignment: React.PropTypes.string,
     children: React.PropTypes.node,
     className: React.PropTypes.string,
     visible: React.PropTypes.bool
@@ -45,11 +43,6 @@ var PopoverComponent = React.createClass({
     let contentNode = React.findDOMNode(this.refs.content);
     let componentPosition = componentNode.getBoundingClientRect();
     let contentHeight = contentNode.clientHeight;
-
-    if (this.props.alignment === RIGHT_ALIGNED) {
-      this.setState({alignment: RIGHT_ALIGNED});
-      return;
-    }
 
     if (componentPosition.top <= contentHeight) {
       this.setState({alignment: BOTTOM_ALIGNED});


### PR DESCRIPTION
The functionality of the right alignment should be done with css
and not with JavaScript. JavaScript only checks if the component
needs to be vertical aligned to fit into the screen.

This closes mesosphere/marathon#2912