### PR TITLE
Fix - Use correct store and events for reset delay

### DIFF
--- a/src/js/mixins/AppActionsHandlerMixin.jsx
+++ b/src/js/mixins/AppActionsHandlerMixin.jsx
@@ -47,9 +47,9 @@ var AppActionsHandlerMixin = {
   },
 
   addResetDelayListener: function () {
-    AppsStore.once(AppsEvents.RESET_DELAY,
+    QueueStore.once(QueueEvents.RESET_DELAY,
       this.onResetDelaySuccess);
-    AppsStore.once(AppsEvents.RESET_DELAY_ERROR,
+    QueueStore.once(QueueEvents.RESET_DELAY_ERROR,
       this.onResetDelayError);
   },
 


### PR DESCRIPTION
The code speaks for itself.

Doesn't need a changelog entry, bug was introduce recently by me.