### PR TITLE
Fix success button focus outline of danger and warning dialogs

### DIFF
--- a/src/css/components/modal.less
+++ b/src/css/components/modal.less
@@ -141,6 +141,14 @@
       &:hover {
         background-color: lighten(@modal-dialog-warning-color,10%);
         border-color: lighten(@modal-dialog-warning-color,10%);
+
+        &:focus{
+          outline-color: lighten(@modal-dialog-warning-color,10%);
+        }
+      }
+
+      &:focus{
+        outline-color: @modal-dialog-warning-color;
       }
     }
   }
@@ -161,6 +169,14 @@
       &:hover {
         background-color: lighten(@modal-dialog-danger-color,10%);
         border-color: lighten(@modal-dialog-danger-color,10%);
+
+        &:focus{
+          outline-color: lighten(@modal-dialog-danger-color,10%);
+        }
+      }
+
+      &:focus{
+        outline-color: @modal-dialog-danger-color;
       }
     }
   }


### PR DESCRIPTION
This changes the `:focus` and the `:hover:foucs` outline color to the same color of the background. It used to be blue like in the confirm dialogs.

![image](https://cloud.githubusercontent.com/assets/156010/12291104/92375b36-b9e5-11e5-87bb-68e745689e51.png)

![image](https://cloud.githubusercontent.com/assets/156010/12291173/0d8095be-b9e6-11e5-8572-093f12b6d78e.png)
