### PR TITLE
Fix - Vertical top align deployment item in deployment list

### DIFF
--- a/src/css/components/deployments.less
+++ b/src/css/components/deployments.less
@@ -4,11 +4,18 @@
  */
 
 .text-right.deployment-buttons {
-  vertical-align: middle;
+  vertical-align: top;
 
   .loading-bar {
     height: 10px;
     display: inline-block;
     width: 100%;
+  }
+}
+
+.deployments.table > tbody > tr {
+  > td {
+    padding-bottom: @base-spacing-unit;
+    vertical-align: top;
   }
 }

--- a/src/js/components/DeploymentsListComponent.jsx
+++ b/src/js/components/DeploymentsListComponent.jsx
@@ -168,7 +168,7 @@ var DeploymentListComponent = React.createClass({
 
     return (
       <div>
-        <table className="table table-fixed">
+        <table className="table table-fixed deployments">
           <colgroup>
             <col style={{width: "28%"}} />
             <col style={{width: "18%"}} />


### PR DESCRIPTION
This closes https://github.com/mesosphere/marathon/issues/2947

Needs no changelog entry, because recently introduced.

Before:
![before](https://cloud.githubusercontent.com/assets/859154/12328378/76cc9086-badb-11e5-9327-0dbc36799971.png)

After: 
![after](https://cloud.githubusercontent.com/assets/859154/12328381/7b0679c8-badb-11e5-9e1c-1c1238faef1f.png)

