### PR TITLE
Require babel-polyfill properly

### DIFF
--- a/src/js/main.jsx
+++ b/src/js/main.jsx
@@ -1,4 +1,4 @@
-require("babel/polyfill");
+require("babel-polyfill");
 var React = require("react/addons");
 var Router = require("react-router");
 var Redirect = Router.Redirect;


### PR DESCRIPTION
When we switched from `babel` to `babel/cli` we lost track of updating the `require("babel/polyfill")` in the main.jsx file. 
This PR fixes this.

Related change:
https://github.com/mesosphere/marathon-ui/pull/554/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R16

This fixes an annoying error 
```
ERROR in ./src/js/main.jsx
Module not found: Error: Cannot resolve module 'babel/polyfill' in /Users/pierlo/Development/marathon-ui/src/js
 @ ./src/js/main.jsx 3:0-25
```
This is very URGENT and needs to end in 0.15!