### PR TITLE
Fix JSDOM React initialization order

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "gulp-util": "^3.0.5",
     "gulp-zip": "^3.0.2",
     "ionicons": "^2.0.1",
+    "jsdom": "^6.5.1",
     "json-loader": "^0.5.2",
     "mocha": "^2.3.4",
     "mocha-teamcity-reporter": "0.0.4",
@@ -76,7 +77,7 @@
     "clean": "rm -rf dist release",
     "dist": "export GULP_ENV=\"production\" && npm run clean && npm run test && npm run build",
     "shrinkwrap": "npm-shrinkwrap --dev",
-    "test": "mocha --ui exports --reporter src/test/reporter/reporterSwitch --require babel-core/register --require babel-polyfill src/test/**/*.test.* src/test/*.test.*",
+    "test": "mocha --ui exports --reporter src/test/reporter/reporterSwitch --require babel-core/register --require babel-polyfill --require src/test/environment/jsdom  src/test/**/*.test.* src/test/*.test.*",
     "serve": "export GULP_ENV=\"development\" DISABLE_SOURCE_MAP=false && gulp serve",
     "livereload": "export GULP_ENV=\"development\" DISABLE_SOURCE_MAP=false && gulp livereload"
   }

--- a/src/test/appVersions.test.js
+++ b/src/test/appVersions.test.js
@@ -194,7 +194,7 @@ describe("AppVersions", function () {
 
 });
 
-describeWithDOM("App Version List component", function () {
+describe("App Version List component", function () {
 
   before(function () {
     AppVersionsStore.currentAppId = "/app-test";
@@ -225,7 +225,7 @@ describeWithDOM("App Version List component", function () {
 
 });
 
-describeWithDOM("App Version component", function () {
+describe("App Version component", function () {
 
   before(function () {
     this.model = {

--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -844,7 +844,7 @@ describe("Apps", function () {
 
   });
 
-  describeWithDOM("on app apply", function () {
+  describe("on app apply", function () {
 
     before(function (done) {
       var nockResponse = {
@@ -944,7 +944,7 @@ describe("Apps", function () {
 
 });
 
-describeWithDOM("Groups", function () {
+describe("Groups", function () {
 
   var apps = [
     {id: "/app-1", instances: 1, mem: 16, cpus: 1},
@@ -1166,7 +1166,7 @@ describe("App Health Bar", function () {
     });
   });
 
-  describeWithDOM("with tooltip", function () {
+  describe("with tooltip", function () {
     var PopoverComponent = require("../js/components/PopoverComponent");
 
     before(function () {

--- a/src/test/dialogs.test.js
+++ b/src/test/dialogs.test.js
@@ -918,7 +918,7 @@ describe("Dialog components", function () {
 
   });
 
-  describeWithDOM("prompt", function () {
+  describe("prompt", function () {
     var PromptDialogComponent =
       require("../js/components/PromptDialogComponent");
 

--- a/src/test/environment/jsdom.js
+++ b/src/test/environment/jsdom.js
@@ -1,0 +1,12 @@
+var jsdom = require("jsdom");
+
+const html = "<!doctype html><html><head></head><body></body></html>";
+
+global.document = jsdom.jsdom(html, {
+  globalize: true,
+  console: true,
+  useEach: false,
+  skipWindowCheck: false
+});
+global.window = document.defaultView;
+global.navigator = window.navigator;

--- a/src/test/info.test.js
+++ b/src/test/info.test.js
@@ -52,7 +52,7 @@ describe("Info", function () {
 
 });
 
-describeWithDOM("About Modal", function () {
+describe("About Modal", function () {
 
   before(function () {
     InfoStore.info = {


### PR DESCRIPTION
React's internals rely on a cached document at require time, which could result in errors if JSDOM isn't initialised before React is required. 

Therefore JSDOM is now initialized globally during test bootstrap using the mocha `--require` flag.   
This enables even more sophisticated test and resolve errors with components that conditionally rendered DOM nodes.  
Downside: It means the same JSDOM instance is used for all test. So please cleanup after your self!   
BTW: There is also no need to call `describeWithDOM` anymore as  JSDOM is already initialized.