### PR TITLE
Feature - 2944 add scale group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   health checks
 - \#2906 - Show health status bar breakdown on application detail view
 - \#2841 - Add a restart forcefully function
+- \#2770 - Allow users to delete groups
+- \#2944 - Allow users to scale a group
 
 ### Changed
 - \#2651 - Improve ui scale error messages

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -224,7 +224,7 @@ var AppListItemComponent = React.createClass({
 
     let model = this.props.model;
 
-    let suspendAppClassSet = classNames({
+    let disabledClassSet = classNames({
       "disabled": model.instances < 1
     });
 
@@ -240,6 +240,16 @@ var AppListItemComponent = React.createClass({
       return (
         <div className={dropdownClassName} ref="dropdown">
           <ul className="dropdown-menu" ref="dropdown-menu">
+            <li className={disabledClassSet}>
+              <a href="#" onClick={this.handleScaleGroup}>
+                Scale By
+              </a>
+            </li>
+            <li className={disabledClassSet}>
+              <a href="#" onClick={this.handleSuspendGroup}>
+                Suspend
+              </a>
+            </li>
             <li>
               <a href="#" onClick={this.handleDestroyGroup}>
                 <span className="text-danger">Destroy</span>
@@ -263,7 +273,7 @@ var AppListItemComponent = React.createClass({
               Restart
             </a>
           </li>
-          <li className={suspendAppClassSet}>
+          <li className={disabledClassSet}>
             <a href="#" onClick={this.handleSuspendApp}>
               Suspend
             </a>

--- a/src/js/mixins/AppActionsHandlerMixin.jsx
+++ b/src/js/mixins/AppActionsHandlerMixin.jsx
@@ -129,6 +129,10 @@ var AppActionsHandlerMixin = {
   handleScaleGroup: function () {
     var model = this.props.model;
 
+    if (model.instances < 1) {
+      return;
+    }
+
     const dialogId =
       DialogActions.prompt("Please provide a scaling factor for all " +
           "applications in this group.",

--- a/src/js/mixins/AppActionsHandlerMixin.jsx
+++ b/src/js/mixins/AppActionsHandlerMixin.jsx
@@ -25,6 +25,11 @@ var AppActionsHandlerMixin = {
       this.onScaleAppError);
   },
 
+  addScaleGroupListener: function () {
+    GroupsStore.once(GroupsEvents.SCALE_ERROR,
+      this.onScaleGroupError);
+  },
+
   addRestartAppListener: function () {
     AppsStore.once(AppsEvents.RESTART_APP_ERROR,
       this.onRestartAppError);
@@ -121,6 +126,29 @@ var AppActionsHandlerMixin = {
     });
   },
 
+  handleScaleGroup: function () {
+    var model = this.props.model;
+
+    const dialogId =
+      DialogActions.prompt("Please provide a scaling factor for all " +
+          "applications in this group.",
+        "1.0", {
+          type: "number",
+          min: "0"
+        }
+      );
+
+    DialogStore.handleUserResponse(dialogId, scaleByString => {
+      if (scaleByString != null && scaleByString !== "") {
+        let scaleBy = parseFloat(scaleByString);
+
+        this.addScaleGroupListener();
+
+        GroupsActions.scaleGroup(model.id, scaleBy);
+      }
+    });
+  },
+
   handleSuspendApp: function (event) {
     event.preventDefault();
 
@@ -141,6 +169,26 @@ var AppActionsHandlerMixin = {
     });
   },
 
+  handleSuspendGroup: function (event) {
+    event.preventDefault();
+
+    var model = this.props.model;
+
+    if (model.instances < 1) {
+      return;
+    }
+
+    const dialogId =
+      DialogActions.confirm("Suspend all apps by scaling the group to 0?",
+        "Suspend");
+
+    DialogStore.handleUserResponse(dialogId, () => {
+      this.addScaleGroupListener();
+
+      GroupsActions.scaleGroup(model.id, 0);
+    });
+  },
+
   onScaleAppError: function (errorMessage, statusCode, instances) {
     if (statusCode === 409) {
       let appId = this.props.model.id;
@@ -156,6 +204,17 @@ var AppActionsHandlerMixin = {
         AppsActions.scaleApp(appId, instances, true);
       });
     } else if (statusCode === 401) {
+      DialogActions.alert(`Not scaling: ${Messages.UNAUTHORIZED}`);
+    } else if (statusCode === 403) {
+      DialogActions.alert(`Not scaling: ${Messages.FORBIDDEN}`);
+    } else {
+      DialogActions.alert(`Not scaling:
+          ${errorMessage.message || errorMessage}`);
+    }
+  },
+
+  onScaleGroupError: function (errorMessage, statusCode) {
+    if (statusCode === 401) {
       DialogActions.alert(`Not scaling: ${Messages.UNAUTHORIZED}`);
     } else if (statusCode === 403) {
       DialogActions.alert(`Not scaling: ${Messages.FORBIDDEN}`);


### PR DESCRIPTION
Please merge this one before #534 

Also contains the suspend function.

If a group has been suspended it can't be scaled up because scale by is only a factor and 0 * *anything* is still `0`. So "Scale By" is also disabled if instances is equal to 0.

![image](https://cloud.githubusercontent.com/assets/156010/12236189/a0002bee-b878-11e5-8e3f-2dcc99ea1799.png)

![image](https://cloud.githubusercontent.com/assets/156010/12236197/a85571e6-b878-11e5-8f4a-3277e8e3510b.png)

![image](https://cloud.githubusercontent.com/assets/156010/12236203/b09f815c-b878-11e5-8f60-aae144d6e736.png)

![image](https://cloud.githubusercontent.com/assets/156010/12236176/9097ab46-b878-11e5-86cf-93f48153a89b.png)


This closes mesosphere/marathon#2944