### PR TITLE
Feature - add code coverage task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ npm-debug.log
 .idea/*
 
 src/js/config/config.dev.js
+coverage/

--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,0 +1,5 @@
+instrumentation:
+    root: src/js
+    extensions:
+        - .js
+        - .jsx

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_script:
 node_js:
   - "5.2.0"
 script: npm install && npm run dist
+after_success: npm run cover:report
 notifications:
   slack:
     secure: apUObVUa/OhaTEvoYw3oM1ZTTT0LtYolofJYqnWiBOusc6qgMlK2rfk5kod7vDn33cSKwGhFcyVrrFCn2qxuvYUWCpK4Yo6Hj7KIjoqMi9yHLHXAAWIfAFNMlCdaUGjlHLWn757rBkbuQUDVH8HmB6Vc3J3sybTbiFmMDP1cEVo=

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Stories in Ready](https://badge.waffle.io/mesosphere/marathon.png?label=ready,gui&title=Ready)](https://waffle.io/mesosphere/marathon?label=gui)
-# Marathon UI [![Build Status](https://travis-ci.org/mesosphere/marathon-ui.png?branch=master)](https://travis-ci.org/mesosphere/marathon-ui) [![Teamcity Snapshot UI Webjar Build Status](https://teamcity.mesosphere.io/app/rest/builds/buildType:%28id:Oss_Marathon_SnapshotUiWebjar%29/statusIcon)](https://teamcity.mesosphere.io/viewType.html?buildTypeId=Oss_Marathon_SnapshotUiWebjar&guest=1)
+# Marathon UI [![Build Status](https://travis-ci.org/mesosphere/marathon-ui.png?branch=master)](https://travis-ci.org/mesosphere/marathon-ui) [![Teamcity Snapshot UI Webjar Build Status](https://teamcity.mesosphere.io/app/rest/builds/buildType:%28id:Oss_Marathon_SnapshotUiWebjar%29/statusIcon)](https://teamcity.mesosphere.io/viewType.html?buildTypeId=Oss_Marathon_SnapshotUiWebjar&guest=1) [![Coverage Status](https://coveralls.io/repos/mesosphere/marathon-ui/badge.svg?branch=master&service=github)](https://coveralls.io/github/mesosphere/marathon-ui?branch=feature%2Fadd-code-coverage-task)
 
 ## The web user interface for Mesosphere's Marathon
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "git://github.com/mesosphere/marathon-ui.git"
   },
   "dependencies": {
-    "babel": "^5.6.14",
+    "babel-cli": "^6.4.0",
     "babel-polyfill": "^6.2.0",
     "classnames": "^2.1.2",
     "eslint": "^1.10.1",
@@ -61,6 +61,7 @@
     "gulp-zip": "^3.0.2",
     "ionicons": "^2.0.1",
     "jsdom": "^6.5.1",
+    "istanbul": "^1.0.0-alpha.2",
     "json-loader": "^0.5.2",
     "mocha": "^2.3.4",
     "mocha-teamcity-reporter": "0.0.4",
@@ -79,6 +80,9 @@
     "shrinkwrap": "npm-shrinkwrap --dev",
     "test": "mocha --ui exports --reporter src/test/reporter/reporterSwitch --require babel-core/register --require babel-polyfill --require src/test/environment/jsdom  src/test/**/*.test.* src/test/*.test.*",
     "serve": "export GULP_ENV=\"development\" DISABLE_SOURCE_MAP=false && gulp serve",
-    "livereload": "export GULP_ENV=\"development\" DISABLE_SOURCE_MAP=false && gulp livereload"
+    "livereload": "export GULP_ENV=\"development\" DISABLE_SOURCE_MAP=false && gulp livereload",
+    "cover:prepare": "rm -Rf coverage",
+    "cover:run": "babel-node ./node_modules/istanbul/lib/cli cover --include-all-sources true node_modules/mocha/bin/_mocha -- src/test/*.test.* src/test/**/*.test.*",
+    "cover": "npm run cover:prepare; npm run cover:run"
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "ionicons": "^2.0.1",
     "jsdom": "^6.5.1",
     "istanbul": "^1.0.0-alpha.2",
+    "istanbul-coveralls": "^1.0.3",
     "json-loader": "^0.5.2",
     "mocha": "^2.3.4",
     "mocha-teamcity-reporter": "0.0.4",
@@ -83,6 +84,7 @@
     "livereload": "export GULP_ENV=\"development\" DISABLE_SOURCE_MAP=false && gulp livereload",
     "cover:prepare": "rm -Rf coverage",
     "cover:run": "babel-node ./node_modules/istanbul/lib/cli cover --include-all-sources true node_modules/mocha/bin/_mocha -- src/test/*.test.* src/test/**/*.test.*",
+    "cover:report": "npm run cover; istanbul-coveralls",
     "cover": "npm run cover:prepare; npm run cover:run"
   }
 }

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "serve": "export GULP_ENV=\"development\" DISABLE_SOURCE_MAP=false && gulp serve",
     "livereload": "export GULP_ENV=\"development\" DISABLE_SOURCE_MAP=false && gulp livereload",
     "cover:prepare": "rm -Rf coverage",
-    "cover:run": "babel-node ./node_modules/istanbul/lib/cli cover --include-all-sources true node_modules/mocha/bin/_mocha -- src/test/*.test.* src/test/**/*.test.*",
+    "cover:run": "babel-node ./node_modules/istanbul/lib/cli cover --include-all-sources true node_modules/mocha/bin/_mocha -- --require src/test/environment/jsdom src/test/*.test.* src/test/**/*.test.*",
     "cover:report": "npm run cover; istanbul-coveralls",
     "cover": "npm run cover:prepare; npm run cover:run"
   }


### PR DESCRIPTION
# Introduction
Adds Code coverage via Istanbul to the project, also adds a Badge to the readme displaying current master code coverage.

The Coverage report can be generated locally with

```bash
npm run cover
```

The report will be generated as lcov.info + html. This may come in handy when we want to see which lines are not tested and which are. They are generated into the coverage folder.

On travis the report is generated with the `after_success` event which will only be triggered if the build was successful. After the report has been generated on Travis the report will then be uploaded to coveralls with `istanbul-coveralls`. As this is travis we do not need to include a token.

## A short overview to the new or updated modules.
**babel => babel-cli**: We are already using babel-core and other babel modules. Babel is the old babel 5 version which contained all babel modules in one module. That's why a switch to `babel-cli` was necessary as with babel 6 a lot of breaking changes were introduced. The one which was blocking this feature was that the configuration in the .babel.rc file has been changed.

**istanbul v1.alpha2**: Including the alpha of v1 because v1 is far better for the use with babel earlier version were always breaking. Also the Author of Istanbul [gotwarlost ](http://www.github.com/gotwarlost) recommends this way.

**istanbul-coveralls**: Is a upload script which uploads the `lcov.info` to coveralls. 

## new scripts
`cover`: Generates the coverage report runs `cover:prepare` and `cover:run`.
`cover:prepare`: clears the coverage directory.
`cover:run`: this runs istanbul and generates the report.
`cover:report`: runs `cover` and after that `istanbul-coveralls`