### PR TITLE
Refactor/convert commonjs to es6 modules

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@ var gutil = require("gulp-util");
 var less = require("gulp-less");
 var minifyCSS = require("gulp-minify-css");
 var path = require("path");
+var fs = require("fs");
 var replace = require("gulp-replace");
 var uglify = require("gulp-uglify");
 var webpack = require("webpack");
@@ -40,8 +41,17 @@ var files = {
 };
 
 var webpackWatch = false;
+var configFilePath = path.resolve(dirs.js + "/config/config.js");
 if (process.env.GULP_ENV === "development") {
   webpackWatch = true;
+  try {
+    var devConfigFilePath = path.resolve(dirs.js + "/config/config.dev.js");
+    fs.accessSync(devConfigFilePath);
+    configFilePath = devConfigFilePath;
+  } catch (e) {
+    console.info("You could copy config.template.js to config.dev.js " +
+      "to enable a development configuration.");
+  }
 }
 
 var webpackConfig = {
@@ -83,6 +93,13 @@ var webpackConfig = {
       }
     ]
   },
+  plugins: [
+    new webpack.NormalModuleReplacementPlugin(/\/config\/config(\.js)?$/,
+      function (result) {
+        result.request = configFilePath;
+      }
+    )
+  ],
   resolve: {
     extensions: ["", ".jsx", ".js"]
   },

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,6 @@
 var autoprefixer = require("gulp-autoprefixer");
 var connect = require("gulp-connect");
-var header = require('gulp-header');
+var header = require("gulp-header");
 var browserSync = require("browser-sync");
 var eslintFormatter = require("eslint/lib/formatters/stylish");
 var gulp = require("gulp");
@@ -176,7 +176,7 @@ gulp.task("minify-js", ["webpack"], function () {
 
   return gulp.src(dirs.dist + "/" + files.mainJs + ".js")
     .pipe(uglify())
-    .pipe(header(banner, { pkg : packageInfo } ))
+    .pipe(header(banner, {pkg : packageInfo}))
     .pipe(gulp.dest(dirs.dist));
 });
 
@@ -187,10 +187,10 @@ gulp.task("images", function () {
 
 gulp.task("fonts", function () {
   return gulp.src([
-      dirs.ionicons + "/**/*.*",
-      dirs.sourceSansPro + "/" + files.sourceSansPro,
-      dirs.sourceSansPro + "/" + files.sourceSansProBold
-    ]).pipe(gulp.dest(dirs.dist + "/" + dirs.fontsDist));
+    dirs.ionicons + "/**/*.*",
+    dirs.sourceSansPro + "/" + files.sourceSansPro,
+    dirs.sourceSansPro + "/" + files.sourceSansProBold
+  ]).pipe(gulp.dest(dirs.dist + "/" + dirs.fontsDist));
 });
 
 gulp.task("index", function () {

--- a/src/js/AppDispatcher.js
+++ b/src/js/AppDispatcher.js
@@ -1,9 +1,10 @@
-var dispatcher = new (require("flux").Dispatcher)();
+import {Dispatcher} from "flux";
 
+var dispatcher = new Dispatcher();
 dispatcher.dispatchNext = function (obj) {
   setTimeout(function () {
     dispatcher.dispatch(obj);
   });
 };
 
-module.exports = dispatcher;
+export default dispatcher;

--- a/src/js/actions/AppVersionsActions.js
+++ b/src/js/actions/AppVersionsActions.js
@@ -1,6 +1,7 @@
 import ajaxWrapper from "../helpers/ajaxWrapper";
 
 import config from "../config/config";
+
 import AppDispatcher from "../AppDispatcher";
 import AppVersionsEvents from "../events/AppVersionsEvents";
 

--- a/src/js/actions/AppVersionsActions.js
+++ b/src/js/actions/AppVersionsActions.js
@@ -1,8 +1,8 @@
-var ajaxWrapper = require("../helpers/ajaxWrapper");
+import ajaxWrapper from "../helpers/ajaxWrapper";
 
-var config = require("../config/config");
-var AppDispatcher = require("../AppDispatcher");
-var AppVersionsEvents = require("../events/AppVersionsEvents");
+import config from "../config/config";
+import AppDispatcher from "../AppDispatcher";
+import AppVersionsEvents from "../events/AppVersionsEvents";
 
 var AppVersionsActions = {
   requestAppVersions: function (appId) {
@@ -48,4 +48,4 @@ var AppVersionsActions = {
   request: ajaxWrapper
 };
 
-module.exports = AppVersionsActions;
+export default AppVersionsActions;

--- a/src/js/actions/AppsActions.js
+++ b/src/js/actions/AppsActions.js
@@ -1,6 +1,7 @@
 import ajaxWrapper from "../helpers/ajaxWrapper";
 
 import config from "../config/config";
+
 import AppDispatcher from "../AppDispatcher";
 import AppsEvents from "../events/AppsEvents";
 

--- a/src/js/actions/AppsActions.js
+++ b/src/js/actions/AppsActions.js
@@ -1,8 +1,8 @@
-var ajaxWrapper = require("../helpers/ajaxWrapper");
+import ajaxWrapper from "../helpers/ajaxWrapper";
 
-var config = require("../config/config");
-var AppDispatcher = require("../AppDispatcher");
-var AppsEvents = require("../events/AppsEvents");
+import config from "../config/config";
+import AppDispatcher from "../AppDispatcher";
+import AppsEvents from "../events/AppsEvents";
 
 var AppsActions = {
   requestApps: function () {
@@ -187,4 +187,4 @@ var AppsActions = {
   request: ajaxWrapper
 };
 
-module.exports = AppsActions;
+export default AppsActions;

--- a/src/js/actions/DCOSActions.js
+++ b/src/js/actions/DCOSActions.js
@@ -1,6 +1,6 @@
-var AppDispatcher = require("../AppDispatcher");
-var ajaxWrapper = require("../helpers/ajaxWrapper");
-var DCOSEvents = require("../events/DCOSEvents");
+import AppDispatcher from "../AppDispatcher";
+import ajaxWrapper from "../helpers/ajaxWrapper";
+import DCOSEvents from "../events/DCOSEvents";
 
 var DCOSActions = {
   requestBuildInformation: function (host) {
@@ -21,4 +21,4 @@ var DCOSActions = {
   request: ajaxWrapper
 };
 
-module.exports = DCOSActions;
+export default DCOSActions;

--- a/src/js/actions/DeploymentActions.js
+++ b/src/js/actions/DeploymentActions.js
@@ -1,6 +1,7 @@
 import ajaxWrapper from "../helpers/ajaxWrapper";
 
 import config from "../config/config";
+
 import AppDispatcher from "../AppDispatcher";
 import DeploymentEvents from "../events/DeploymentEvents";
 

--- a/src/js/actions/DeploymentActions.js
+++ b/src/js/actions/DeploymentActions.js
@@ -1,8 +1,8 @@
-var ajaxWrapper = require("../helpers/ajaxWrapper");
+import ajaxWrapper from "../helpers/ajaxWrapper";
 
-var config = require("../config/config");
-var AppDispatcher = require("../AppDispatcher");
-var DeploymentEvents = require("../events/DeploymentEvents");
+import config from "../config/config";
+import AppDispatcher from "../AppDispatcher";
+import DeploymentEvents from "../events/DeploymentEvents";
 
 var DeploymentActions = {
   requestDeployments: function () {
@@ -63,4 +63,4 @@ var DeploymentActions = {
   request: ajaxWrapper
 };
 
-module.exports = DeploymentActions;
+export default DeploymentActions;

--- a/src/js/actions/DialogActions.js
+++ b/src/js/actions/DialogActions.js
@@ -1,8 +1,8 @@
-var Util = require("../helpers/Util");
-var AppDispatcher = require("../AppDispatcher");
-var DialogEvents = require("../events/DialogEvents");
-var DialogTypes = require("../constants/DialogTypes");
-var dialogScheme = require("../stores/schemes/dialogScheme");
+import Util from "../helpers/Util";
+import AppDispatcher from "../AppDispatcher";
+import DialogEvents from "../events/DialogEvents";
+import DialogTypes from "../constants/DialogTypes";
+import dialogScheme from "../stores/schemes/dialogScheme";
 
 function showDialog(data) {
   var dialog = Util.extendObject(dialogScheme, data,
@@ -86,4 +86,4 @@ var DialogActions = {
   }
 };
 
-module.exports = DialogActions;
+export default DialogActions;

--- a/src/js/actions/FormActions.js
+++ b/src/js/actions/FormActions.js
@@ -1,5 +1,5 @@
-var AppDispatcher = require("../AppDispatcher");
-var FormsEvents = require("../events/FormEvents");
+import AppDispatcher from "../AppDispatcher";
+import FormsEvents from "../events/FormEvents";
 
 var FormActions = {
   insert: function (fieldId, value, index = null) {
@@ -28,4 +28,4 @@ var FormActions = {
   }
 };
 
-module.exports = FormActions;
+export default FormActions;

--- a/src/js/actions/GroupsActions.js
+++ b/src/js/actions/GroupsActions.js
@@ -1,8 +1,8 @@
-var ajaxWrapper = require("../helpers/ajaxWrapper");
+import ajaxWrapper from "../helpers/ajaxWrapper";
 
-var config = require("../config/config");
-var AppDispatcher = require("../AppDispatcher");
-var GroupsEvents = require("../events/GroupsEvents");
+import config from "../config/config";
+import AppDispatcher from "../AppDispatcher";
+import GroupsEvents from "../events/GroupsEvents";
 
 var GroupsActions = {
   scaleGroup: function (groupId, scaleBy) {
@@ -50,4 +50,4 @@ var GroupsActions = {
   request: ajaxWrapper
 };
 
-module.exports = GroupsActions;
+export default GroupsActions;

--- a/src/js/actions/GroupsActions.js
+++ b/src/js/actions/GroupsActions.js
@@ -1,6 +1,7 @@
 import ajaxWrapper from "../helpers/ajaxWrapper";
 
 import config from "../config/config";
+
 import AppDispatcher from "../AppDispatcher";
 import GroupsEvents from "../events/GroupsEvents";
 

--- a/src/js/actions/InfoActions.js
+++ b/src/js/actions/InfoActions.js
@@ -1,6 +1,7 @@
 import ajaxWrapper from "../helpers/ajaxWrapper";
 
 import config from "../config/config";
+
 import AppDispatcher from "../AppDispatcher";
 import InfoEvents from "../events/InfoEvents";
 

--- a/src/js/actions/InfoActions.js
+++ b/src/js/actions/InfoActions.js
@@ -1,8 +1,8 @@
-var ajaxWrapper = require("../helpers/ajaxWrapper");
+import ajaxWrapper from "../helpers/ajaxWrapper";
 
-var config = require("../config/config");
-var AppDispatcher = require("../AppDispatcher");
-var InfoEvents = require("../events/InfoEvents");
+import config from "../config/config";
+import AppDispatcher from "../AppDispatcher";
+import InfoEvents from "../events/InfoEvents";
 
 var InfoActions = {
   requestInfo: function () {
@@ -25,4 +25,4 @@ var InfoActions = {
   request: ajaxWrapper
 };
 
-module.exports = InfoActions;
+export default InfoActions;

--- a/src/js/actions/MesosActions.js
+++ b/src/js/actions/MesosActions.js
@@ -1,8 +1,8 @@
-var semver = require("semver");
+import semver from "semver";
 
-var AppDispatcher = require("../AppDispatcher");
-var JSONPUtil = require("../helpers/JSONPUtil");
-var MesosEvents = require("../events/MesosEvents");
+import AppDispatcher from "../AppDispatcher";
+import JSONPUtil from "../helpers/JSONPUtil";
+import MesosEvents from "../events/MesosEvents";
 
 var MesosActions = {
   requestVersionInformation: function (host) {
@@ -76,4 +76,4 @@ var MesosActions = {
   request: JSONPUtil.request
 };
 
-module.exports = MesosActions;
+export default MesosActions;

--- a/src/js/actions/QueueActions.js
+++ b/src/js/actions/QueueActions.js
@@ -1,8 +1,8 @@
-var ajaxWrapper = require("../helpers/ajaxWrapper");
+import ajaxWrapper from "../helpers/ajaxWrapper";
 
-var config = require("../config/config");
-var AppDispatcher = require("../AppDispatcher");
-var QueueEvents = require("../events/QueueEvents");
+import config from "../config/config";
+import AppDispatcher from "../AppDispatcher";
+import QueueEvents from "../events/QueueEvents";
 
 var QueueActions = {
   requestQueue: function () {
@@ -44,4 +44,4 @@ var QueueActions = {
   request: ajaxWrapper
 };
 
-module.exports = QueueActions;
+export default QueueActions;

--- a/src/js/actions/QueueActions.js
+++ b/src/js/actions/QueueActions.js
@@ -1,6 +1,7 @@
 import ajaxWrapper from "../helpers/ajaxWrapper";
 
 import config from "../config/config";
+
 import AppDispatcher from "../AppDispatcher";
 import QueueEvents from "../events/QueueEvents";
 

--- a/src/js/actions/TasksActions.js
+++ b/src/js/actions/TasksActions.js
@@ -1,6 +1,7 @@
 import ajaxWrapper from "../helpers/ajaxWrapper";
 
 import config from "../config/config";
+
 import AppDispatcher from "../AppDispatcher";
 import TasksEvents from "../events/TasksEvents";
 

--- a/src/js/actions/TasksActions.js
+++ b/src/js/actions/TasksActions.js
@@ -1,8 +1,8 @@
-var ajaxWrapper = require("../helpers/ajaxWrapper");
+import ajaxWrapper from "../helpers/ajaxWrapper";
 
-var config = require("../config/config");
-var AppDispatcher = require("../AppDispatcher");
-var TasksEvents = require("../events/TasksEvents");
+import config from "../config/config";
+import AppDispatcher from "../AppDispatcher";
+import TasksEvents from "../events/TasksEvents";
 
 var TasksActions = {
   deleteTasks: function (appId, taskIds = []) {
@@ -57,4 +57,4 @@ var TasksActions = {
   request: ajaxWrapper
 };
 
-module.exports = TasksActions;
+export default TasksActions;

--- a/src/js/components/AlertDialogComponent.jsx
+++ b/src/js/components/AlertDialogComponent.jsx
@@ -1,9 +1,9 @@
-var React = require("react/addons");
-var classNames = require("classnames");
+import React from "react/addons";
+import classNames from "classnames";
 
-var DialogSeverity = require("../constants/DialogSeverity");
-var Util = require("../helpers/Util");
-var ModalComponent = require("../components/ModalComponent");
+import DialogSeverity from "../constants/DialogSeverity";
+import Util from "../helpers/Util";
+import ModalComponent from "../components/ModalComponent";
 
 var AlertDialogComponent = React.createClass({
   displayName: "AlertDialogComponent",
@@ -64,4 +64,4 @@ var AlertDialogComponent = React.createClass({
   }
 });
 
-module.exports = AlertDialogComponent;
+export default AlertDialogComponent;

--- a/src/js/components/AppDebugInfoComponent.jsx
+++ b/src/js/components/AppDebugInfoComponent.jsx
@@ -1,14 +1,12 @@
-var React = require("react/addons");
-var Moment = require("moment");
+import React from "react/addons";
+import Moment from "moment";
 
-var AppsStore = require("../stores/AppsStore");
-var AppsActions = require("../actions/AppsActions");
-var AppsEvents = require("../events/AppsEvents");
-var AppTaskStatsListComponent =
-  require("../components/AppTaskStatsListComponent");
-var TaskMesosUrlComponent = require("../components/TaskMesosUrlComponent");
-var UnspecifiedNodeComponent =
-  require("../components/UnspecifiedNodeComponent");
+import AppsStore from "../stores/AppsStore";
+import AppsActions from "../actions/AppsActions";
+import AppsEvents from "../events/AppsEvents";
+import AppTaskStatsListComponent from "../components/AppTaskStatsListComponent";
+import TaskMesosUrlComponent from "../components/TaskMesosUrlComponent";
+import UnspecifiedNodeComponent from "../components/UnspecifiedNodeComponent";
 
 function invalidateValue(value, suffix) {
   if (value == null || value === "") {
@@ -170,4 +168,4 @@ var AppDebugInfoComponent = React.createClass({
   }
 });
 
-module.exports = AppDebugInfoComponent;
+export default AppDebugInfoComponent;

--- a/src/js/components/AppHealthBarComponent.jsx
+++ b/src/js/components/AppHealthBarComponent.jsx
@@ -1,6 +1,6 @@
-var classNames = require("classnames");
-var React = require("react/addons");
-var AppStatus = require("../constants/AppStatus");
+import classNames from "classnames";
+import React from "react/addons";
+import AppStatus from "../constants/AppStatus";
 
 function roundWorkaround(x) {
   return Math.floor(x * 1000) / 1000;
@@ -64,4 +64,4 @@ var AppHealthBarComponent = React.createClass({
 
 });
 
-module.exports = AppHealthBarComponent;
+export default AppHealthBarComponent;

--- a/src/js/components/AppHealthBarWithTooltipComponent.jsx
+++ b/src/js/components/AppHealthBarWithTooltipComponent.jsx
@@ -1,10 +1,10 @@
-var React = require("react/addons");
+import React from "react/addons";
 
-var AppHealthBarComponent = require("./AppHealthBarComponent");
-var AppHealthDetailComponent = require("./AppHealthDetailComponent");
-var PopoverComponent = require("./PopoverComponent");
-var Util = require("../helpers/Util");
-var HealthStatus = require("../constants/HealthStatus");
+import AppHealthBarComponent from "./AppHealthBarComponent";
+import AppHealthDetailComponent from "./AppHealthDetailComponent";
+import PopoverComponent from "./PopoverComponent";
+import Util from "../helpers/Util";
+import HealthStatus from "../constants/HealthStatus";
 
 var AppHealthBarWithTooltipComponent = React.createClass({
   displayName: "AppHealthBarWithTooltipComponent",
@@ -62,4 +62,4 @@ var AppHealthBarWithTooltipComponent = React.createClass({
   }
 });
 
-module.exports = AppHealthBarWithTooltipComponent;
+export default AppHealthBarWithTooltipComponent;

--- a/src/js/components/AppHealthDetailComponent.jsx
+++ b/src/js/components/AppHealthDetailComponent.jsx
@@ -1,7 +1,7 @@
-var classNames = require("classnames");
-var React = require("react/addons");
+import classNames from "classnames";
+import React from "react/addons";
 
-var HealthStatus = require("../constants/HealthStatus");
+import HealthStatus from "../constants/HealthStatus";
 
 var healthStatusLabels = {
   [HealthStatus.HEALTHY]: "Healthy",
@@ -83,4 +83,4 @@ var AppHealthDetailComponent = React.createClass({
 
 });
 
-module.exports = AppHealthDetailComponent;
+export default AppHealthDetailComponent;

--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -1,22 +1,22 @@
-var classNames = require("classnames");
-var lazy = require("lazy.js");
-var Link = require("react-router").Link;
-var React = require("react/addons");
+import classNames from "classnames";
+import lazy from "lazy.js";
+import {Link} from "react-router";
+import React from "react/addons";
 
-var AppListViewTypes = require("../constants/AppListViewTypes");
-var AppStatus = require("../constants/AppStatus");
-var FilterTypes = require("../constants/FilterTypes");
-var HealthStatus = require("../constants/HealthStatus");
-var Messages = require("../constants/Messages");
-var States = require("../constants/States");
-var AppListItemComponent = require("./AppListItemComponent");
-var CenteredInlineDialogComponent = require("./CenteredInlineDialogComponent");
+import AppListViewTypes from "../constants/AppListViewTypes";
+import AppStatus from "../constants/AppStatus";
+import FilterTypes from "../constants/FilterTypes";
+import HealthStatus from "../constants/HealthStatus";
+import Messages from "../constants/Messages";
+import States from "../constants/States";
+import AppListItemComponent from "./AppListItemComponent";
+import CenteredInlineDialogComponent from "./CenteredInlineDialogComponent";
 
-var AppsActions = require("../actions/AppsActions");
-var AppsStore = require("../stores/AppsStore");
-var AppsEvents = require("../events/AppsEvents");
+import AppsActions from "../actions/AppsActions";
+import AppsStore from "../stores/AppsStore";
+import AppsEvents from "../events/AppsEvents";
 
-var Util = require("../helpers/Util");
+import Util from "../helpers/Util";
 
 function getGroupStatus(groupStatus, appStatus) {
   if (appStatus === AppStatus.DEPLOYING ||
@@ -516,4 +516,4 @@ var AppListComponent = React.createClass({
   }
 });
 
-module.exports = AppListComponent;
+export default AppListComponent;

--- a/src/js/components/AppListFilterComponent.jsx
+++ b/src/js/components/AppListFilterComponent.jsx
@@ -1,10 +1,10 @@
-var classNames = require("classnames");
-var React = require("react/addons");
-var Mousetrap = require("mousetrap");
+import classNames from "classnames";
+import React from "react/addons";
+import Mousetrap from "mousetrap";
 
-var FilterTypes = require("../constants/FilterTypes");
+import FilterTypes from "../constants/FilterTypes";
 
-var QueryParamsMixin = require("../mixins/QueryParamsMixin");
+import QueryParamsMixin from "../mixins/QueryParamsMixin";
 
 var AppListFilterComponent = React.createClass({
   displayName: "AppListFilterComponent",
@@ -143,4 +143,4 @@ var AppListFilterComponent = React.createClass({
   }
 });
 
-module.exports = AppListFilterComponent;
+export default AppListFilterComponent;

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -1,20 +1,20 @@
-var classNames = require("classnames");
-var React = require("react/addons");
-var OnClickOutsideMixin = require("react-onclickoutside");
+import classNames from "classnames";
+import React from "react/addons";
+import OnClickOutsideMixin from "react-onclickoutside";
 
-var AppActionsHandlerMixin = require("../mixins/AppActionsHandlerMixin");
-var AppHealthBarWithTooltipComponent =
-  require("./AppHealthBarWithTooltipComponent");
-var AppListItemLabelsComponent =
-  require("../components/AppListItemLabelsComponent");
-var AppListViewTypes = require("../constants/AppListViewTypes");
-var AppStatus = require("../constants/AppStatus");
-var AppStatusComponent = require("../components/AppStatusComponent");
-var BreadcrumbComponent = require("../components/BreadcrumbComponent");
-var Util = require("../helpers/Util");
-var PathUtil = require("../helpers/PathUtil");
-var PopoverComponent = require("./PopoverComponent");
-var DOMUtil = require("../helpers/DOMUtil");
+import AppActionsHandlerMixin from "../mixins/AppActionsHandlerMixin";
+import AppHealthBarWithTooltipComponent
+  from "./AppHealthBarWithTooltipComponent";
+import AppListItemLabelsComponent
+  from "../components/AppListItemLabelsComponent";
+import AppListViewTypes from "../constants/AppListViewTypes";
+import AppStatus from "../constants/AppStatus";
+import AppStatusComponent from "../components/AppStatusComponent";
+import BreadcrumbComponent from "../components/BreadcrumbComponent";
+import Util from "../helpers/Util";
+import PathUtil from "../helpers/PathUtil";
+import PopoverComponent from "./PopoverComponent";
+import DOMUtil from "../helpers/DOMUtil";
 
 var AppListItemComponent = React.createClass({
   displayName: "AppListItemComponent",
@@ -367,4 +367,4 @@ var AppListItemComponent = React.createClass({
   }
 });
 
-module.exports = AppListItemComponent;
+export default AppListItemComponent;

--- a/src/js/components/AppListItemLabelsComponent.jsx
+++ b/src/js/components/AppListItemLabelsComponent.jsx
@@ -1,10 +1,10 @@
-var classNames = require("classnames");
-var React = require("react/addons");
+import classNames from "classnames";
+import React from "react/addons";
 
-var PopoverComponent = require("./PopoverComponent");
+import PopoverComponent from "./PopoverComponent";
 
-var OnClickOutsideMixin = require("react-onclickoutside");
-var Util = require("../helpers/Util");
+import OnClickOutsideMixin from "react-onclickoutside";
+import Util from "../helpers/Util";
 
 // Keep track of post-render initial margin value, on a per-reactid basis
 var _initialTopMargins = [];
@@ -120,4 +120,4 @@ var AppListItemLabelsComponent = React.createClass({
   }
 });
 
-module.exports = AppListItemLabelsComponent;
+export default AppListItemLabelsComponent;

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -1,30 +1,30 @@
-var React = require("react/addons");
+import React from "react/addons";
 
-var AppsActions = require("../actions/AppsActions");
-var AppsEvents = require("../events/AppsEvents");
-var AppsStore = require("../stores/AppsStore");
-var BreadcrumbComponent = require("../components/BreadcrumbComponent");
-var AppHealthBarComponent = require("./AppHealthBarComponent");
-var AppPageControlsComponent = require("./AppPageControlsComponent");
-var AppStatusComponent = require("../components/AppStatusComponent");
-var AppVersionsActions = require("../actions/AppVersionsActions");
-var AppDebugInfoComponent = require("../components/AppDebugInfoComponent");
-var AppVersionListComponent = require("../components/AppVersionListComponent");
-var DialogActions = require("../actions/DialogActions");
-var DialogStore = require("../stores/DialogStore");
-var DialogSeverity = require("../constants/DialogSeverity");
-var HealthStatus = require("../constants/HealthStatus");
-var Messages = require("../constants/Messages");
-var States = require("../constants/States");
-var TabPaneComponent = require("../components/TabPaneComponent");
-var TaskDetailComponent = require("../components/TaskDetailComponent");
-var TaskViewComponent = require("../components/TaskViewComponent");
-var AppHealthDetailComponent = require("./AppHealthDetailComponent");
-var TogglableTabsComponent = require("../components/TogglableTabsComponent");
-var Util = require("../helpers/Util");
-var PathUtil = require("../helpers/PathUtil");
-var TasksActions = require("../actions/TasksActions");
-var TasksEvents = require("../events/TasksEvents");
+import AppsActions from "../actions/AppsActions";
+import AppsEvents from "../events/AppsEvents";
+import AppsStore from "../stores/AppsStore";
+import BreadcrumbComponent from "../components/BreadcrumbComponent";
+import AppHealthBarComponent from "./AppHealthBarComponent";
+import AppPageControlsComponent from "./AppPageControlsComponent";
+import AppStatusComponent from "../components/AppStatusComponent";
+import AppVersionsActions from "../actions/AppVersionsActions";
+import AppDebugInfoComponent from "../components/AppDebugInfoComponent";
+import AppVersionListComponent from "../components/AppVersionListComponent";
+import DialogActions from "../actions/DialogActions";
+import DialogStore from "../stores/DialogStore";
+import DialogSeverity from "../constants/DialogSeverity";
+import HealthStatus from "../constants/HealthStatus";
+import Messages from "../constants/Messages";
+import States from "../constants/States";
+import TabPaneComponent from "../components/TabPaneComponent";
+import TaskDetailComponent from "../components/TaskDetailComponent";
+import TaskViewComponent from "../components/TaskViewComponent";
+import AppHealthDetailComponent from "./AppHealthDetailComponent";
+import TogglableTabsComponent from "../components/TogglableTabsComponent";
+import Util from "../helpers/Util";
+import PathUtil from "../helpers/PathUtil";
+import TasksActions from "../actions/TasksActions";
+import TasksEvents from "../events/TasksEvents";
 
 var tabsTemplate = [
   {id: "apps/:appId", text: "Instances"},
@@ -350,4 +350,4 @@ var AppPageComponent = React.createClass({
   }
 });
 
-module.exports = AppPageComponent;
+export default AppPageComponent;

--- a/src/js/components/AppPageControlsComponent.jsx
+++ b/src/js/components/AppPageControlsComponent.jsx
@@ -1,9 +1,9 @@
-var classNames = require("classnames");
-var OnClickOutsideMixin = require("react-onclickoutside");
-var React = require("react");
+import classNames from "classnames";
+import OnClickOutsideMixin from "react-onclickoutside";
+import React from "react";
 
-var AppActionsHandlerMixin = require("../mixins/AppActionsHandlerMixin");
-var AppStatus = require("../constants/AppStatus");
+import AppActionsHandlerMixin from "../mixins/AppActionsHandlerMixin";
+import AppStatus from "../constants/AppStatus";
 
 var AppPageControlsComponent = React.createClass({
 
@@ -97,4 +97,4 @@ var AppPageControlsComponent = React.createClass({
   }
 });
 
-module.exports = AppPageControlsComponent;
+export default AppPageControlsComponent;

--- a/src/js/components/AppStatusComponent.jsx
+++ b/src/js/components/AppStatusComponent.jsx
@@ -1,12 +1,12 @@
-var classNames = require("classnames");
-var moment = require("moment");
-var React = require("react/addons");
+import classNames from "classnames";
+import moment from "moment";
+import React from "react/addons";
 
-var AppStatus = require("../constants/AppStatus");
-var QueueStore = require("../stores/QueueStore");
-var Util = require("../helpers/Util");
+import AppStatus from "../constants/AppStatus";
+import QueueStore from "../stores/QueueStore";
+import Util from "../helpers/Util";
 
-var statusNameMapping = require("../constants/LabelMapping").statusNameMapping;
+import {statusNameMapping} from "../constants/LabelMapping";
 
 var statusClassNameMapping = {
   [AppStatus.RUNNING]: "running",
@@ -83,4 +83,4 @@ var AppStatusComponent = React.createClass({
   }
 });
 
-module.exports = AppStatusComponent;
+export default AppStatusComponent;

--- a/src/js/components/AppTaskStatsComponent.jsx
+++ b/src/js/components/AppTaskStatsComponent.jsx
@@ -1,6 +1,6 @@
-var classNames = require("classnames");
-var React = require("react/addons");
-var Moment = require("moment");
+import classNames from "classnames";
+import React from "react/addons";
+import Moment from "moment";
 
 var AppTaskStatsComponent = React.createClass({
   displayName: "AppTaskStatsComponent",
@@ -132,4 +132,4 @@ var AppTaskStatsComponent = React.createClass({
   }
 });
 
-module.exports = AppTaskStatsComponent;
+export default AppTaskStatsComponent;

--- a/src/js/components/AppTaskStatsListComponent.jsx
+++ b/src/js/components/AppTaskStatsListComponent.jsx
@@ -1,6 +1,6 @@
-var React = require("react/addons");
+import React from "react/addons";
 
-var AppTaskStatsComponent = require("../components/AppTaskStatsComponent");
+import AppTaskStatsComponent from "../components/AppTaskStatsComponent";
 
 const keyCaptionMap = {
   startedAfterLastScaling: "Started After Last Scaling",
@@ -66,4 +66,4 @@ var AppTaskStatsListComponent = React.createClass({
   }
 });
 
-module.exports = AppTaskStatsListComponent;
+export default AppTaskStatsListComponent;

--- a/src/js/components/AppVersionComponent.jsx
+++ b/src/js/components/AppVersionComponent.jsx
@@ -1,14 +1,13 @@
-var classNames = require("classnames");
-var highlight = require("highlight.js");
-var Link = require("react-router").Link;
-var React = require("react/addons");
-var url = require("url");
+import classNames from "classnames";
+import highlight from "highlight.js";
+import {Link} from "react-router";
+import React from "react/addons";
+import url from "url";
 
-var AppsActions = require("../actions/AppsActions");
-var AppsEvents = require("../events/AppsEvents");
-var AppsStore = require("../stores/AppsStore");
-var UnspecifiedNodeComponent =
-  require("../components/UnspecifiedNodeComponent");
+import AppsActions from "../actions/AppsActions";
+import AppsEvents from "../events/AppsEvents";
+import AppsStore from "../stores/AppsStore";
+import UnspecifiedNodeComponent from "../components/UnspecifiedNodeComponent";
 
 function invalidateValue(value, suffix) {
   if (value == null) {
@@ -282,4 +281,4 @@ var AppVersionComponent = React.createClass({
   }
 });
 
-module.exports = AppVersionComponent;
+export default AppVersionComponent;

--- a/src/js/components/AppVersionListComponent.jsx
+++ b/src/js/components/AppVersionListComponent.jsx
@@ -1,19 +1,19 @@
-var classNames = require("classnames");
-var React = require("react/addons");
+import classNames from "classnames";
+import React from "react/addons";
 
-var States = require("../constants/States");
-var AppsStore = require("../stores/AppsStore");
-var AppVersionsActions = require("../actions/AppVersionsActions");
-var AppsEvents = require("../events/AppsEvents");
-var AppVersionsEvents = require("../events/AppVersionsEvents");
-var AppVersionsStore = require("../stores/AppVersionsStore");
-var AppVersionComponent = require("../components/AppVersionComponent");
-var AppVersionListItemComponent =
-  require("../components/AppVersionListItemComponent");
-var DialogActions = require("../actions/DialogActions");
-var DialogSeverity = require("../constants/DialogSeverity");
-var PagedContentComponent = require("../components/PagedContentComponent");
-var PagedNavComponent = require("../components/PagedNavComponent");
+import States from "../constants/States";
+import AppsStore from "../stores/AppsStore";
+import AppVersionsActions from "../actions/AppVersionsActions";
+import AppsEvents from "../events/AppsEvents";
+import AppVersionsEvents from "../events/AppVersionsEvents";
+import AppVersionsStore from "../stores/AppVersionsStore";
+import AppVersionComponent from "../components/AppVersionComponent";
+import AppVersionListItemComponent
+  from "../components/AppVersionListItemComponent";
+import DialogActions from "../actions/DialogActions";
+import DialogSeverity from "../constants/DialogSeverity";
+import PagedContentComponent from "../components/PagedContentComponent";
+import PagedNavComponent from "../components/PagedNavComponent";
 
 var AppVersionListComponent = React.createClass({
   displayName: "AppVersionListComponent",
@@ -201,4 +201,4 @@ var AppVersionListComponent = React.createClass({
   }
 });
 
-module.exports = AppVersionListComponent;
+export default AppVersionListComponent;

--- a/src/js/components/AppVersionListItemComponent.jsx
+++ b/src/js/components/AppVersionListItemComponent.jsx
@@ -1,12 +1,12 @@
-var classNames = require("classnames");
-var React = require("react/addons");
+import classNames from "classnames";
+import React from "react/addons";
 
-var AppVersionsActions = require("../actions/AppVersionsActions");
-var AppVersionsEvents = require("../events/AppVersionsEvents");
-var AppVersionsStore = require("../stores/AppVersionsStore");
-var AppVersionComponent = require("../components/AppVersionComponent");
-var Messages = require("../constants/Messages");
-var States = require("../constants/States");
+import AppVersionsActions from "../actions/AppVersionsActions";
+import AppVersionsEvents from "../events/AppVersionsEvents";
+import AppVersionsStore from "../stores/AppVersionsStore";
+import AppVersionComponent from "../components/AppVersionComponent";
+import Messages from "../constants/Messages";
+import States from "../constants/States";
 
 var AppVersionListItemComponent = React.createClass({
   displayName: "AppVersionListItemComponent",
@@ -171,4 +171,4 @@ var AppVersionListItemComponent = React.createClass({
   }
 });
 
-module.exports = AppVersionListItemComponent;
+export default AppVersionListItemComponent;

--- a/src/js/components/BreadcrumbComponent.jsx
+++ b/src/js/components/BreadcrumbComponent.jsx
@@ -1,8 +1,8 @@
-var classNames = require("classnames");
-var React = require("react/addons");
-var Link = require("react-router").Link;
+import classNames from "classnames";
+import React from "react/addons";
+import {Link} from "react-router";
 
-var PathUtil = require("../helpers/PathUtil");
+import PathUtil from "../helpers/PathUtil";
 
 const COLLAPSE_BUFFER = 12;
 const PADDED_ICON_WIDTH = 24; // 16px icon + 8px padding
@@ -232,4 +232,4 @@ var BreadcrumbComponent = React.createClass({
   }
 });
 
-module.exports = BreadcrumbComponent;
+export default BreadcrumbComponent;

--- a/src/js/components/CenteredInlineDialogComponent.jsx
+++ b/src/js/components/CenteredInlineDialogComponent.jsx
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import React from "react/addons";
 import {Link} from "react-router";
 
-var Util = require("../helpers/Util");
+import Util from "../helpers/Util"
 
 var CenteredInlineDialogComponent = React.createClass({
   displayName: "CenteredInlineDialogComponent",

--- a/src/js/components/CenteredInlineDialogComponent.jsx
+++ b/src/js/components/CenteredInlineDialogComponent.jsx
@@ -1,6 +1,6 @@
-var classNames = require("classnames");
-var React = require("react/addons");
-var Link = require("react-router").Link;
+import classNames from "classnames";
+import React from "react/addons";
+import {Link} from "react-router";
 
 var Util = require("../helpers/Util");
 
@@ -38,4 +38,4 @@ var CenteredInlineDialogComponent = React.createClass({
   }
 });
 
-module.exports = CenteredInlineDialogComponent;
+export default CenteredInlineDialogComponent;

--- a/src/js/components/CollapsiblePanelComponent.jsx
+++ b/src/js/components/CollapsiblePanelComponent.jsx
@@ -1,5 +1,5 @@
-var classNames = require("classnames");
-var React = require("react");
+import classNames from "classnames";
+import React from "react";
 
 var CollapsiblePanelComponent = React.createClass({
   displayName: "CollapsiblePanelComponent",
@@ -65,4 +65,4 @@ var CollapsiblePanelComponent = React.createClass({
   }
 });
 
-module.exports = CollapsiblePanelComponent;
+export default CollapsiblePanelComponent;

--- a/src/js/components/ConfirmDialoglComponent.jsx
+++ b/src/js/components/ConfirmDialoglComponent.jsx
@@ -1,9 +1,9 @@
-var React = require("react/addons");
-var classNames = require("classnames");
+import React from "react/addons";
+import classNames from "classnames";
 
-var DialogSeverity = require("../constants/DialogSeverity");
-var Util = require("../helpers/Util");
-var ModalComponent = require("../components/ModalComponent");
+import DialogSeverity from "../constants/DialogSeverity";
+import Util from "../helpers/Util";
+import ModalComponent from "../components/ModalComponent";
 
 var ConfirmDialogComponent = React.createClass({
   displayName: "ConfirmDialogComponent",
@@ -72,4 +72,4 @@ var ConfirmDialogComponent = React.createClass({
   }
 });
 
-module.exports = ConfirmDialogComponent;
+export default ConfirmDialogComponent;

--- a/src/js/components/ContainerSettingsComponent.jsx
+++ b/src/js/components/ContainerSettingsComponent.jsx
@@ -1,12 +1,12 @@
-var classNames = require("classnames");
-var React = require("react/addons");
+import classNames from "classnames";
+import React from "react/addons";
 
-var ContainerConstants = require("../constants/ContainerConstants");
-var DuplicableRowControls = require("../components/DuplicableRowControls");
-var DuplicableRowsMixin = require("../mixins/DuplicableRowsMixin");
-var dockerRowSchemes = require("../stores/schemes/dockerRowSchemes");
-var FormActions = require("../actions/FormActions");
-var FormGroupComponent = require("../components/FormGroupComponent");
+import ContainerConstants from "../constants/ContainerConstants";
+import DuplicableRowControls from "../components/DuplicableRowControls";
+import DuplicableRowsMixin from "../mixins/DuplicableRowsMixin";
+import dockerRowSchemes from "../stores/schemes/dockerRowSchemes";
+import FormActions from "../actions/FormActions";
+import FormGroupComponent from "../components/FormGroupComponent";
 
 const portInputAttributes = {
   min: 0,
@@ -359,4 +359,4 @@ var ContainerSettingsComponent = React.createClass({
   }
 });
 
-module.exports = ContainerSettingsComponent;
+export default ContainerSettingsComponent;

--- a/src/js/components/DeploymentComponent.jsx
+++ b/src/js/components/DeploymentComponent.jsx
@@ -1,11 +1,11 @@
-var classNames = require("classnames");
-var Link = require("react-router").Link;
-var React = require("react/addons");
+import classNames from "classnames";
+import {Link} from "react-router";
+import React from "react/addons";
 
-var DeploymentActions = require("../actions/DeploymentActions");
-var DialogActions = require("../actions/DialogActions");
-var DialogStore = require("../stores/DialogStore");
-var DialogSeverity = require("../constants/DialogSeverity");
+import DeploymentActions from "../actions/DeploymentActions";
+import DialogActions from "../actions/DialogActions";
+import DialogStore from "../stores/DialogStore";
+import DialogSeverity from "../constants/DialogSeverity";
 
 var DeploymentComponent = React.createClass({
   displayName: "DeploymentComponent",
@@ -129,4 +129,4 @@ var DeploymentComponent = React.createClass({
   }
 });
 
-module.exports = DeploymentComponent;
+export default DeploymentComponent;

--- a/src/js/components/DeploymentsListComponent.jsx
+++ b/src/js/components/DeploymentsListComponent.jsx
@@ -1,15 +1,15 @@
-var classNames = require("classnames");
-var lazy = require("lazy.js");
-var Link = require("react-router").Link;
-var React = require("react/addons");
+import classNames from "classnames";
+import lazy from "lazy.js";
+import {Link} from "react-router";
+import React from "react/addons";
 
-var Messages = require("../constants/Messages");
-var States = require("../constants/States");
+import Messages from "../constants/Messages";
+import States from "../constants/States";
 
-var CenteredInlineDialogComponent = require("./CenteredInlineDialogComponent");
-var DeploymentComponent = require("../components/DeploymentComponent");
-var DeploymentStore = require("../stores/DeploymentStore");
-var DeploymentEvents = require("../events/DeploymentEvents");
+import CenteredInlineDialogComponent from "./CenteredInlineDialogComponent";
+import DeploymentComponent from "../components/DeploymentComponent";
+import DeploymentStore from "../stores/DeploymentStore";
+import DeploymentEvents from "../events/DeploymentEvents";
 
 var DeploymentListComponent = React.createClass({
   displayName: "DeploymentListComponent",
@@ -244,4 +244,4 @@ var DeploymentListComponent = React.createClass({
   }
 });
 
-module.exports = DeploymentListComponent;
+export default DeploymentListComponent;

--- a/src/js/components/DialogsComponent.jsx
+++ b/src/js/components/DialogsComponent.jsx
@@ -1,14 +1,13 @@
-var React = require("react/addons");
+import React from "react/addons";
 
-var AlertDialogComponent = require("../components/AlertDialogComponent");
-var ConfirmDialogComponent =
-  require("../components/ConfirmDialoglComponent");
-var PromptDialogComponent = require("../components/PromptDialogComponent");
+import AlertDialogComponent from "../components/AlertDialogComponent";
+import ConfirmDialogComponent from "../components/ConfirmDialoglComponent";
+import PromptDialogComponent from "../components/PromptDialogComponent";
 
-var DialogActions = require("../actions/DialogActions");
-var DialogEvents = require("../events/DialogEvents");
-var DialogStore = require("../stores/DialogStore");
-var DialogTypes = require("../constants/DialogTypes");
+import DialogActions from "../actions/DialogActions";
+import DialogEvents from "../events/DialogEvents";
+import DialogStore from "../stores/DialogStore";
+import DialogTypes from "../constants/DialogTypes";
 
 var DialogsComponent = React.createClass({
   displayName: "DialogsComponent",
@@ -97,4 +96,4 @@ var DialogsComponent = React.createClass({
   }
 });
 
-module.exports = DialogsComponent;
+export default DialogsComponent;

--- a/src/js/components/DuplicableRowControls.jsx
+++ b/src/js/components/DuplicableRowControls.jsx
@@ -1,5 +1,5 @@
-var classNames = require("classnames");
-var React = require("react/addons");
+import classNames from "classnames";
+import React from "react/addons";
 
 var DuplicableRowControls = React.createClass({
   displayName: "DuplicableRowControls",
@@ -32,4 +32,4 @@ var DuplicableRowControls = React.createClass({
   }
 });
 
-module.exports = DuplicableRowControls;
+export default DuplicableRowControls;

--- a/src/js/components/FormGroupComponent.jsx
+++ b/src/js/components/FormGroupComponent.jsx
@@ -1,5 +1,5 @@
-var classNames = require("classnames");
-var React = require("react/addons");
+import classNames from "classnames";
+import React from "react/addons";
 
 var FormGroupComponent = React.createClass({
   displayName: "FormGroupComponent",
@@ -79,4 +79,4 @@ var FormGroupComponent = React.createClass({
   }
 });
 
-module.exports = FormGroupComponent;
+export default FormGroupComponent;

--- a/src/js/components/HealthChecksComponent.jsx
+++ b/src/js/components/HealthChecksComponent.jsx
@@ -1,13 +1,12 @@
-var classNames = require("classnames");
-var React = require("react/addons");
+import classNames from "classnames";
+import React from "react/addons";
 
-var DuplicableRowsMixin = require("../mixins/DuplicableRowsMixin");
-var FormGroupComponent = require("../components/FormGroupComponent");
-var HealthCheckProtocols = require("../constants/HealthCheckProtocols");
-var HealthCheckPortTypes = require("../constants/HealthCheckPortTypes");
+import DuplicableRowsMixin from "../mixins/DuplicableRowsMixin";
+import FormGroupComponent from "../components/FormGroupComponent";
+import HealthCheckProtocols from "../constants/HealthCheckProtocols";
+import HealthCheckPortTypes from "../constants/HealthCheckPortTypes";
 
-const healthChecksRowScheme =
-  require("../stores/schemes/healthChecksRowScheme");
+import healthChecksRowScheme from "../stores/schemes/healthChecksRowScheme";
 
 const numberInputAttributes = {
   min: 0,
@@ -287,4 +286,4 @@ var HealthChecksComponent = React.createClass({
   }
 });
 
-module.exports = HealthChecksComponent;
+export default HealthChecksComponent;

--- a/src/js/components/Marathon.jsx
+++ b/src/js/components/Marathon.jsx
@@ -1,25 +1,23 @@
-var config = require("../config/config");
+import config from "../config/config";
 
-var Link = require("react-router").Link;
-var Mousetrap = require("mousetrap");
-require("mousetrap/plugins/global-bind/mousetrap-global-bind");
-var React = require("react/addons");
-var RouteHandler = require("react-router").RouteHandler;
+import React from "react/addons";
+import {Link, RouteHandler} from "react-router";
+import Mousetrap from "mousetrap";
+import "mousetrap/plugins/global-bind/mousetrap-global-bind";
 
-var AboutModalComponent = require("../components/modals/AboutModalComponent");
-var AppModalComponent = require("../components/modals/AppModalComponent");
-var DialogsComponent = require("../components/DialogsComponent");
-var EditAppModalComponent =
-  require("../components/modals/EditAppModalComponent");
-var HelpModalComponent = require("../components/modals/HelpModalComponent");
-var NavTabsComponent = require("../components/NavTabsComponent");
+import AboutModalComponent from "../components/modals/AboutModalComponent";
+import AppModalComponent from "../components/modals/AppModalComponent";
+import DialogsComponent from "../components/DialogsComponent";
+import EditAppModalComponent from "../components/modals/EditAppModalComponent";
+import HelpModalComponent from "../components/modals/HelpModalComponent";
+import NavTabsComponent from "../components/NavTabsComponent";
 
-var AppsActions = require("../actions/AppsActions");
-var DeploymentActions = require("../actions/DeploymentActions");
-var DialogActions = require("../actions/DialogActions");
-var QueueActions = require("../actions/QueueActions");
+import AppsActions from "../actions/AppsActions";
+import DeploymentActions from "../actions/DeploymentActions";
+import DialogActions from "../actions/DialogActions";
+import QueueActions from "../actions/QueueActions";
 
-var tabs = require("../constants/tabs");
+import tabs from "../constants/tabs";
 
 var Marathon = React.createClass({
   displayName: "Marathon",
@@ -281,4 +279,4 @@ var Marathon = React.createClass({
   }
 });
 
-module.exports = Marathon;
+export default Marathon;

--- a/src/js/components/Marathon.jsx
+++ b/src/js/components/Marathon.jsx
@@ -1,9 +1,9 @@
-import config from "../config/config";
-
 import React from "react/addons";
 import {Link, RouteHandler} from "react-router";
 import Mousetrap from "mousetrap";
 import "mousetrap/plugins/global-bind/mousetrap-global-bind";
+
+import config from "../config/config";
 
 import AboutModalComponent from "../components/modals/AboutModalComponent";
 import AppModalComponent from "../components/modals/AppModalComponent";

--- a/src/js/components/ModalComponent.jsx
+++ b/src/js/components/ModalComponent.jsx
@@ -1,6 +1,6 @@
-var Util = require("../helpers/Util");
-var classNames = require("classnames");
-var React = require("react/addons");
+import Util from "../helpers/Util";
+import classNames from "classnames";
+import React from "react/addons";
 
 function modalSizeClassName(size) {
   return (size == null) ? "" : "modal-" + size;
@@ -86,4 +86,4 @@ var ModalComponent = React.createClass({
   }
 });
 
-module.exports = ModalComponent;
+export default ModalComponent;

--- a/src/js/components/NavTabsComponent.jsx
+++ b/src/js/components/NavTabsComponent.jsx
@@ -1,8 +1,8 @@
-var classNames = require("classnames");
-var React = require("react/addons");
+import classNames from "classnames";
+import React from "react/addons";
 
-var DeploymentEvents = require("../events/DeploymentEvents");
-var DeploymentStore = require("../stores/DeploymentStore");
+import DeploymentEvents from "../events/DeploymentEvents";
+import DeploymentStore from "../stores/DeploymentStore";
 
 var NavTabsComponent = React.createClass({
   displayName: "NavTabsComponent",
@@ -81,4 +81,4 @@ var NavTabsComponent = React.createClass({
   }
 });
 
-module.exports = NavTabsComponent;
+export default NavTabsComponent;

--- a/src/js/components/ObjectDlComponent.jsx
+++ b/src/js/components/ObjectDlComponent.jsx
@@ -1,7 +1,6 @@
-var React = require("react/addons");
+import React from "react/addons";
 
-var UnspecifiedNodeComponent =
-  require("../components/UnspecifiedNodeComponent");
+import UnspecifiedNodeComponent from "../components/UnspecifiedNodeComponent";
 
 function formatKey(key) {
   return key.split("_").map(function (piece) {
@@ -53,4 +52,4 @@ var ObjectDlComponent = React.createClass({
   }
 });
 
-module.exports = ObjectDlComponent;
+export default ObjectDlComponent;

--- a/src/js/components/OptionalEnviromentComponent.jsx
+++ b/src/js/components/OptionalEnviromentComponent.jsx
@@ -1,10 +1,9 @@
-var classNames = require("classnames");
-var React = require("react/addons");
+import classNames from "classnames";
+import React from "react/addons";
 
-var DuplicableRowControls = require("../components/DuplicableRowControls");
-var DuplicableRowsMixin = require("../mixins/DuplicableRowsMixin");
-var FormGroupComponent =
-  require("../components/FormGroupComponent");
+import DuplicableRowControls from "../components/DuplicableRowControls";
+import DuplicableRowsMixin from "../mixins/DuplicableRowsMixin";
+import FormGroupComponent from "../components/FormGroupComponent";
 
 var OptionalEnvironmentComponent = React.createClass({
   displayName: "OptionalEnvironmentComponent",
@@ -101,4 +100,4 @@ var OptionalEnvironmentComponent = React.createClass({
   }
 });
 
-module.exports = OptionalEnvironmentComponent;
+export default OptionalEnvironmentComponent;

--- a/src/js/components/OptionalLabelsComponent.jsx
+++ b/src/js/components/OptionalLabelsComponent.jsx
@@ -1,10 +1,9 @@
-var classNames = require("classnames");
-var React = require("react/addons");
+import classNames from "classnames";
+import React from "react/addons";
 
-var DuplicableRowControls = require("../components/DuplicableRowControls");
-var DuplicableRowsMixin = require("../mixins/DuplicableRowsMixin");
-var FormGroupComponent =
-  require("../components/FormGroupComponent");
+import DuplicableRowControls from "../components/DuplicableRowControls";
+import DuplicableRowsMixin from "../mixins/DuplicableRowsMixin";
+import FormGroupComponent from "../components/FormGroupComponent";
 
 var OptionalLabelsComponent = React.createClass({
   displayName: "OptionalLabelsComponent",
@@ -101,4 +100,4 @@ var OptionalLabelsComponent = React.createClass({
   }
 });
 
-module.exports = OptionalLabelsComponent;
+export default OptionalLabelsComponent;

--- a/src/js/components/OptionalSettingsComponent.jsx
+++ b/src/js/components/OptionalSettingsComponent.jsx
@@ -1,8 +1,7 @@
-var React = require("react/addons");
+import React from "react/addons";
 
-var FormActions = require("../actions/FormActions");
-var FormGroupComponent =
-  require("../components/FormGroupComponent");
+import FormActions from "../actions/FormActions";
+import FormGroupComponent from "../components/FormGroupComponent";
 
 var OptionalSettingsComponent = React.createClass({
   displayName: "OptionalSettingsComponent",
@@ -103,4 +102,4 @@ var OptionalSettingsComponent = React.createClass({
   }
 });
 
-module.exports = OptionalSettingsComponent;
+export default OptionalSettingsComponent;

--- a/src/js/components/PageNotFoundComponent.jsx
+++ b/src/js/components/PageNotFoundComponent.jsx
@@ -1,6 +1,6 @@
-var React = require("react/addons");
-var Link = require("react-router").Link;
-var CenteredInlineDialogComponent = require("./CenteredInlineDialogComponent");
+import React from "react/addons";
+import {Link} from "react-router";
+import CenteredInlineDialogComponent from "./CenteredInlineDialogComponent";
 
 var PageNotFoundComponent = React.createClass({
   displayName: "PageNotFoundComponent",
@@ -23,4 +23,4 @@ var PageNotFoundComponent = React.createClass({
   }
 });
 
-module.exports = PageNotFoundComponent;
+export default PageNotFoundComponent;

--- a/src/js/components/PagedContentComponent.jsx
+++ b/src/js/components/PagedContentComponent.jsx
@@ -1,6 +1,6 @@
-var React = require("react/addons");
+import React from "react/addons";
 
-module.exports = React.createClass({
+export default React.createClass({
   displayName: "PagedContentComponent",
 
   propTypes: {

--- a/src/js/components/PagedNavComponent.jsx
+++ b/src/js/components/PagedNavComponent.jsx
@@ -1,5 +1,5 @@
-var classNames = require("classnames");
-var React = require("react/addons");
+import classNames from "classnames";
+import React from "react/addons";
 
 var PagedNavComponent = React.createClass({
   displayName: "PagedNavComponent",
@@ -149,4 +149,4 @@ var PagedNavComponent = React.createClass({
   }
 });
 
-module.exports = PagedNavComponent;
+export default PagedNavComponent;

--- a/src/js/components/PopoverComponent.js
+++ b/src/js/components/PopoverComponent.js
@@ -1,7 +1,7 @@
-var React = require("react/addons");
-var classNames = require("classnames");
+import React from "react/addons";
+import classNames from "classnames";
 
-var Util = require("../helpers/Util");
+import Util from "../helpers/Util";
 
 const DEFAULT_ALIGNED = "default";
 const TOP_ALIGNED = "top";
@@ -78,4 +78,4 @@ var PopoverComponent = React.createClass({
   }
 });
 
-module.exports = PopoverComponent;
+export default PopoverComponent;

--- a/src/js/components/PromptDialogComponent.jsx
+++ b/src/js/components/PromptDialogComponent.jsx
@@ -1,9 +1,9 @@
-var React = require("react/addons");
-var classNames = require("classnames");
+import React from "react/addons";
+import classNames from "classnames";
 
-var DialogSeverity = require("../constants/DialogSeverity");
-var Util = require("../helpers/Util");
-var ModalComponent = require("../components/ModalComponent");
+import DialogSeverity from "../constants/DialogSeverity";
+import Util from "../helpers/Util";
+import ModalComponent from "../components/ModalComponent";
 
 var PromptDialogComponent = React.createClass({
   displayName: "PromptDialogComponent",
@@ -84,4 +84,4 @@ var PromptDialogComponent = React.createClass({
   }
 });
 
-module.exports = PromptDialogComponent;
+export default PromptDialogComponent;

--- a/src/js/components/SidebarComponent.jsx
+++ b/src/js/components/SidebarComponent.jsx
@@ -1,15 +1,15 @@
-var Link = require("react-router").Link;
-var React = require("react/addons");
+import {Link} from "react-router";
+import React from "react/addons";
 
-var FilterTypes = require("../constants/FilterTypes");
-var SidebarHealthFilterComponent =
-  require("../components/SidebarHealthFilterComponent");
-var SidebarLabelsFilterComponent =
-  require("../components/SidebarLabelsFilterComponent");
-var SidebarStatusFilterComponent =
-  require("../components/SidebarStatusFilterComponent");
+import FilterTypes from "../constants/FilterTypes";
+import SidebarHealthFilterComponent
+  from "../components/SidebarHealthFilterComponent";
+import SidebarLabelsFilterComponent
+  from "../components/SidebarLabelsFilterComponent";
+import SidebarStatusFilterComponent
+  from "../components/SidebarStatusFilterComponent";
 
-var QueryParamsMixin = require("../mixins/QueryParamsMixin");
+import QueryParamsMixin from "../mixins/QueryParamsMixin";
 
 var SidebarComponent = React.createClass({
   displayName: "SidebarComponent",
@@ -88,4 +88,4 @@ var SidebarComponent = React.createClass({
   }
 });
 
-module.exports = SidebarComponent;
+export default SidebarComponent;

--- a/src/js/components/SidebarHealthFilterComponent.jsx
+++ b/src/js/components/SidebarHealthFilterComponent.jsx
@@ -1,12 +1,12 @@
-var classNames = require("classnames");
-var React = require("react/addons");
+import classNames from "classnames";
+import React from "react/addons";
 
-var AppsStore = require("../stores/AppsStore");
-var AppsEvents = require("../events/AppsEvents");
-var FilterTypes = require("../constants/FilterTypes");
-var HealthStatus = require("../constants/HealthStatus");
+import AppsStore from "../stores/AppsStore";
+import AppsEvents from "../events/AppsEvents";
+import FilterTypes from "../constants/FilterTypes";
+import HealthStatus from "../constants/HealthStatus";
 
-var QueryParamsMixin = require("../mixins/QueryParamsMixin");
+import QueryParamsMixin from "../mixins/QueryParamsMixin";
 
 var healthNameMapping = {
   [HealthStatus.HEALTHY]: "Healthy",
@@ -155,4 +155,4 @@ var SidebarHealthFilterComponent = React.createClass({
 
 });
 
-module.exports = SidebarHealthFilterComponent;
+export default SidebarHealthFilterComponent;

--- a/src/js/components/SidebarLabelsFilterComponent.jsx
+++ b/src/js/components/SidebarLabelsFilterComponent.jsx
@@ -1,13 +1,13 @@
-var classNames = require("classnames");
-var lazy = require("lazy.js");
-var OnClickOutsideMixin = require("react-onclickoutside");
-var React = require("react/addons");
+import classNames from "classnames";
+import lazy from "lazy.js";
+import OnClickOutsideMixin from "react-onclickoutside";
+import React from "react/addons";
 
-var AppsStore = require("../stores/AppsStore");
-var AppsEvents = require("../events/AppsEvents");
-var FilterTypes = require("../constants/FilterTypes");
+import AppsStore from "../stores/AppsStore";
+import AppsEvents from "../events/AppsEvents";
+import FilterTypes from "../constants/FilterTypes";
 
-var QueryParamsMixin = require("../mixins/QueryParamsMixin");
+import QueryParamsMixin from "../mixins/QueryParamsMixin";
 
 var SidebarLabelsFilterComponent = React.createClass({
   displayName: "SidebarLabelsFilterComponent",
@@ -259,4 +259,4 @@ var SidebarLabelsFilterComponent = React.createClass({
 
 });
 
-module.exports = SidebarLabelsFilterComponent;
+export default SidebarLabelsFilterComponent;

--- a/src/js/components/SidebarStatusFilterComponent.jsx
+++ b/src/js/components/SidebarStatusFilterComponent.jsx
@@ -1,13 +1,13 @@
-var classNames = require("classnames");
-var React = require("react/addons");
+import classNames from "classnames";
+import React from "react/addons";
 
-var AppsStore = require("../stores/AppsStore");
-var AppsEvents = require("../events/AppsEvents");
-var FilterTypes = require("../constants/FilterTypes");
+import AppsStore from "../stores/AppsStore";
+import AppsEvents from "../events/AppsEvents";
+import FilterTypes from "../constants/FilterTypes";
 
-var QueryParamsMixin = require("../mixins/QueryParamsMixin");
+import QueryParamsMixin from "../mixins/QueryParamsMixin";
 
-var statusNameMapping = require("../constants/LabelMapping").statusNameMapping;
+import {statusNameMapping} from "../constants/LabelMapping";
 
 var SidebarStatusFilterComponent = React.createClass({
   displayName: "SidebarStatusFilterComponent",
@@ -147,4 +147,4 @@ var SidebarStatusFilterComponent = React.createClass({
 
 });
 
-module.exports = SidebarStatusFilterComponent;
+export default SidebarStatusFilterComponent;

--- a/src/js/components/TabPaneComponent.jsx
+++ b/src/js/components/TabPaneComponent.jsx
@@ -1,5 +1,5 @@
-var classNames = require("classnames");
-var React = require("react/addons");
+import classNames from "classnames";
+import React from "react/addons";
 
 var TabPaneComponent = React.createClass({
   displayName: "TabPaneComponent",
@@ -38,4 +38,4 @@ var TabPaneComponent = React.createClass({
   }
 });
 
-module.exports = TabPaneComponent;
+export default TabPaneComponent;

--- a/src/js/components/TabPanesComponent.jsx
+++ b/src/js/components/TabPanesComponent.jsx
@@ -1,18 +1,17 @@
-var React = require("react/addons");
+import React from "react/addons";
 
-var AppListFilterComponent = require("../components/AppListFilterComponent");
-var AppListComponent = require("../components/AppListComponent");
-var BreadcrumbComponent = require("../components/BreadcrumbComponent");
-var DeploymentsListComponent =
-  require("../components/DeploymentsListComponent");
-var FilterTypes = require("../constants/FilterTypes");
-var SidebarComponent = require("../components/SidebarComponent");
-var TabPaneComponent = require("../components/TabPaneComponent");
-var TogglableTabsComponent = require("../components/TogglableTabsComponent");
-var Util = require("../helpers/Util");
-var tabs = require("../constants/tabs");
+import AppListFilterComponent from "../components/AppListFilterComponent";
+import AppListComponent from "../components/AppListComponent";
+import BreadcrumbComponent from "../components/BreadcrumbComponent";
+import DeploymentsListComponent from "../components/DeploymentsListComponent";
+import FilterTypes from "../constants/FilterTypes";
+import SidebarComponent from "../components/SidebarComponent";
+import TabPaneComponent from "../components/TabPaneComponent";
+import TogglableTabsComponent from "../components/TogglableTabsComponent";
+import Util from "../helpers/Util";
+import tabs from "../constants/tabs";
 
-var QueryParamsMixin = require("../mixins/QueryParamsMixin");
+import QueryParamsMixin from "../mixins/QueryParamsMixin";
 
 var TabPanesComponent = React.createClass({
   displayName: "TabPanesComponent",
@@ -123,4 +122,4 @@ var TabPanesComponent = React.createClass({
   }
 });
 
-module.exports = TabPanesComponent;
+export default TabPanesComponent;

--- a/src/js/components/TaskDetailComponent.jsx
+++ b/src/js/components/TaskDetailComponent.jsx
@@ -1,15 +1,15 @@
-var classNames = require("classnames");
-var Link = require("react-router").Link;
-var objectPath = require("object-path");
-var React = require("react/addons");
+import classNames from "classnames";
+import {Link} from "react-router";
+import objectPath from "object-path";
+import React from "react/addons";
 
-var AppsStore = require("../stores/AppsStore");
-var States = require("../constants/States");
-var TimeFieldComponent = require("../components/TimeFieldComponent");
-var TaskHealthComponent = require("../components/TaskHealthComponent");
-var TaskMesosUrlComponent = require("../components/TaskMesosUrlComponent");
-var TaskFileListComponent = require("../components/TaskFileListComponent");
-var HealthStatus = require("../constants/HealthStatus");
+import AppsStore from "../stores/AppsStore";
+import States from "../constants/States";
+import TimeFieldComponent from "../components/TimeFieldComponent";
+import TaskHealthComponent from "../components/TaskHealthComponent";
+import TaskMesosUrlComponent from "../components/TaskMesosUrlComponent";
+import TaskFileListComponent from "../components/TaskFileListComponent";
+import HealthStatus from "../constants/HealthStatus";
 
 var TaskDetailComponent = React.createClass({
   displayName: "TaskDetailComponent",
@@ -224,4 +224,4 @@ var TaskDetailComponent = React.createClass({
   }
 });
 
-module.exports = TaskDetailComponent;
+export default TaskDetailComponent;

--- a/src/js/components/TaskFileDownloadComponent.jsx
+++ b/src/js/components/TaskFileDownloadComponent.jsx
@@ -1,11 +1,11 @@
-var React = require("react/addons");
-var classNames = require("classnames");
+import React from "react/addons";
+import classNames from "classnames";
 
-var MesosActions = require("../actions/MesosActions");
-var MesosEvents = require("../events/MesosEvents");
-var MesosStore = require("../stores/MesosStore");
-var PopoverComponent = require("../components/PopoverComponent");
-var TooltipComponent = require("../components/TooltipComponent");
+import MesosActions from "../actions/MesosActions";
+import MesosEvents from "../events/MesosEvents";
+import MesosStore from "../stores/MesosStore";
+import PopoverComponent from "../components/PopoverComponent";
+import TooltipComponent from "../components/TooltipComponent";
 
 var TaskFileDownloadComponent = React.createClass({
   displayName: "TaskFileDownloadComponent",
@@ -134,4 +134,4 @@ var TaskFileDownloadComponent = React.createClass({
   }
 });
 
-module.exports = TaskFileDownloadComponent;
+export default TaskFileDownloadComponent;

--- a/src/js/components/TaskFileListComponent.jsx
+++ b/src/js/components/TaskFileListComponent.jsx
@@ -1,11 +1,11 @@
-var React = require("react/addons");
-var classNames = require("classnames");
-var lazy = require("lazy.js");
+import React from "react/addons";
+import classNames from "classnames";
+import lazy from "lazy.js";
 
-var Util = require("../helpers/Util");
-var MesosActions = require("../actions/MesosActions");
-var MesosEvents = require("../events/MesosEvents");
-var MesosStore = require("../stores/MesosStore");
+import Util from "../helpers/Util";
+import MesosActions from "../actions/MesosActions";
+import MesosEvents from "../events/MesosEvents";
+import MesosStore from "../stores/MesosStore";
 
 var TaskFileListComponent = React.createClass({
   displayName: "TaskFileListComponent",
@@ -192,4 +192,4 @@ var TaskFileListComponent = React.createClass({
   }
 });
 
-module.exports = TaskFileListComponent;
+export default TaskFileListComponent;

--- a/src/js/components/TaskHealthComponent.jsx
+++ b/src/js/components/TaskHealthComponent.jsx
@@ -1,5 +1,5 @@
-var React = require("react/addons");
-var TimeFieldComponent = require("../components/TimeFieldComponent");
+import React from "react/addons";
+import TimeFieldComponent from "../components/TimeFieldComponent";
 
 var TaskHealthComponent = React.createClass({
   displayName: "TaskHealthComponent",
@@ -64,4 +64,4 @@ var TaskHealthComponent = React.createClass({
   }
 });
 
-module.exports = TaskHealthComponent;
+export default TaskHealthComponent;

--- a/src/js/components/TaskListComponent.jsx
+++ b/src/js/components/TaskListComponent.jsx
@@ -1,12 +1,12 @@
-var classNames = require("classnames");
-var lazy = require("lazy.js");
-var React = require("react/addons");
+import classNames from "classnames";
+import lazy from "lazy.js";
+import React from "react/addons";
 
-var Messages = require("../constants/Messages");
-var States = require("../constants/States");
+import Messages from "../constants/Messages";
+import States from "../constants/States";
 
-var CenteredInlineDialogComponent = require("./CenteredInlineDialogComponent");
-var TaskListItemComponent = require("../components/TaskListItemComponent");
+import CenteredInlineDialogComponent from "./CenteredInlineDialogComponent";
+import TaskListItemComponent from "../components/TaskListItemComponent";
 
 var TaskListComponent = React.createClass({
   displayName: "TaskListComponent",
@@ -236,4 +236,4 @@ var TaskListComponent = React.createClass({
   }
 });
 
-module.exports = TaskListComponent;
+export default TaskListComponent;

--- a/src/js/components/TaskListItemComponent.jsx
+++ b/src/js/components/TaskListItemComponent.jsx
@@ -1,13 +1,12 @@
-var classNames = require("classnames");
-var objectPath = require("object-path");
-var React = require("react/addons");
-var Moment = require("moment");
+import classNames from "classnames";
+import objectPath from "object-path";
+import React from "react/addons";
+import Moment from "moment";
 
-var AppsStore = require("../stores/AppsStore");
-var HealthStatus = require("../constants/HealthStatus");
-var TaskStatus = require("../constants/TaskStatus");
-var TaskFileDownloadComponent =
-  require("../components/TaskFileDownloadComponent");
+import AppsStore from "../stores/AppsStore";
+import HealthStatus from "../constants/HealthStatus";
+import TaskStatus from "../constants/TaskStatus";
+import TaskFileDownloadComponent from "../components/TaskFileDownloadComponent";
 
 function joinNodes(nodes, separator = ", ") {
   var lastIndex = nodes.length - 1;
@@ -231,4 +230,4 @@ var TaskListItemComponent = React.createClass({
   }
 });
 
-module.exports = TaskListItemComponent;
+export default TaskListItemComponent;

--- a/src/js/components/TaskMesosUrlComponent.jsx
+++ b/src/js/components/TaskMesosUrlComponent.jsx
@@ -1,8 +1,8 @@
-var React = require("react/addons");
+import React from "react/addons";
 
-var InfoActions = require("../actions/InfoActions");
-var InfoEvents = require("../events/InfoEvents");
-var InfoStore = require("../stores/InfoStore");
+import InfoActions from "../actions/InfoActions";
+import InfoEvents from "../events/InfoEvents";
+import InfoStore from "../stores/InfoStore";
 
 var TaskMesosUrlComponent = React.createClass({
   displayName: "TaskMesosUrlComponent",
@@ -74,4 +74,4 @@ var TaskMesosUrlComponent = React.createClass({
   }
 });
 
-module.exports = TaskMesosUrlComponent;
+export default TaskMesosUrlComponent;

--- a/src/js/components/TaskViewComponent.jsx
+++ b/src/js/components/TaskViewComponent.jsx
@@ -1,10 +1,10 @@
-var lazy = require("lazy.js");
-var React = require("react/addons");
+import lazy from "lazy.js";
+import React from "react/addons";
 
-var AppsActions = require("../actions/AppsActions");
-var PagedNavComponent = require("../components/PagedNavComponent");
-var TasksActions = require("../actions/TasksActions");
-var TaskListComponent = require("../components/TaskListComponent");
+import AppsActions from "../actions/AppsActions";
+import PagedNavComponent from "../components/PagedNavComponent";
+import TasksActions from "../actions/TasksActions";
+import TaskListComponent from "../components/TaskListComponent";
 
 var TaskViewComponent = React.createClass({
   displayName: "TaskViewComponent",
@@ -174,4 +174,4 @@ var TaskViewComponent = React.createClass({
   }
 });
 
-module.exports = TaskViewComponent;
+export default TaskViewComponent;

--- a/src/js/components/TimeFieldComponent.jsx
+++ b/src/js/components/TimeFieldComponent.jsx
@@ -1,4 +1,4 @@
-var React = require("react/addons");
+import React from "react/addons";
 
 var TimeFieldComponent = React.createClass({
   displayName: "TimeFieldComponent",
@@ -29,4 +29,4 @@ var TimeFieldComponent = React.createClass({
   }
 });
 
-module.exports = TimeFieldComponent;
+export default TimeFieldComponent;

--- a/src/js/components/TogglableTabsComponent.jsx
+++ b/src/js/components/TogglableTabsComponent.jsx
@@ -1,9 +1,9 @@
-var classNames = require("classnames");
-var React = require("react/addons");
+import classNames from "classnames";
+import React from "react/addons";
 
-var NavTabsComponent = require("../components/NavTabsComponent");
+import NavTabsComponent from "../components/NavTabsComponent";
 
-module.exports = React.createClass({
+export default React.createClass({
   displayName: "TogglableTabsComponent",
 
   propTypes: {

--- a/src/js/components/TooltipComponent.jsx
+++ b/src/js/components/TooltipComponent.jsx
@@ -1,6 +1,6 @@
-var React = require("react/addons");
-var classNames = require("classnames");
-var PopoverComponent = require("../components/PopoverComponent");
+import React from "react/addons";
+import classNames from "classnames";
+import PopoverComponent from "../components/PopoverComponent";
 
 var TooltipComponent = React.createClass({
   displayName: "TooltipComponent",
@@ -53,4 +53,4 @@ var TooltipComponent = React.createClass({
 
 });
 
-module.exports = TooltipComponent;
+export default TooltipComponent;

--- a/src/js/components/UnspecifiedNodeComponent.jsx
+++ b/src/js/components/UnspecifiedNodeComponent.jsx
@@ -1,4 +1,4 @@
-var React = require("react/addons");
+import React from "react/addons";
 
 var UnspecifiedNodeComponent = React.createClass({
   displayName: "UnspecifiedNodeComponent",
@@ -28,4 +28,4 @@ var UnspecifiedNodeComponent = React.createClass({
   }
 });
 
-module.exports = UnspecifiedNodeComponent;
+export default UnspecifiedNodeComponent;

--- a/src/js/components/modals/AboutModalComponent.jsx
+++ b/src/js/components/modals/AboutModalComponent.jsx
@@ -1,14 +1,14 @@
 import React from "react/addons";
 
+import config from "../../config/config";
+
 import InfoActions from "../../actions/InfoActions";
 import InfoEvents from "../../events/InfoEvents";
 import InfoStore from "../../stores/InfoStore";
 import ModalComponent from "../ModalComponent";
 import ObjectDlComponent from "../ObjectDlComponent";
-import UnspecifiedNodeComponent from
-  "../../components/UnspecifiedNodeComponent";
-
-import config from "../../config/config";
+import UnspecifiedNodeComponent
+  from "../../components/UnspecifiedNodeComponent";
 
 var AboutModalComponent = React.createClass({
   displayName: "AboutModalComponent",

--- a/src/js/components/modals/AboutModalComponent.jsx
+++ b/src/js/components/modals/AboutModalComponent.jsx
@@ -1,14 +1,14 @@
-var React = require("react/addons");
+import React from "react/addons";
 
-var InfoActions = require("../../actions/InfoActions");
-var InfoEvents = require("../../events/InfoEvents");
-var InfoStore = require("../../stores/InfoStore");
-var ModalComponent = require("../ModalComponent");
-var ObjectDlComponent = require("../ObjectDlComponent");
-var UnspecifiedNodeComponent =
-  require("../../components/UnspecifiedNodeComponent");
+import InfoActions from "../../actions/InfoActions";
+import InfoEvents from "../../events/InfoEvents";
+import InfoStore from "../../stores/InfoStore";
+import ModalComponent from "../ModalComponent";
+import ObjectDlComponent from "../ObjectDlComponent";
+import UnspecifiedNodeComponent from
+  "../../components/UnspecifiedNodeComponent";
 
-var config = require("../../config/config");
+import config from "../../config/config";
 
 var AboutModalComponent = React.createClass({
   displayName: "AboutModalComponent",
@@ -89,4 +89,4 @@ var AboutModalComponent = React.createClass({
   }
 });
 
-module.exports = AboutModalComponent;
+export default AboutModalComponent;

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -1,29 +1,26 @@
-var classNames = require("classnames");
-var React = require("react/addons");
-var Util = require("../../helpers/Util");
+import classNames from "classnames";
+import React from "react/addons";
+import Util from "../../helpers/Util";
 
-var AppsActions = require("../../actions/AppsActions");
-var AppsEvents = require("../../events/AppsEvents");
-var AppFormErrorMessages = require("../../constants/AppFormErrorMessages");
-var AppFormStore = require("../../stores/AppFormStore");
-var AppsStore = require("../../stores/AppsStore");
-var CollapsiblePanelComponent =
-  require("../../components/CollapsiblePanelComponent");
-var ContainerSettingsComponent =
-  require("../../components/ContainerSettingsComponent");
-var FormActions = require("../../actions/FormActions");
-var FormEvents = require("../../events/FormEvents");
-var HealthChecksComponent =
-  require("../../components/HealthChecksComponent");
-var ModalComponent = require("../../components/ModalComponent");
-var OptionalEnvironmentComponent =
-  require("../../components/OptionalEnviromentComponent");
-var OptionalLabelsComponent =
-  require("../../components/OptionalLabelsComponent");
-var OptionalSettingsComponent =
-  require("../../components/OptionalSettingsComponent");
-var FormGroupComponent =
-  require("../../components/FormGroupComponent");
+import AppsActions from "../../actions/AppsActions";
+import AppsEvents from "../../events/AppsEvents";
+import AppFormErrorMessages from "../../constants/AppFormErrorMessages";
+import AppFormStore from "../../stores/AppFormStore";
+import AppsStore from "../../stores/AppsStore";
+import CollapsiblePanelComponent
+  from "../../components/CollapsiblePanelComponent";
+import ContainerSettingsComponent
+  from "../../components/ContainerSettingsComponent";
+import FormActions from "../../actions/FormActions";
+import FormEvents from "../../events/FormEvents";
+import HealthChecksComponent from "../../components/HealthChecksComponent";
+import ModalComponent from "../../components/ModalComponent";
+import OptionalEnvironmentComponent
+  from "../../components/OptionalEnviromentComponent";
+import OptionalLabelsComponent from "../../components/OptionalLabelsComponent";
+import OptionalSettingsComponent
+  from "../../components/OptionalSettingsComponent";
+import FormGroupComponent from "../../components/FormGroupComponent";
 
 var AppModalComponent = React.createClass({
   displayName: "AppModalComponent",
@@ -367,4 +364,4 @@ var AppModalComponent = React.createClass({
   }
 });
 
-module.exports = AppModalComponent;
+export default AppModalComponent;

--- a/src/js/components/modals/EditAppModalComponent.jsx
+++ b/src/js/components/modals/EditAppModalComponent.jsx
@@ -1,13 +1,13 @@
-var React = require("react/addons");
-var Util = require("../../helpers/Util");
+import React from "react/addons";
+import Util from "../../helpers/Util";
 
-var AppVersionsActions = require("../../actions/AppVersionsActions");
-var AppVersionsEvents = require("../../events/AppVersionsEvents");
-var AppVersionsStore = require("../../stores/AppVersionsStore");
-var DialogActions = require("../../actions/DialogActions");
-var DialogSeverity = require("../../constants/DialogSeverity");
+import AppVersionsActions from "../../actions/AppVersionsActions";
+import AppVersionsEvents from "../../events/AppVersionsEvents";
+import AppVersionsStore from "../../stores/AppVersionsStore";
+import DialogActions from "../../actions/DialogActions";
+import DialogSeverity from "../../constants/DialogSeverity";
 
-var AppModalComponent = require("./AppModalComponent");
+import AppModalComponent from "./AppModalComponent";
 
 var EditAppModalComponent = React.createClass({
   displayName: "EditAppModalComponent",
@@ -97,4 +97,4 @@ var EditAppModalComponent = React.createClass({
   }
 });
 
-module.exports = EditAppModalComponent;
+export default EditAppModalComponent;

--- a/src/js/components/modals/HelpModalComponent.jsx
+++ b/src/js/components/modals/HelpModalComponent.jsx
@@ -1,6 +1,6 @@
-var React = require("react/addons");
+import React from "react/addons";
 
-var ModalComponent = require("../ModalComponent");
+import ModalComponent from "../ModalComponent";
 
 var HelpModalComponent = React.createClass({
   displayName: "HelpModalComponent",
@@ -50,4 +50,4 @@ var HelpModalComponent = React.createClass({
   }
 });
 
-module.exports = HelpModalComponent;
+export default HelpModalComponent;

--- a/src/js/config/config.js
+++ b/src/js/config/config.js
@@ -1,4 +1,5 @@
-var packageJSON = require("../../../package.json");
+import packageJSON from "../../../package.json";
+import configDev from "./config.dev";
 
 var config = {
   // @@ENV gets replaced by build system
@@ -22,11 +23,10 @@ var config = {
 
 if (process.env.GULP_ENV === "development") {
   try {
-    var configDev = require("./config.dev");
     config = Object.assign(config, configDev);
   } catch (e) {
     console.info("You could copy config.template.js to config.dev.js " +
       "to enable a development configuration.");
   }
 }
-module.exports = config;
+export default config;

--- a/src/js/config/config.js
+++ b/src/js/config/config.js
@@ -1,5 +1,4 @@
 import packageJSON from "../../../package.json";
-import configDev from "./config.dev";
 
 var config = {
   // @@ENV gets replaced by build system
@@ -21,12 +20,4 @@ var config = {
     `${packageJSON.version}-SNAPSHOT`
 };
 
-if (process.env.GULP_ENV === "development") {
-  try {
-    config = Object.assign(config, configDev);
-  } catch (e) {
-    console.info("You could copy config.template.js to config.dev.js " +
-      "to enable a development configuration.");
-  }
-}
 export default config;

--- a/src/js/config/config.template.js
+++ b/src/js/config/config.template.js
@@ -5,4 +5,4 @@ var configDev = {
   // If the UI is served through a proxied URL, this can be set here.
   rootUrl: ""
 };
-module.exports = configDev;
+export default configDev;

--- a/src/js/config/config.template.js
+++ b/src/js/config/config.template.js
@@ -1,8 +1,10 @@
-var configDev = {
+import config from "./config";
+
+var configDev = Object.assign(config, {
   // Defines the Marathon API URL,
   // leave empty to use the same as the UI is served.
   apiURL: "",
   // If the UI is served through a proxied URL, this can be set here.
   rootUrl: ""
-};
+});
 export default configDev;

--- a/src/js/constants/AppFormErrorMessages.js
+++ b/src/js/constants/AppFormErrorMessages.js
@@ -1,7 +1,7 @@
-var Messages = require("../constants/Messages");
-var Util = require("../helpers/Util");
+import Messages from "../constants/Messages";
+import Util from "../helpers/Util";
 
-const ValidConstraints = require("./ValidConstraints");
+import ValidConstraints from "./ValidConstraints";
 
 const applicationFieldValidationErrors = Util.deepFreeze({
   appId: [
@@ -90,4 +90,4 @@ const AppFormErrorMessages = {
   }
 };
 
-module.exports = Util.deepFreeze(AppFormErrorMessages);
+export default Util.deepFreeze(AppFormErrorMessages);

--- a/src/js/constants/AppListViewTypes.js
+++ b/src/js/constants/AppListViewTypes.js
@@ -3,4 +3,4 @@ const AppListViewTypes = {
   GROUPED_LIST: "GROUPED_LIST"
 };
 
-module.exports = Object.freeze(AppListViewTypes);
+export default Object.freeze(AppListViewTypes);

--- a/src/js/constants/AppStatus.js
+++ b/src/js/constants/AppStatus.js
@@ -9,4 +9,4 @@ const AppStatus = {
   WAITING: 4
 };
 
-module.exports = Object.freeze(AppStatus);
+export default Object.freeze(AppStatus);

--- a/src/js/constants/AppTypes.js
+++ b/src/js/constants/AppTypes.js
@@ -3,4 +3,4 @@ const AppTypes = {
   DOCKER: "DOCKER"
 };
 
-module.exports = Object.freeze(AppTypes);
+export default Object.freeze(AppTypes);

--- a/src/js/constants/ContainerConstants.js
+++ b/src/js/constants/ContainerConstants.js
@@ -1,4 +1,4 @@
-var Util = require("../helpers/Util");
+import Util from "../helpers/Util";
 
 const ContainerConstants = {
   NETWORK: {
@@ -22,4 +22,4 @@ const ContainerConstants = {
   }
 };
 
-module.exports = Util.deepFreeze(ContainerConstants);
+export default Util.deepFreeze(ContainerConstants);

--- a/src/js/constants/DialogSeverity.js
+++ b/src/js/constants/DialogSeverity.js
@@ -4,4 +4,4 @@ const DialogSeverity = {
   WARNING: "warning"
 };
 
-module.exports = Object.freeze(DialogSeverity);
+export default Object.freeze(DialogSeverity);

--- a/src/js/constants/DialogTypes.js
+++ b/src/js/constants/DialogTypes.js
@@ -4,4 +4,4 @@ const DialogTypes = {
   PROMPT: "prompt"
 };
 
-module.exports = Object.freeze(DialogTypes);
+export default Object.freeze(DialogTypes);

--- a/src/js/constants/FilterTypes.js
+++ b/src/js/constants/FilterTypes.js
@@ -5,4 +5,4 @@ const FilterTypes = {
   TEXT: "filterText"
 };
 
-module.exports = Object.freeze(FilterTypes);
+export default Object.freeze(FilterTypes);

--- a/src/js/constants/HealthCheckPortTypes.js
+++ b/src/js/constants/HealthCheckPortTypes.js
@@ -3,4 +3,4 @@ const HealthCheckPortTypes = {
   PORT_NUMBER: "PORT_NUMBER"
 };
 
-module.exports = Object.freeze(HealthCheckPortTypes);
+export default Object.freeze(HealthCheckPortTypes);

--- a/src/js/constants/HealthCheckProtocols.js
+++ b/src/js/constants/HealthCheckProtocols.js
@@ -4,4 +4,4 @@ const HealthCheckProtocols = {
   COMMAND: "COMMAND"
 };
 
-module.exports = Object.freeze(HealthCheckProtocols);
+export default Object.freeze(HealthCheckProtocols);

--- a/src/js/constants/HealthStatus.js
+++ b/src/js/constants/HealthStatus.js
@@ -7,4 +7,4 @@ const HealthStatus = {
   UNSCHEDULED: "unscheduled"
 };
 
-module.exports = Object.freeze(HealthStatus);
+export default Object.freeze(HealthStatus);

--- a/src/js/constants/LabelMapping.js
+++ b/src/js/constants/LabelMapping.js
@@ -1,15 +1,11 @@
-var Util = require("../helpers/Util");
+import Util from "../helpers/Util";
 
-var AppStatus = require("../constants/AppStatus");
+import AppStatus from "../constants/AppStatus";
 
-const LabelMapping = {
-  statusNameMapping: {
-    [AppStatus.RUNNING]: "Running",
-    [AppStatus.DEPLOYING]: "Deploying",
-    [AppStatus.SUSPENDED]: "Suspended",
-    [AppStatus.DELAYED]: "Delayed",
-    [AppStatus.WAITING]: "Waiting"
-  }
-};
-
-module.exports = Util.deepFreeze(LabelMapping);
+export const statusNameMapping = Util.deepFreeze({
+  [AppStatus.RUNNING]: "Running",
+  [AppStatus.DEPLOYING]: "Deploying",
+  [AppStatus.SUSPENDED]: "Suspended",
+  [AppStatus.DELAYED]: "Delayed",
+  [AppStatus.WAITING]: "Waiting"
+});

--- a/src/js/constants/Messages.js
+++ b/src/js/constants/Messages.js
@@ -7,4 +7,4 @@ const Messages = {
 Messages[401] = Messages.UNAUTHORIZED;
 Messages[403] = Messages.FORBIDDEN;
 
-module.exports = Object.freeze(Messages);
+export default Object.freeze(Messages);

--- a/src/js/constants/States.js
+++ b/src/js/constants/States.js
@@ -6,4 +6,4 @@ const States = {
   STATE_FORBIDDEN: 4
 };
 
-module.exports = Object.freeze(States);
+export default Object.freeze(States);

--- a/src/js/constants/TaskStatus.js
+++ b/src/js/constants/TaskStatus.js
@@ -3,4 +3,4 @@ const TaskStatus = {
   STARTED: "Started"
 };
 
-module.exports = Object.freeze(TaskStatus);
+export default Object.freeze(TaskStatus);

--- a/src/js/constants/ValidConstraints.js
+++ b/src/js/constants/ValidConstraints.js
@@ -1,3 +1,3 @@
 const ValidConstraints = ["unique", "like", "unlike", "cluster", "group_by"];
 
-module.exports = Object.freeze(ValidConstraints);
+export default Object.freeze(ValidConstraints);

--- a/src/js/constants/tabs.js
+++ b/src/js/constants/tabs.js
@@ -3,4 +3,4 @@ var tabs = [
   {id: "/deployments", text: "Deployments"}
 ];
 
-module.exports = tabs;
+export default tabs;

--- a/src/js/events/AppVersionsEvents.js
+++ b/src/js/events/AppVersionsEvents.js
@@ -7,4 +7,4 @@ const AppVersionsEvents = {
   REQUEST_ONE_ERROR: "APP_VERSIONS_EVENTS_REQUEST_ONE_ERROR"
 };
 
-module.exports = Object.freeze(AppVersionsEvents);
+export default Object.freeze(AppVersionsEvents);

--- a/src/js/events/AppsEvents.js
+++ b/src/js/events/AppsEvents.js
@@ -18,4 +18,4 @@ const AppsEvents = {
   UPDATE_APPS_FILTER_COUNT: "APPS_EVENT_UPDATE_APPS_FILTER_COUNT"
 };
 
-module.exports = Object.freeze(AppsEvents);
+export default Object.freeze(AppsEvents);

--- a/src/js/events/DCOSEvents.js
+++ b/src/js/events/DCOSEvents.js
@@ -4,4 +4,4 @@ const DCOSEvents = Object.freeze({
   REQUEST_BUILD_INFORMATION_ERROR: "DCOS_EVENTS_REQUEST_BUILD_INFORMATION_ERROR"
 });
 
-module.exports = DCOSEvents;
+export default DCOSEvents;

--- a/src/js/events/DeploymentEvents.js
+++ b/src/js/events/DeploymentEvents.js
@@ -8,4 +8,4 @@ const DeploymentEvents = {
   STOP_ERROR: "DEPLOYMENT_EVENTS_STOP_ERROR"
 };
 
-module.exports = Object.freeze(DeploymentEvents);
+export default Object.freeze(DeploymentEvents);

--- a/src/js/events/DialogEvents.js
+++ b/src/js/events/DialogEvents.js
@@ -5,4 +5,4 @@ const DialogEvents = {
   DISMISS_LATEST: "DIALOG_EVENTS_DISMISS_LATEST"
 };
 
-module.exports = Object.freeze(DialogEvents);
+export default Object.freeze(DialogEvents);

--- a/src/js/events/FormEvents.js
+++ b/src/js/events/FormEvents.js
@@ -6,4 +6,4 @@ const FormEvents = {
   UPDATE: "FORM_EVENTS_UPDATE"
 };
 
-module.exports = Object.freeze(FormEvents);
+export default Object.freeze(FormEvents);

--- a/src/js/events/GroupsEvents.js
+++ b/src/js/events/GroupsEvents.js
@@ -5,4 +5,4 @@ const GroupsEvents = {
   DELETE_ERROR: "GROUPS_EVENTS_DELETE_ERROR"
 };
 
-module.exports = Object.freeze(GroupsEvents);
+export default Object.freeze(GroupsEvents);

--- a/src/js/events/InfoEvents.js
+++ b/src/js/events/InfoEvents.js
@@ -4,4 +4,4 @@ const InfoEvents = {
   REQUEST_ERROR: "INFO_EVENTS_REQUEST_ERROR"
 };
 
-module.exports = Object.freeze(InfoEvents);
+export default Object.freeze(InfoEvents);

--- a/src/js/events/MesosEvents.js
+++ b/src/js/events/MesosEvents.js
@@ -13,4 +13,4 @@ const MesosEvents = Object.freeze({
   REQUEST_FILES_ERROR: "MESOS_EVENTS_REQUEST_FILES_ERROR"
 });
 
-module.exports = MesosEvents;
+export default MesosEvents;

--- a/src/js/events/QueueEvents.js
+++ b/src/js/events/QueueEvents.js
@@ -6,4 +6,4 @@ const QueueEvents = {
   RESET_DELAY_ERROR: "QUEUE_EVENTS_RESET_DELAY_ERROR"
 };
 
-module.exports = Object.freeze(QueueEvents);
+export default Object.freeze(QueueEvents);

--- a/src/js/events/TasksEvents.js
+++ b/src/js/events/TasksEvents.js
@@ -3,4 +3,4 @@ const TasksEvents = {
   DELETE_ERROR: "TASKS_EVENTS_DELETE_ERROR"
 };
 
-module.exports = Object.freeze(TasksEvents);
+export default Object.freeze(TasksEvents);

--- a/src/js/helpers/DOMUtil.js
+++ b/src/js/helpers/DOMUtil.js
@@ -23,4 +23,4 @@ var DOMUtil = {
   }
 };
 
-module.exports = DOMUtil;
+export default DOMUtil;

--- a/src/js/helpers/JSONPUtil.js
+++ b/src/js/helpers/JSONPUtil.js
@@ -31,4 +31,4 @@ const JSONPUtil = {
   }
 };
 
-module.exports = JSONPUtil;
+export default JSONPUtil;

--- a/src/js/helpers/PathUtil.js
+++ b/src/js/helpers/PathUtil.js
@@ -17,4 +17,4 @@ var PathUtil = {
   }
 };
 
-module.exports = PathUtil;
+export default PathUtil;

--- a/src/js/helpers/Util.js
+++ b/src/js/helpers/Util.js
@@ -1,4 +1,4 @@
-var objectPath = require("object-path");
+import objectPath from "object-path";
 
 var consecutiveNumber = 0;
 // Use ``Object.prototype.toString``, as the *global* ``window.toString``
@@ -173,4 +173,4 @@ var Util = {
   }
 };
 
-module.exports = Util;
+export default Util;

--- a/src/js/helpers/ajaxWrapper.js
+++ b/src/js/helpers/ajaxWrapper.js
@@ -1,5 +1,5 @@
-var fetch = require("isomorphic-fetch");
-var Util = require("./Util");
+import fetch from "isomorphic-fetch";
+import Util from "./Util";
 
 var uniqueCalls = [];
 
@@ -116,4 +116,4 @@ var ajaxWrapper = function (opts = {}) {
   return api;
 };
 
-module.exports = ajaxWrapper;
+export default ajaxWrapper;

--- a/src/js/main.jsx
+++ b/src/js/main.jsx
@@ -1,14 +1,10 @@
-require("babel-polyfill");
-var React = require("react/addons");
-var Router = require("react-router");
-var Redirect = Router.Redirect;
-var Route = Router.Route;
-var NotFoundRoute = Router.NotFoundRoute;
-
-var AppPageComponent = require("./components/AppPageComponent");
-var PageNotFoundComponent = require("./components/PageNotFoundComponent");
-var TabPanesComponent = require("./components/TabPanesComponent");
-var Marathon = require("./components/Marathon");
+import "babel-polyfill";
+import React from "react/addons";
+import Router, {Redirect, Route, NotFoundRoute} from "react-router";
+import AppPageComponent from "./components/AppPageComponent";
+import PageNotFoundComponent from "./components/PageNotFoundComponent";
+import TabPanesComponent from "./components/TabPanesComponent";
+import Marathon from "./components/Marathon";
 
 var routes = (
   <Route name="home" path="/" handler={Marathon}>

--- a/src/js/mixins/AppActionsHandlerMixin.jsx
+++ b/src/js/mixins/AppActionsHandlerMixin.jsx
@@ -1,16 +1,16 @@
-var AppsActions = require("../actions/AppsActions");
-var AppsEvents = require("../events/AppsEvents");
-var AppsStore = require("../stores/AppsStore");
-var DialogActions = require("../actions/DialogActions");
-var DialogStore = require("../stores/DialogStore");
-var DialogSeverity = require("../constants/DialogSeverity");
-var GroupsActions = require("../actions/GroupsActions");
-var GroupsEvents = require("../events/GroupsEvents");
-var GroupsStore = require("../stores/GroupsStore");
-var Messages = require("../constants/Messages");
-var QueueActions = require("../actions/QueueActions");
-var QueueEvents = require("../events/QueueEvents");
-var QueueStore = require("../stores/QueueStore");
+import AppsActions from "../actions/AppsActions";
+import AppsEvents from "../events/AppsEvents";
+import AppsStore from "../stores/AppsStore";
+import DialogActions from "../actions/DialogActions";
+import DialogStore from "../stores/DialogStore";
+import DialogSeverity from "../constants/DialogSeverity";
+import GroupsActions from "../actions/GroupsActions";
+import GroupsEvents from "../events/GroupsEvents";
+import GroupsStore from "../stores/GroupsStore";
+import Messages from "../constants/Messages";
+import QueueActions from "../actions/QueueActions";
+import QueueEvents from "../events/QueueEvents";
+import QueueStore from "../stores/QueueStore";
 
 var bindOneTimeEvents = function (store, resolverEvents, handlers) {
   var eventHandlers = [];
@@ -380,4 +380,4 @@ var AppActionsHandlerMixin = {
   }
 };
 
-module.exports = AppActionsHandlerMixin;
+export default AppActionsHandlerMixin;

--- a/src/js/mixins/DuplicableRowsMixin.jsx
+++ b/src/js/mixins/DuplicableRowsMixin.jsx
@@ -1,9 +1,9 @@
-var React = require("react/addons");
+import React from "react/addons";
 
-var AppFormErrorMessages = require("../constants/AppFormErrorMessages");
-var FormActions = require("../actions/FormActions");
+import AppFormErrorMessages from "../constants/AppFormErrorMessages";
+import FormActions from "../actions/FormActions";
 
-var Util = require("../helpers/Util");
+import Util from "../helpers/Util";
 
 var DuplicableRowsMixin = {
   propTypes: {
@@ -153,4 +153,4 @@ var DuplicableRowsMixin = {
 
 };
 
-module.exports = DuplicableRowsMixin;
+export default DuplicableRowsMixin;

--- a/src/js/mixins/QueryParamsMixin.jsx
+++ b/src/js/mixins/QueryParamsMixin.jsx
@@ -1,7 +1,7 @@
-var Link = require("react-router").Link;
-var React = require("react/addons");
+import {Link} from "react-router";
+import React from "react/addons";
 
-var Util = require("../helpers/Util");
+import Util from "../helpers/Util";
 
 function encodeValuesToURIComponents(values) {
   if (Util.isArray(values)) {
@@ -73,4 +73,4 @@ var QueryParamsMixin = {
   }
 };
 
-module.exports = QueryParamsMixin;
+export default QueryParamsMixin;

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -1,16 +1,16 @@
-var EventEmitter = require("events").EventEmitter;
-var lazy = require("lazy.js");
-var objectPath = require("object-path");
-var Util = require("../helpers/Util");
+import {EventEmitter} from "events";
+import lazy from "lazy.js";
+import objectPath from "object-path";
+import Util from "../helpers/Util";
 
-var AppDispatcher = require("../AppDispatcher");
-var AppFormErrorMessages = require("../constants/AppFormErrorMessages");
-var AppFormTransforms = require("./transforms/AppFormTransforms");
-var AppFormModelPostProcess = require("./transforms/AppFormModelPostProcess");
-var AppFormValidators = require("./validators/AppFormValidators");
-var AppsStore = require("./AppsStore");
-var AppsEvents = require("../events/AppsEvents");
-var FormEvents = require("../events/FormEvents");
+import AppDispatcher from "../AppDispatcher";
+import AppFormErrorMessages from "../constants/AppFormErrorMessages";
+import AppFormTransforms from "./transforms/AppFormTransforms";
+import AppFormModelPostProcess from "./transforms/AppFormModelPostProcess";
+import AppFormValidators from "./validators/AppFormValidators";
+import AppsStore from "./AppsStore";
+import AppsEvents from "../events/AppsEvents";
+import FormEvents from "../events/FormEvents";
 
 const defaultFieldValues = Object.freeze({
   cpus: 0.1,
@@ -447,4 +447,4 @@ AppDispatcher.register(function (action) {
   }
 });
 
-module.exports = AppFormStore;
+export default AppFormStore;

--- a/src/js/stores/AppVersionsStore.js
+++ b/src/js/stores/AppVersionsStore.js
@@ -1,9 +1,9 @@
-var EventEmitter = require("events").EventEmitter;
-var lazy = require("lazy.js");
+import {EventEmitter} from "events";
+import lazy from "lazy.js";
 
-var AppDispatcher = require("../AppDispatcher");
-var appScheme = require("../stores/schemes/appScheme");
-var AppVersionsEvents = require("../events/AppVersionsEvents");
+import AppDispatcher from "../AppDispatcher";
+import appScheme from "../stores/schemes/appScheme";
+import AppVersionsEvents from "../events/AppVersionsEvents";
 
 function processAppVersion(appVersion) {
   return lazy(appScheme).extend(appVersion).value();
@@ -70,4 +70,4 @@ AppDispatcher.register(function (action) {
   }
 });
 
-module.exports = AppVersionsStore;
+export default AppVersionsStore;

--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -1,17 +1,17 @@
-var EventEmitter = require("events").EventEmitter;
-var lazy = require("lazy.js");
+import {EventEmitter} from "events";
+import lazy from "lazy.js";
 
-var AppDispatcher = require("../AppDispatcher");
-var AppsEvents = require("../events/AppsEvents");
-var appScheme = require("../stores/schemes/appScheme");
-var AppTypes = require("../constants/AppTypes");
-var ContainerConstants = require("../constants/ContainerConstants");
-var AppStatus = require("../constants/AppStatus");
-var HealthStatus = require("../constants/HealthStatus");
-var TasksEvents = require("../events/TasksEvents");
-var TaskStatus = require("../constants/TaskStatus");
-var QueueStore = require("./QueueStore");
-var QueueEvents = require("../events/QueueEvents");
+import AppDispatcher from "../AppDispatcher";
+import AppsEvents from "../events/AppsEvents";
+import appScheme from "../stores/schemes/appScheme";
+import AppTypes from "../constants/AppTypes";
+import ContainerConstants from "../constants/ContainerConstants";
+import AppStatus from "../constants/AppStatus";
+import HealthStatus from "../constants/HealthStatus";
+import TasksEvents from "../events/TasksEvents";
+import TaskStatus from "../constants/TaskStatus";
+import QueueStore from "./QueueStore";
+import QueueEvents from "../events/QueueEvents";
 
 const healthWeights = Object.freeze({
   [HealthStatus.UNHEALTHY]: 32,
@@ -318,4 +318,4 @@ AppDispatcher.register(function (action) {
   }
 });
 
-module.exports = AppsStore;
+export default AppsStore;

--- a/src/js/stores/DeploymentStore.js
+++ b/src/js/stores/DeploymentStore.js
@@ -1,9 +1,9 @@
-var EventEmitter = require("events").EventEmitter;
-var lazy = require("lazy.js");
+import {EventEmitter} from "events";
+import lazy from "lazy.js";
 
-var AppDispatcher = require("../AppDispatcher");
-var DeploymentEvents = require("../events/DeploymentEvents");
-var deploymentScheme = require("./schemes/deploymentScheme");
+import AppDispatcher from "../AppDispatcher";
+import DeploymentEvents from "../events/DeploymentEvents";
+import deploymentScheme from "./schemes/deploymentScheme";
 
 function processDeployments(deployments) {
   return lazy(deployments).map(function (deployment) {
@@ -66,4 +66,4 @@ AppDispatcher.register(function (action) {
   }
 });
 
-module.exports = DeploymentStore;
+export default DeploymentStore;

--- a/src/js/stores/DialogStore.js
+++ b/src/js/stores/DialogStore.js
@@ -1,10 +1,10 @@
-var EventEmitter = require("events").EventEmitter;
-var lazy = require("lazy.js");
-var Util = require("../helpers/Util");
+import {EventEmitter} from "events";
+import lazy from "lazy.js";
+import Util from "../helpers/Util";
 
-var AppDispatcher = require("../AppDispatcher");
-var DialogEvents = require("../events/DialogEvents");
-var DialogTypes = require("../constants/DialogTypes");
+import AppDispatcher from "../AppDispatcher";
+import DialogEvents from "../events/DialogEvents";
+import DialogTypes from "../constants/DialogTypes";
 
 var dialogs = [];
 
@@ -76,4 +76,4 @@ AppDispatcher.register(function (action) {
   }
 });
 
-module.exports = DialogStore;
+export default DialogStore;

--- a/src/js/stores/GroupsStore.js
+++ b/src/js/stores/GroupsStore.js
@@ -1,9 +1,9 @@
-var EventEmitter = require("events").EventEmitter;
+import {EventEmitter} from "events";
 
-var AppDispatcher = require("../AppDispatcher");
-var GroupsEvents = require("../events/GroupsEvents");
+import AppDispatcher from "../AppDispatcher";
+import GroupsEvents from "../events/GroupsEvents";
 
-var Util = require("../helpers/Util");
+import Util from "../helpers/Util";
 
 var GroupsStore = Util.extendObject(EventEmitter.prototype, {});
 
@@ -34,4 +34,4 @@ AppDispatcher.register(function (action) {
   }
 });
 
-module.exports = GroupsStore;
+export default GroupsStore;

--- a/src/js/stores/InfoStore.js
+++ b/src/js/stores/InfoStore.js
@@ -1,8 +1,8 @@
-var EventEmitter = require("events").EventEmitter;
-var lazy = require("lazy.js");
+import {EventEmitter} from "events";
+import lazy from "lazy.js";
 
-var AppDispatcher = require("../AppDispatcher");
-var InfoEvents = require("../events/InfoEvents");
+import AppDispatcher from "../AppDispatcher";
+import InfoEvents from "../events/InfoEvents";
 
 var InfoStore = lazy(EventEmitter.prototype).extend({
   info: {}
@@ -21,4 +21,4 @@ InfoStore.dispatchToken = AppDispatcher.register(function (action) {
   }
 });
 
-module.exports = InfoStore;
+export default InfoStore;

--- a/src/js/stores/MesosStore.js
+++ b/src/js/stores/MesosStore.js
@@ -1,15 +1,15 @@
-var EventEmitter = require("events").EventEmitter;
-var semver = require("semver");
+import {EventEmitter} from "events";
+import semver from "semver";
 
-var AppDispatcher = require("../AppDispatcher");
-var Util = require("../helpers/Util");
-var InfoStore = require("../stores/InfoStore");
-var InfoActions = require("../actions/InfoActions");
-var InfoEvents = require("../events/InfoEvents");
-var DCOSActions = require("../actions/DCOSActions");
-var DCOSEvents = require("../events/DCOSEvents");
-var MesosActions = require("../actions/MesosActions");
-var MesosEvents = require("../events/MesosEvents");
+import AppDispatcher from "../AppDispatcher";
+import Util from "../helpers/Util";
+import InfoStore from "../stores/InfoStore";
+import InfoActions from "../actions/InfoActions";
+import InfoEvents from "../events/InfoEvents";
+import DCOSActions from "../actions/DCOSActions";
+import DCOSEvents from "../events/DCOSEvents";
+import MesosActions from "../actions/MesosActions";
+import MesosEvents from "../events/MesosEvents";
 
 const FILES_TTL = 60000; // in ms
 const STATE_TTL = 60000;
@@ -364,5 +364,5 @@ AppDispatcher.register(function (action) {
   }
 });
 
-module.exports = MesosStore;
+export default MesosStore;
 

--- a/src/js/stores/QueueStore.js
+++ b/src/js/stores/QueueStore.js
@@ -1,10 +1,10 @@
-var EventEmitter = require("events").EventEmitter;
+import {EventEmitter} from "events";
 
-var AppDispatcher = require("../AppDispatcher");
-var QueueEvents = require("../events/QueueEvents");
-var queueScheme = require("./schemes/queueScheme");
+import AppDispatcher from "../AppDispatcher";
+import QueueEvents from "../events/QueueEvents";
+import queueScheme from "./schemes/queueScheme";
 
-var Util = require("../helpers/Util");
+import Util from "../helpers/Util";
 
 function processQueue(queue = []) {
   return queue.map(function (entry) {
@@ -58,4 +58,4 @@ AppDispatcher.register(function (action) {
   }
 });
 
-module.exports = QueueStore;
+export default QueueStore;

--- a/src/js/stores/schemes/appScheme.js
+++ b/src/js/stores/schemes/appScheme.js
@@ -1,7 +1,7 @@
-var Util = require("../../helpers/Util");
+import Util from "../../helpers/Util";
 
-var AppTypes = require("../../constants/AppTypes");
-var AppStatus = require("../../constants/AppStatus");
+import AppTypes from "../../constants/AppTypes";
+import AppStatus from "../../constants/AppStatus";
 
 const appScheme = {
   cmd: null,
@@ -32,4 +32,4 @@ const appScheme = {
   type: AppTypes.CGROUP
 };
 
-module.exports = Util.deepFreeze(appScheme);
+export default Util.deepFreeze(appScheme);

--- a/src/js/stores/schemes/deploymentScheme.js
+++ b/src/js/stores/schemes/deploymentScheme.js
@@ -1,4 +1,4 @@
-var Util = require("../../helpers/Util");
+import Util from "../../helpers/Util";
 
 const deploymentScheme = {
   affectedApps: [],
@@ -10,4 +10,4 @@ const deploymentScheme = {
   version: null
 };
 
-module.exports = Util.deepFreeze(deploymentScheme);
+export default Util.deepFreeze(deploymentScheme);

--- a/src/js/stores/schemes/dialogScheme.js
+++ b/src/js/stores/schemes/dialogScheme.js
@@ -1,6 +1,6 @@
-var Util = require("../../helpers/Util");
-var DialogTypes = require("../../constants/DialogTypes");
-var DialogSeverity = require("../../constants/DialogSeverity");
+import Util from "../../helpers/Util";
+import DialogTypes from "../../constants/DialogTypes";
+import DialogSeverity from "../../constants/DialogSeverity";
 
 const dialogScheme = {
   actionButtonLabel: "OK",
@@ -15,4 +15,4 @@ const dialogScheme = {
   type: DialogTypes.ALERT
 };
 
-module.exports = Util.deepFreeze(dialogScheme);
+export default Util.deepFreeze(dialogScheme);

--- a/src/js/stores/schemes/dockerRowSchemes.js
+++ b/src/js/stores/schemes/dockerRowSchemes.js
@@ -1,4 +1,4 @@
-var Util = require("../../helpers/Util");
+import Util from "../../helpers/Util";
 
 const dockerRowSchemes = {
   dockerPortMappings: {
@@ -18,4 +18,4 @@ const dockerRowSchemes = {
   }
 };
 
-module.exports = Util.deepFreeze(dockerRowSchemes);
+export default Util.deepFreeze(dockerRowSchemes);

--- a/src/js/stores/schemes/healthChecksRowScheme.js
+++ b/src/js/stores/schemes/healthChecksRowScheme.js
@@ -1,7 +1,7 @@
-var Util = require("../../helpers/Util");
+import Util from "../../helpers/Util";
 
-var HealthCheckProtocols = require("../../constants/HealthCheckProtocols");
-var HealthCheckPortTypes = require("../../constants/HealthCheckPortTypes");
+import HealthCheckProtocols from "../../constants/HealthCheckProtocols";
+import HealthCheckPortTypes from "../../constants/HealthCheckPortTypes";
 
 const healthChecksRowScheme = {
   protocol: HealthCheckProtocols.HTTP,
@@ -17,4 +17,4 @@ const healthChecksRowScheme = {
   ignoreHttp1xx: false
 };
 
-module.exports = Util.deepFreeze(healthChecksRowScheme);
+export default Util.deepFreeze(healthChecksRowScheme);

--- a/src/js/stores/schemes/queueScheme.js
+++ b/src/js/stores/schemes/queueScheme.js
@@ -1,8 +1,8 @@
-var Util = require("../../helpers/Util");
+import Util from "../../helpers/Util";
 
 const queueScheme = {
   app: {},
   delay: {}
 };
 
-module.exports = Util.deepFreeze(queueScheme);
+export default Util.deepFreeze(queueScheme);

--- a/src/js/stores/transforms/AppFormFieldToModelTransforms.js
+++ b/src/js/stores/transforms/AppFormFieldToModelTransforms.js
@@ -1,10 +1,10 @@
-var HealthCheckProtocols = require("../../constants/HealthCheckProtocols");
+import HealthCheckProtocols from "../../constants/HealthCheckProtocols";
 
-const dockerRowSchemes = require("../schemes/dockerRowSchemes");
-const healthChecksRowScheme = require("../schemes/healthChecksRowScheme");
+import dockerRowSchemes from "../schemes/dockerRowSchemes";
+import healthChecksRowScheme from "../schemes/healthChecksRowScheme";
 
-var Util = require("../../helpers/Util");
-var lazy = require("lazy.js");
+import Util from "../../helpers/Util";
+import lazy from "lazy.js";
 
 function ensureObjectScheme(row, scheme) {
   return Object.keys(row).reduce((obj, key) => {
@@ -147,4 +147,4 @@ const AppFormFieldToModelTransforms = {
     .value()
 };
 
-module.exports = Object.freeze(AppFormFieldToModelTransforms);
+export default Object.freeze(AppFormFieldToModelTransforms);

--- a/src/js/stores/transforms/AppFormModelPostProcess.js
+++ b/src/js/stores/transforms/AppFormModelPostProcess.js
@@ -1,9 +1,9 @@
-var Util = require("../../helpers/Util");
+import Util from "../../helpers/Util";
 
-var HealthCheckProtocols = require("../../constants/HealthCheckProtocols");
-var HealthCheckPortTypes = require("../../constants/HealthCheckPortTypes");
+import HealthCheckProtocols from "../../constants/HealthCheckProtocols";
+import HealthCheckPortTypes from "../../constants/HealthCheckPortTypes";
 
-const healthChecksRowScheme = require("../schemes/healthChecksRowScheme");
+import healthChecksRowScheme from "../schemes/healthChecksRowScheme";
 
 function hasOnlyEmptyValues(obj) {
   return obj == null || Util.isObject(obj) &&
@@ -80,4 +80,4 @@ const AppFormModelPostProcess = {
   }
 };
 
-module.exports = Object.freeze(AppFormModelPostProcess);
+export default Object.freeze(AppFormModelPostProcess);

--- a/src/js/stores/transforms/AppFormModelToFieldTransforms.js
+++ b/src/js/stores/transforms/AppFormModelToFieldTransforms.js
@@ -1,6 +1,6 @@
-var HealthCheckProtocols = require("../../constants/HealthCheckProtocols");
-var HealthCheckPortTypes = require("../../constants/HealthCheckPortTypes");
-var Util = require("../../helpers/Util");
+import HealthCheckProtocols from "../../constants/HealthCheckProtocols";
+import HealthCheckPortTypes from "../../constants/HealthCheckPortTypes";
+import Util from "../../helpers/Util";
 
 const AppFormModelToFieldTransforms = {
   acceptedResourceRoles: (acceptedResourceRoles) => {
@@ -80,4 +80,4 @@ const AppFormModelToFieldTransforms = {
     .join(", ")
 };
 
-module.exports = Object.freeze(AppFormModelToFieldTransforms);
+export default Object.freeze(AppFormModelToFieldTransforms);

--- a/src/js/stores/transforms/AppFormTransforms.js
+++ b/src/js/stores/transforms/AppFormTransforms.js
@@ -1,9 +1,9 @@
-var AppFormFieldToModelTransforms = require("./AppFormFieldToModelTransforms");
-var AppFormModelToFieldTransforms = require("./AppFormModelToFieldTransforms");
+import AppFormFieldToModelTransforms from "./AppFormFieldToModelTransforms";
+import AppFormModelToFieldTransforms from "./AppFormModelToFieldTransforms";
 
 const AppFormTransforms = {
   FieldToModel: AppFormFieldToModelTransforms,
   ModelToField: AppFormModelToFieldTransforms
 };
 
-module.exports = Object.freeze(AppFormTransforms);
+export default Object.freeze(AppFormTransforms);

--- a/src/js/stores/validators/AppFormValidators.js
+++ b/src/js/stores/validators/AppFormValidators.js
@@ -1,7 +1,7 @@
-var Util = require("../../helpers/Util");
-var HealthCheckProtocols = require("../../constants/HealthCheckProtocols");
-var HealthCheckPortTypes = require("../../constants/HealthCheckPortTypes");
-var ValidConstraints = require("../../constants/ValidConstraints");
+import Util from "../../helpers/Util";
+import HealthCheckProtocols from "../../constants/HealthCheckProtocols";
+import HealthCheckPortTypes from "../../constants/HealthCheckPortTypes";
+import ValidConstraints from "../../constants/ValidConstraints";
 
 function isValidPort(value) {
   if (value == null || Util.isStringAndEmpty(value)) {
@@ -156,4 +156,4 @@ const AppFormValidators = {
       .every((port) => port.toString().trim().match(/^[0-9]+$/))
 };
 
-module.exports = Object.freeze(AppFormValidators);
+export default Object.freeze(AppFormValidators);

--- a/src/test/ajaxWrapper.test.js
+++ b/src/test/ajaxWrapper.test.js
@@ -1,10 +1,10 @@
 import {expect} from "chai";
 import nock from "nock";
-
-import ajaxWrapper from "../js/helpers/ajaxWrapper";
 import expectAsync from "./helpers/expectAsync";
 
 import config from "../js/config/config";
+
+import ajaxWrapper from "../js/helpers/ajaxWrapper";
 
 var server = config.localTestserverURI;
 config.apiURL = `http://${server.address}:${server.port}/`;

--- a/src/test/ajaxWrapper.test.js
+++ b/src/test/ajaxWrapper.test.js
@@ -1,9 +1,10 @@
-var expect = require("chai").expect;
-var ajaxWrapper = require("../js/helpers/ajaxWrapper");
-var config = require("../js/config/config");
+import {expect} from "chai";
+import nock from "nock";
 
-var expectAsync = require("./helpers/expectAsync");
-var nock = require("nock");
+import ajaxWrapper from "../js/helpers/ajaxWrapper";
+import expectAsync from "./helpers/expectAsync";
+
+import config from "../js/config/config";
 
 var server = config.localTestserverURI;
 config.apiURL = `http://${server.address}:${server.port}/`;

--- a/src/test/appDebugInfo.test.js
+++ b/src/test/appDebugInfo.test.js
@@ -1,18 +1,16 @@
-var expect = require("chai").expect;
-var nock = require("nock");
-var shallow = require("enzyme").shallow;
-
-var React = require("react/addons");
+import {expect} from "chai";
+import nock from "nock";
+import {shallow} from "enzyme";
+import React from "react/addons";
 var TestUtils = React.addons.TestUtils;
 
-var config = require("../js/config/config");
-var Util = require("../js/helpers/Util");
-var appScheme = require("../js/stores/schemes/appScheme");
-var InfoStore = require("../js/stores/InfoStore");
-var AppsStore = require("../js/stores/AppsStore");
-var AppDebugInfoComponent = require("../js/components/AppDebugInfoComponent");
-var AppTaskStatsListComponent =
-  require("../js/components/AppTaskStatsListComponent");
+import config from "../js/config/config";
+import Util from "../js/helpers/Util";
+import appScheme from "../js/stores/schemes/appScheme";
+import InfoStore from "../js/stores/InfoStore";
+import AppsStore from "../js/stores/AppsStore";
+import AppDebugInfoComponent from "../js/components/AppDebugInfoComponent";
+import AppTaskStatsListComponent from "../js/components/AppTaskStatsListComponent";
 
 var server = config.localTestserverURI;
 config.apiURL = "http://" + server.address + ":" + server.port + "/";

--- a/src/test/appDebugInfo.test.js
+++ b/src/test/appDebugInfo.test.js
@@ -2,9 +2,9 @@ import {expect} from "chai";
 import nock from "nock";
 import {shallow} from "enzyme";
 import React from "react/addons";
-var TestUtils = React.addons.TestUtils;
 
 import config from "../js/config/config";
+
 import Util from "../js/helpers/Util";
 import appScheme from "../js/stores/schemes/appScheme";
 import InfoStore from "../js/stores/InfoStore";

--- a/src/test/appForm.test.js
+++ b/src/test/appForm.test.js
@@ -3,6 +3,7 @@ import nock from "nock";
 import expectAsync from "./helpers/expectAsync";
 
 import config from "../js/config/config";
+
 import FormActions from "../js/actions/FormActions";
 import FormEvents from "../js/events/FormEvents";
 import AppsActions from "../js/actions/AppsActions";

--- a/src/test/appForm.test.js
+++ b/src/test/appForm.test.js
@@ -1,15 +1,15 @@
-var expect = require("chai").expect;
-var config = require("../js/config/config");
+import {expect} from "chai";
+import nock from "nock";
+import expectAsync from "./helpers/expectAsync";
 
-var expectAsync = require("./helpers/expectAsync");
-var FormActions = require("../js/actions/FormActions");
-var FormEvents = require("../js/events/FormEvents");
-var AppsActions = require("../js/actions/AppsActions");
-var AppsEvents = require("../js/events/AppsEvents");
-var AppsStore = require("../js/stores/AppsStore");
-var AppFormErrorMessages = require("../js/constants/AppFormErrorMessages");
-var AppFormStore = require("../js/stores/AppFormStore");
-var nock = require("nock");
+import config from "../js/config/config";
+import FormActions from "../js/actions/FormActions";
+import FormEvents from "../js/events/FormEvents";
+import AppsActions from "../js/actions/AppsActions";
+import AppsEvents from "../js/events/AppsEvents";
+import AppsStore from "../js/stores/AppsStore";
+import AppFormErrorMessages from "../js/constants/AppFormErrorMessages";
+import AppFormStore from "../js/stores/AppFormStore";
 
 var server = config.localTestserverURI;
 config.apiURL = "http://" + server.address + ":" + server.port + "/";

--- a/src/test/appFormModelPostProcess.test.js
+++ b/src/test/appFormModelPostProcess.test.js
@@ -1,7 +1,7 @@
-var expect = require("chai").expect;
+import {expect} from "chai";
 
-var AppFormModelPostProcess =
-  require("../js/stores/transforms/AppFormModelPostProcess");
+import AppFormModelPostProcess
+  from "../js/stores/transforms/AppFormModelPostProcess";
 
 describe("App Form Model Post Process", function () {
 

--- a/src/test/appFormTransforms.test.js
+++ b/src/test/appFormTransforms.test.js
@@ -1,7 +1,6 @@
-var expect = require("chai").expect;
+import {expect} from "chai";
 
-var AppFormTransforms =
-  require("../js/stores/transforms/AppFormTransforms");
+import AppFormTransforms from "../js/stores/transforms/AppFormTransforms";
 
 describe("App Form Field to Model Transform", function () {
 

--- a/src/test/appFormValidators.test.js
+++ b/src/test/appFormValidators.test.js
@@ -1,7 +1,7 @@
-var expect = require("chai").expect;
+import {expect} from "chai";
 
-var AppFormValidators = require("../js/stores/validators/AppFormValidators");
-var HealthCheckPortTypes = require("../js/constants/HealthCheckPortTypes");
+import AppFormValidators from "../js/stores/validators/AppFormValidators";
+import HealthCheckPortTypes from "../js/constants/HealthCheckPortTypes";
 
 describe("App Form Validators", function () {
 

--- a/src/test/appVersions.test.js
+++ b/src/test/appVersions.test.js
@@ -5,12 +5,14 @@ import React from "react/addons";
 import expectAsync from "./helpers/expectAsync";
 
 import config from "../js/config/config";
+
 import AppVersionsActions from "../js/actions/AppVersionsActions";
 import AppVersionsEvents from "../js/events/AppVersionsEvents";
 import AppVersionsStore from "../js/stores/AppVersionsStore";
 import AppVersionComponent from "../js/components/AppVersionComponent";
 import AppVersionListComponent from "../js/components/AppVersionListComponent";
-import AppVersionListItemComponent from "../js/components/AppVersionListItemComponent";
+import AppVersionListItemComponent
+  from "../js/components/AppVersionListItemComponent";
 
 var server = config.localTestserverURI;
 config.apiURL = `http://${server.address}:${server.port}/`;

--- a/src/test/appVersions.test.js
+++ b/src/test/appVersions.test.js
@@ -1,20 +1,16 @@
-var describeWithDOM = require("enzyme").describeWithDOM;
-var expect = require("chai").expect;
-var expectAsync = require("./helpers/expectAsync");
-var mount = require("enzyme").mount;
-var nock = require("nock");
+import {expect} from "chai";
+import {mount} from "enzyme";
+import nock from "nock";
+import React from "react/addons";
+import expectAsync from "./helpers/expectAsync";
 
-var React = require("react/addons");
-
-var config = require("../js/config/config");
-var AppVersionsActions = require("../js/actions/AppVersionsActions");
-var AppVersionsEvents = require("../js/events/AppVersionsEvents");
-var AppVersionsStore = require("../js/stores/AppVersionsStore");
-var AppVersionComponent = require("../js/components/AppVersionComponent");
-var AppVersionListComponent =
-  require("../js/components/AppVersionListComponent");
-var AppVersionListItemComponent =
-  require("../js/components/AppVersionListItemComponent");
+import config from "../js/config/config";
+import AppVersionsActions from "../js/actions/AppVersionsActions";
+import AppVersionsEvents from "../js/events/AppVersionsEvents";
+import AppVersionsStore from "../js/stores/AppVersionsStore";
+import AppVersionComponent from "../js/components/AppVersionComponent";
+import AppVersionListComponent from "../js/components/AppVersionListComponent";
+import AppVersionListItemComponent from "../js/components/AppVersionListItemComponent";
 
 var server = config.localTestserverURI;
 config.apiURL = `http://${server.address}:${server.port}/`;

--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -8,6 +8,7 @@ import expectAsync from "./helpers/expectAsync";
 import * as ShallowUtils from "./helpers/ShallowUtils";
 
 import config from "../js/config/config";
+
 import Util from "../js/helpers/Util";
 import AppTypes from "../js/constants/AppTypes";
 import AppsActions from "../js/actions/AppsActions";

--- a/src/test/apps.test.js
+++ b/src/test/apps.test.js
@@ -1,39 +1,36 @@
-var _ = require("underscore");
-var config = require("../js/config/config");
-var describeWithDOM = require("enzyme").describeWithDOM;
-var expect = require("chai").expect;
-var expectAsync = require("./helpers/expectAsync");
-var mount = require("enzyme").mount;
-var nock = require("nock");
-var render = require("enzyme").render;
-var shallow = require("enzyme").shallow;
-var Util = require("../js/helpers/Util");
+import {expect} from "chai";
+import nock from "nock";
+import {mount, render, shallow} from "enzyme";
+import _ from "underscore";
+import React from "react/addons";
+var TestUtils = React.addons.TestUtils;
+import expectAsync from "./helpers/expectAsync";
+import * as ShallowUtils from "./helpers/ShallowUtils";
 
-var React = require("react/addons");
-
-var AppTypes = require("../js/constants/AppTypes");
-
-var AppsActions = require("../js/actions/AppsActions");
-var AppDispatcher = require("../js/AppDispatcher");
-var BreadcrumbComponent = require("../js/components/BreadcrumbComponent.jsx");
-var AppListComponent = require("../js/components/AppListComponent");
-var AppListItemComponent = require("../js/components/AppListItemComponent");
-var AppHealthBarComponent =
-  require("../js/components/AppHealthBarComponent");
-var AppHealthBarWithTooltipComponent =
-  require("../js/components/AppHealthBarWithTooltipComponent");
-var AppHealthDetailComponent =
-  require("../js/components/AppHealthDetailComponent");
-var AppPageComponent = require("../js/components/AppPageComponent");
-var AppStatusComponent = require("../js/components/AppStatusComponent");
-var appScheme = require("../js/stores/schemes/appScheme");
-var AppsEvents = require("../js/events/AppsEvents");
-var AppsStore = require("../js/stores/AppsStore");
-var AppStatus = require("../js/constants/AppStatus");
-var HealthStatus = require("../js/constants/HealthStatus");
-var QueueActions = require("../js/actions/QueueActions");
-var QueueStore = require("../js/stores/QueueStore");
-var States = require("../js/constants/States");
+import config from "../js/config/config";
+import Util from "../js/helpers/Util";
+import AppTypes from "../js/constants/AppTypes";
+import AppsActions from "../js/actions/AppsActions";
+import AppDispatcher from "../js/AppDispatcher";
+import BreadcrumbComponent from "../js/components/BreadcrumbComponent.jsx";
+import AppListComponent from "../js/components/AppListComponent";
+import AppListItemComponent from "../js/components/AppListItemComponent";
+import AppHealthBarComponent from "../js/components/AppHealthBarComponent";
+import AppHealthBarWithTooltipComponent
+  from "../js/components/AppHealthBarWithTooltipComponent";
+import AppHealthDetailComponent
+  from "../js/components/AppHealthDetailComponent";
+import AppPageComponent from "../js/components/AppPageComponent";
+import AppStatusComponent from "../js/components/AppStatusComponent";
+import appScheme from "../js/stores/schemes/appScheme";
+import AppsEvents from "../js/events/AppsEvents";
+import AppsStore from "../js/stores/AppsStore";
+import AppStatus from "../js/constants/AppStatus";
+import HealthStatus from "../js/constants/HealthStatus";
+import QueueActions from "../js/actions/QueueActions";
+import QueueStore from "../js/stores/QueueStore";
+import States from "../js/constants/States";
+import PopoverComponent from "../js/components/PopoverComponent";
 
 var server = config.localTestserverURI;
 config.apiURL = "http://" + server.address + ":" + server.port + "/";
@@ -1167,7 +1164,6 @@ describe("App Health Bar", function () {
   });
 
   describe("with tooltip", function () {
-    var PopoverComponent = require("../js/components/PopoverComponent");
 
     before(function () {
       this.component = mount(
@@ -1389,8 +1385,6 @@ describe("App Status component", function () {
 * the BreadcrumbComponent testing once we upgrade to ReactRouter 1.x
 */
 describe("Breadcrumb Component", function () {
-  var TestUtils = React.addons.TestUtils;
-  var ShallowUtils = require("./helpers/ShallowUtils");
 
   before(function () {
     this.renderComponent = (group, app, task) => {

--- a/src/test/dcos.test.js
+++ b/src/test/dcos.test.js
@@ -3,6 +3,7 @@ import nock from "nock";
 import expectAsync from "./helpers/expectAsync";
 
 import config from "../js/config/config";
+
 import AppDispatcher from "../js/AppDispatcher";
 import DCOSActions from "../js/actions/DCOSActions";
 import DCOSEvents from "../js/events/DCOSEvents";

--- a/src/test/dcos.test.js
+++ b/src/test/dcos.test.js
@@ -1,13 +1,11 @@
-var expect = require("chai").expect;
-var nock = require("nock");
+import {expect} from "chai";
+import nock from "nock";
+import expectAsync from "./helpers/expectAsync";
 
-var config = require("../js/config/config");
-
-var AppDispatcher = require("../js/AppDispatcher");
-var DCOSActions = require("../js/actions/DCOSActions");
-var DCOSEvents = require("../js/events/DCOSEvents");
-
-var expectAsync = require("./helpers/expectAsync");
+import config from "../js/config/config";
+import AppDispatcher from "../js/AppDispatcher";
+import DCOSActions from "../js/actions/DCOSActions";
+import DCOSEvents from "../js/events/DCOSEvents";
 
 var server = config.localTestserverURI;
 config.apiURL = "http://" + server.address + ":" + server.port + "/";

--- a/src/test/deployments.test.js
+++ b/src/test/deployments.test.js
@@ -6,6 +6,7 @@ import React from "react/addons";
 import expectAsync from "./helpers/expectAsync";
 
 import config from "../js/config/config";
+
 import DeploymentActions from "../js/actions/DeploymentActions";
 import DeploymentComponent from "../js/components/DeploymentComponent";
 import NavTabsComponent from "../js/components/NavTabsComponent";

--- a/src/test/deployments.test.js
+++ b/src/test/deployments.test.js
@@ -1,20 +1,20 @@
-var _ = require("underscore");
-var expect = require("chai").expect;
-var expectAsync = require("./helpers/expectAsync");
-var nock = require("nock");
-var shallow = require("enzyme").shallow;
-var React = require("react/addons");
+import {expect} from "chai";
+import nock from "nock";
+import {shallow} from "enzyme";
+import _ from "underscore";
+import React from "react/addons";
+import expectAsync from "./helpers/expectAsync";
 
-var config = require("../js/config/config");
-var DeploymentActions = require("../js/actions/DeploymentActions");
-var DeploymentComponent = require("../js/components/DeploymentComponent");
-var NavTabsComponent = require("../js/components/NavTabsComponent");
-var DeploymentEvents = require("../js/events/DeploymentEvents");
-var DeploymentStore = require("../js/stores/DeploymentStore");
+import config from "../js/config/config";
+import DeploymentActions from "../js/actions/DeploymentActions";
+import DeploymentComponent from "../js/components/DeploymentComponent";
+import NavTabsComponent from "../js/components/NavTabsComponent";
+import DeploymentEvents from "../js/events/DeploymentEvents";
+import DeploymentStore from "../js/stores/DeploymentStore";
 
 var server = config.localTestserverURI;
 config.apiURL = "http://" + server.address + ":" + server.port + "/";
-var tabs = require("../js/constants/tabs");
+import tabs from "../js/constants/tabs";
 
 describe("Deployments", function () {
 

--- a/src/test/dialogs.test.js
+++ b/src/test/dialogs.test.js
@@ -1,17 +1,18 @@
-var describeWithDOM = require("enzyme").describeWithDOM;
-var mount = require("enzyme").mount;
-var shallow = require("enzyme").shallow;
-var expect = require("chai").expect;
-var React = require("react/addons");
+import {expect} from "chai";
+import {mount, shallow} from "enzyme";
+import React from "react/addons";
 var TestUtils = React.addons.TestUtils;
+import expectAsync from "./helpers/expectAsync";
 
-var DialogActions = require("../js/actions/DialogActions");
-var DialogEvents = require("../js/events/DialogEvents");
-var DialogStore = require("../js/stores/DialogStore");
-var DialogTypes = require("../js/constants/DialogTypes");
-var DialogSeverity = require("../js/constants/DialogSeverity");
+import DialogActions from "../js/actions/DialogActions";
+import DialogEvents from "../js/events/DialogEvents";
+import DialogStore from "../js/stores/DialogStore";
+import DialogTypes from "../js/constants/DialogTypes";
+import DialogSeverity from "../js/constants/DialogSeverity";
 
-var expectAsync = require("./helpers/expectAsync");
+import AlertDialogComponent from "../js/components/AlertDialogComponent";
+import ConfirmDialoglComponent from "../js/components/ConfirmDialoglComponent";
+import PromptDialogComponent from "../js/components/PromptDialogComponent";
 
 describe("Dialog store", function () {
 
@@ -795,7 +796,6 @@ describe("Dialog store", function () {
 describe("Dialog components", function () {
 
   describe("alert", function () {
-    var AlertDialogComponent = require("../js/components/AlertDialogComponent");
 
     var dialogData = {
       actionButtonLabel: "Test Button Label",
@@ -850,8 +850,6 @@ describe("Dialog components", function () {
   });
 
   describe("confirm", function () {
-    var ConfirmDialoglComponent =
-      require("../js/components/ConfirmDialoglComponent");
 
     var dialogData = {
       actionButtonLabel: "Test Button Label",
@@ -919,8 +917,6 @@ describe("Dialog components", function () {
   });
 
   describe("prompt", function () {
-    var PromptDialogComponent =
-      require("../js/components/PromptDialogComponent");
 
     var dialogData = {
       actionButtonLabel: "Test Button Label",

--- a/src/test/environment/jsdom.js
+++ b/src/test/environment/jsdom.js
@@ -1,4 +1,4 @@
-var jsdom = require("jsdom");
+import jsdom from "jsdom";
 
 const html = "<!doctype html><html><head></head><body></body></html>";
 

--- a/src/test/groups.test.js
+++ b/src/test/groups.test.js
@@ -3,6 +3,7 @@ import nock from "nock";
 import expectAsync from "./helpers/expectAsync";
 
 import config from "../js/config/config";
+
 import GroupsAction from "../js/actions/GroupsActions";
 import GroupsEvents from "../js/events/GroupsEvents";
 import GroupsStore from "../js/stores/GroupsStore";

--- a/src/test/groups.test.js
+++ b/src/test/groups.test.js
@@ -1,11 +1,11 @@
-var expect = require("chai").expect;
-var expectAsync = require("./helpers/expectAsync");
-var nock = require("nock");
+import {expect} from "chai";
+import nock from "nock";
+import expectAsync from "./helpers/expectAsync";
 
-var config = require("../js/config/config");
-var GroupsAction = require("../js/actions/GroupsActions");
-var GroupsEvents = require("../js/events/GroupsEvents");
-var GroupsStore = require("../js/stores/GroupsStore");
+import config from "../js/config/config";
+import GroupsAction from "../js/actions/GroupsActions";
+import GroupsEvents from "../js/events/GroupsEvents";
+import GroupsStore from "../js/stores/GroupsStore";
 
 var server = config.localTestserverURI;
 config.apiURL = "http://" + server.address + ":" + server.port + "/";

--- a/src/test/helpers/ShallowUtils.js
+++ b/src/test/helpers/ShallowUtils.js
@@ -1,4 +1,4 @@
-var _ = require("underscore");
+import _ from "underscore";
 
 function getClassNames(component) {
   if (component.props == null || component.props.className == null) {
@@ -9,7 +9,7 @@ function getClassNames(component) {
     .match(/\S+/g);
 }
 
-function findAll(component, className) {
+export function findAll(component, className) {
   return _.reduce(component.props.children, function (matches, child) {
     if (child != null && child.props != null) {
       var classes = getClassNames(child);
@@ -23,11 +23,11 @@ function findAll(component, className) {
   }, []);
 }
 
-function findOne(component, className) {
+export function findOne(component, className) {
   return _.first(findAll(component, className));
 }
 
-function getText(component) {
+export function getText(component) {
   if (typeof (component) === "string") {
     return component;
   }
@@ -37,9 +37,3 @@ function getText(component) {
     }, "");
   }
 }
-
-module.exports = {
-  findAll: findAll,
-  findOne: findOne,
-  getText: getText
-};

--- a/src/test/helpers/expectAsync.js
+++ b/src/test/helpers/expectAsync.js
@@ -1,5 +1,5 @@
 // Allows the use of chai assertions inside an async block
-function expectAsync (fn, done) {
+function expectAsync(fn, done) {
   try {
     fn();
     done()
@@ -9,4 +9,4 @@ function expectAsync (fn, done) {
   }
 }
 
-module.exports = expectAsync;
+export default expectAsync;

--- a/src/test/info.test.js
+++ b/src/test/info.test.js
@@ -5,8 +5,8 @@ import _ from "underscore";
 import React from "react/addons";
 import expectAsync from "./helpers/expectAsync";
 
-
 import config from "../js/config/config";
+
 import AboutModalComponent from "../js/components/modals/AboutModalComponent";
 import InfoActions from "../js/actions/InfoActions";
 import InfoEvents from "../js/events/InfoEvents";

--- a/src/test/info.test.js
+++ b/src/test/info.test.js
@@ -1,19 +1,17 @@
-var _ = require("underscore");
-var expect = require("chai").expect;
-var expectAsync = require("./helpers/expectAsync");
-var shallow = require("enzyme").shallow;
-var nock = require("nock");
-var describeWithDOM = require("enzyme").describeWithDOM;
+import {expect} from "chai";
+import {shallow} from "enzyme";
+import nock from "nock";
+import _ from "underscore";
+import React from "react/addons";
+import expectAsync from "./helpers/expectAsync";
 
-var React = require("react/addons");
 
-var config = require("../js/config/config");
-var AboutModalComponent = require(
-  "../js/components/modals/AboutModalComponent");
-var InfoActions = require("../js/actions/InfoActions");
-var InfoEvents = require("../js/events/InfoEvents");
-var InfoStore = require("../js/stores/InfoStore");
-var ObjectDlComponent = require("../js/components/ObjectDlComponent");
+import config from "../js/config/config";
+import AboutModalComponent from "../js/components/modals/AboutModalComponent";
+import InfoActions from "../js/actions/InfoActions";
+import InfoEvents from "../js/events/InfoEvents";
+import InfoStore from "../js/stores/InfoStore";
+import ObjectDlComponent from "../js/components/ObjectDlComponent";
 
 var server = config.localTestserverURI;
 config.apiURL = "http://" + server.address + ":" + server.port + "/";

--- a/src/test/mesos.test.js
+++ b/src/test/mesos.test.js
@@ -2,10 +2,11 @@ import {expect} from "chai";
 import nock from "nock";
 import React from "react/addons";
 import expectAsync from "./helpers/expectAsync";
+import ajaxWrapper from "../js/helpers/ajaxWrapper";
 
 import config from "../js/config/config";
+
 import AppDispatcher from "../js/AppDispatcher";
-import ajaxWrapper from "../js/helpers/ajaxWrapper";
 import JSONPUtil from "../js/helpers/JSONPUtil";
 import InfoActions from "../js/actions/InfoActions";
 import InfoStore from "../js/stores/InfoStore";

--- a/src/test/mesos.test.js
+++ b/src/test/mesos.test.js
@@ -1,23 +1,22 @@
-var expect = require("chai").expect;
-var expectAsync = require("./helpers/expectAsync");
-var nock = require("nock");
-var React = require("react/addons");
+import {expect} from "chai";
+import nock from "nock";
+import React from "react/addons";
+import expectAsync from "./helpers/expectAsync";
 
-var config = require("../js/config/config");
+import config from "../js/config/config";
+import AppDispatcher from "../js/AppDispatcher";
+import ajaxWrapper from "../js/helpers/ajaxWrapper";
+import JSONPUtil from "../js/helpers/JSONPUtil";
+import InfoActions from "../js/actions/InfoActions";
+import InfoStore from "../js/stores/InfoStore";
+import InfoEvents from "../js/events/InfoEvents";
+import DCOSActions from "../js/actions/DCOSActions";
+import MesosActions from "../js/actions/MesosActions";
+import MesosStore from "../js/stores/MesosStore";
+import MesosEvents from "../js/events/MesosEvents";
 
-var AppDispatcher = require("../js/AppDispatcher");
-var ajaxWrapper = require("../js/helpers/ajaxWrapper");
-var JSONPUtil = require("../js/helpers/JSONPUtil");
-var InfoActions = require("../js/actions/InfoActions");
-var InfoStore = require("../js/stores/InfoStore");
-var InfoEvents = require("../js/events/InfoEvents");
-var DCOSActions = require("../js/actions/DCOSActions");
-var MesosActions = require("../js/actions/MesosActions");
-var MesosStore = require("../js/stores/MesosStore");
-var MesosEvents = require("../js/events/MesosEvents");
-
-var ajaxWrapperStub = require("./stubs/ajaxWrapperStub");
-var JSONPUtilRequestStub = require("./stubs/JSONPUtilRequestStub");
+import ajaxWrapperStub from "./stubs/ajaxWrapperStub";
+import JSONPUtilRequestStub from "./stubs/JSONPUtilRequestStub";
 
 var server = config.localTestserverURI;
 config.apiURL = "http://" + server.address + ":" + server.port + "/";

--- a/src/test/pathUtil.test.js
+++ b/src/test/pathUtil.test.js
@@ -1,5 +1,5 @@
-var expect = require("chai").expect;
-var PathUtil = require("../js/helpers/PathUtil");
+import {expect} from "chai";
+import PathUtil from "../js/helpers/PathUtil";
 
 describe("Path", function () {
   describe("getRelativePath", function () {

--- a/src/test/queue.test.js
+++ b/src/test/queue.test.js
@@ -1,11 +1,11 @@
-var expect = require("chai").expect;
-var expectAsync = require("./helpers/expectAsync");
-var nock = require("nock");
+import {expect} from "chai";
+import nock from "nock";
+import expectAsync from "./helpers/expectAsync";
 
-var config = require("../js/config/config");
-var QueueActions = require("../js/actions/QueueActions");
-var QueueEvents = require("../js/events/QueueEvents");
-var QueueStore = require("../js/stores/QueueStore");
+import config from "../js/config/config";
+import QueueActions from "../js/actions/QueueActions";
+import QueueEvents from "../js/events/QueueEvents";
+import QueueStore from "../js/stores/QueueStore";
 
 var server = config.localTestserverURI;
 config.apiURL = "http://" + server.address + ":" + server.port + "/";

--- a/src/test/queue.test.js
+++ b/src/test/queue.test.js
@@ -3,6 +3,7 @@ import nock from "nock";
 import expectAsync from "./helpers/expectAsync";
 
 import config from "../js/config/config";
+
 import QueueActions from "../js/actions/QueueActions";
 import QueueEvents from "../js/events/QueueEvents";
 import QueueStore from "../js/stores/QueueStore";

--- a/src/test/reporter/reporterSwitch.js
+++ b/src/test/reporter/reporterSwitch.js
@@ -1,5 +1,7 @@
-var reporter;
+// This file is loaded by mocha directly and does not support any of
+// the shiny new ES6 features.
 
+var reporter;
 if (process.env.TEAMCITY_VERSION == null) {
   reporter = require("../../../node_modules/mocha/lib/reporters/spec");
 } else {

--- a/src/test/stubs/JSONPUtilRequestStub.js
+++ b/src/test/stubs/JSONPUtilRequestStub.js
@@ -18,4 +18,4 @@ var JSONPUtilStub = function (executor) {
   }
 };
 
-module.exports = JSONPUtilStub;
+export default JSONPUtilStub;

--- a/src/test/stubs/ajaxWrapperStub.js
+++ b/src/test/stubs/ajaxWrapperStub.js
@@ -17,4 +17,4 @@ var ajaxWrapperStub = function (executor) {
     return promise;
   }
 };
-module.exports = ajaxWrapperStub;
+export default ajaxWrapperStub;

--- a/src/test/tasks.test.js
+++ b/src/test/tasks.test.js
@@ -1,29 +1,29 @@
-var _ = require("underscore");
-var expect = require("chai").expect;
-var expectAsync = require("./helpers/expectAsync");
-var nock = require("nock");
-var shallow = require("enzyme").shallow;
+import {expect} from "chai";
+import expectAsync from "./helpers/expectAsync";
+import nock from "nock";
+import {shallow} from "enzyme";
+import React from "react/addons";
+import _ from "underscore";
 
-var React = require("react/addons");
-
-var config = require("../js/config/config");
-var AppDispatcher = require("../js/AppDispatcher");
-var States = require("../js/constants/States");
-var AppsActions = require("../js/actions/AppsActions");
-var AppsStore = require("../js/stores/AppsStore");
-var AppsEvents = require("../js/events/AppsEvents");
-var InfoStore = require("../js/stores/InfoStore");
-var MesosStore = require("../js/stores/MesosStore");
-var MesosEvents = require("../js/events/MesosEvents");
-var TasksActions = require("../js/actions/TasksActions");
-var TasksEvents = require("../js/events/TasksEvents");
-var TaskListItemComponent = require("../js/components/TaskListItemComponent");
-var TaskDetailComponent = require("../js/components/TaskDetailComponent");
-var TaskListComponent = require("../js/components/TaskListComponent");
-var TaskMesosUrlComponent = require("../js/components/TaskMesosUrlComponent");
-var TaskFileListComponent = require("../js/components/TaskFileListComponent");
-var TaskFileDownloadComponent =
-  require("../js/components/TaskFileDownloadComponent");
+import config from "../js/config/config";
+import AppDispatcher from "../js/AppDispatcher";
+import States from "../js/constants/States";
+import AppsActions from "../js/actions/AppsActions";
+import AppsStore from "../js/stores/AppsStore";
+import AppsEvents from "../js/events/AppsEvents";
+import InfoStore from "../js/stores/InfoStore";
+import MesosStore from "../js/stores/MesosStore";
+import MesosEvents from "../js/events/MesosEvents";
+import TasksActions from "../js/actions/TasksActions";
+import TasksEvents from "../js/events/TasksEvents";
+import TaskListItemComponent from "../js/components/TaskListItemComponent";
+import TaskDetailComponent from "../js/components/TaskDetailComponent";
+import TaskListComponent from "../js/components/TaskListComponent";
+import TaskMesosUrlComponent from "../js/components/TaskMesosUrlComponent";
+import TaskFileListComponent from "../js/components/TaskFileListComponent";
+import TaskFileDownloadComponent
+  from "../js/components/TaskFileDownloadComponent";
+import TimeFieldComponent from "../js/components/TimeFieldComponent";
 
 var server = config.localTestserverURI;
 config.apiURL = "http://" + server.address + ":" + server.port + "/";
@@ -279,7 +279,6 @@ describe("Task Detail component", function () {
   });
 
   it("has the correct timefields", function () {
-    var TimeFieldComponent = require("../js/components/TimeFieldComponent");
     var timeFields = this.component
       .find(".task-details")
       .find(TimeFieldComponent);

--- a/src/test/tasks.test.js
+++ b/src/test/tasks.test.js
@@ -6,6 +6,7 @@ import React from "react/addons";
 import _ from "underscore";
 
 import config from "../js/config/config";
+
 import AppDispatcher from "../js/AppDispatcher";
 import States from "../js/constants/States";
 import AppsActions from "../js/actions/AppsActions";

--- a/src/test/util.test.js
+++ b/src/test/util.test.js
@@ -1,5 +1,5 @@
-var expect = require("chai").expect;
-var Util = require("../js/helpers/Util");
+import {expect} from "chai";
+import Util from "../js/helpers/Util";
 
 describe("Util", function () {
 


### PR DESCRIPTION
Refactor all usages of `require` to the shiny new `import`-statement and update all the `export` statements as well.

Close mesosphere/marathon#2738