### PR TITLE
Never preselect dangerous actions in dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - \#2511 - Improve UI error messages
 - \#2831 - Convert alert, confirm and prompt dialogs to new design
 - \#2909 - Update dialog messages
+- \#2655 - Never preselect dangerous actions in modal dialogs
 
 ### Fixed
 - \#2892 - Version in task detail component shouldn't be localised

--- a/src/js/components/AlertDialogComponent.jsx
+++ b/src/js/components/AlertDialogComponent.jsx
@@ -1,6 +1,7 @@
 var React = require("react/addons");
 var classNames = require("classnames");
 
+var DialogSeverity = require("../constants/DialogSeverity");
 var Util = require("../helpers/Util");
 var ModalComponent = require("../components/ModalComponent");
 
@@ -26,7 +27,9 @@ var AlertDialogComponent = React.createClass({
   },
 
   componentDidMount: function () {
-    React.findDOMNode(this.refs.button).focus();
+    if (this.props.data.severity === DialogSeverity.INFO) {
+      React.findDOMNode(this.refs.button).focus();
+    }
   },
 
   render: function () {

--- a/src/js/components/ConfirmDialoglComponent.jsx
+++ b/src/js/components/ConfirmDialoglComponent.jsx
@@ -1,6 +1,7 @@
 var React = require("react/addons");
 var classNames = require("classnames");
 
+var DialogSeverity = require("../constants/DialogSeverity");
 var Util = require("../helpers/Util");
 var ModalComponent = require("../components/ModalComponent");
 
@@ -26,7 +27,9 @@ var ConfirmDialogComponent = React.createClass({
   },
 
   componentDidMount: function () {
-    React.findDOMNode(this.refs.acceptButton).focus();
+    if (this.props.data.severity === DialogSeverity.INFO) {
+      React.findDOMNode(this.refs.acceptButton).focus();
+    }
   },
 
   render: function () {

--- a/src/js/components/PromptDialogComponent.jsx
+++ b/src/js/components/PromptDialogComponent.jsx
@@ -1,6 +1,7 @@
 var React = require("react/addons");
 var classNames = require("classnames");
 
+var DialogSeverity = require("../constants/DialogSeverity");
 var Util = require("../helpers/Util");
 var ModalComponent = require("../components/ModalComponent");
 


### PR DESCRIPTION
Only focus the action button when a dialog is of severity "INFO".

This does not apply to Prompts, where we always want to focus the input field. 

This fixes mesosphere/marathon#2655 