### PR TITLE
Show correct host + port info

### DIFF
--- a/src/js/components/TaskListItemComponent.jsx
+++ b/src/js/components/TaskListItemComponent.jsx
@@ -74,9 +74,9 @@ var TaskListItemComponent = React.createClass({
   },
 
   getEndpoints: function () {
-    var task = this.props.task;
+    var app = AppsStore.getCurrentApp(this.props.appId);
 
-    if (task.ipAddresses == null) {
+    if (app.ipAddress == null) {
       return this.getHostAndPorts();
     }
 


### PR DESCRIPTION
This fixes https://github.com/mesosphere/marathon/issues/2972

The wrong assumption introduced in https://github.com/mesosphere/marathon-ui/pull/466 checked the `task` instead of the `app` to determine wether or not the task list item should render service discovery ports. 
As `task.ipAddresses` can be an empty array, a more solid approach is to check app.ipAddress directly.

#### Please Note
We should consider adding this to 0.14 (where the issue was introduced) and tag a new bugfix release.

<img width="895" alt="screen shot 2016-01-14 at 13 39 12" src="https://cloud.githubusercontent.com/assets/1078545/12324620/3b22588e-bac4-11e5-9cee-14193d42aab3.png">
