### PR TITLE
Add a version check gulp task to default

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -225,10 +225,25 @@ gulp.task("replace-js-strings", ["webpack", "minify-js"], function () {
     .pipe(gulp.dest(dirs.dist));
 });
 
+gulp.task("version-check", function () {
+  var shrinkwrapVersion = require("./npm-shrinkwrap")["node-version"];
+  var packageVersion = require("./package").engines.node;
+  var nodeVersion = process.version;
+  if (shrinkwrapVersion !== nodeVersion ||
+    nodeVersion !== "v" + packageVersion) {
+    throw(
+      "\nPackage engine version is " + packageVersion + "\n" +
+      "Shrinkwrap version is " + shrinkwrapVersion + "\n" +
+      "Current Node version is " + nodeVersion
+    );
+  }
+});
+
 gulp.task("serve", ["default", "connect:server", "watch"]);
 gulp.task("livereload", ["default", "browsersync", "watch"]);
 
 var tasks = [
+  "version-check",
   "webpack",
   "less",
   "images",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -226,14 +226,14 @@ gulp.task("replace-js-strings", ["webpack", "minify-js"], function () {
 });
 
 gulp.task("version-check", function () {
-  var shrinkwrapVersion = require("./npm-shrinkwrap")["node-version"];
-  var packageVersion = require("./package").engines.node;
+  var shrinkwrapNodeVersion = require("./npm-shrinkwrap")["node-version"];
+  var packageNodeVersion = require("./package").engines.node;
   var nodeVersion = process.version;
-  if (shrinkwrapVersion !== nodeVersion ||
-    nodeVersion !== "v" + packageVersion) {
+  if (shrinkwrapNodeVersion !== nodeVersion ||
+    nodeVersion !== "v" + packageNodeVersion) {
     throw(
-      "\nPackage engine version is " + packageVersion + "\n" +
-      "Shrinkwrap version is " + shrinkwrapVersion + "\n" +
+      "\nPackage Node engine version is " + packageVersion + "\n" +
+      "Shrinkwrap Node version is " + shrinkwrapVersion + "\n" +
       "Current Node version is " + nodeVersion
     );
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "marathon-ui",
   "version": "0.16.0",
+  "engines": {
+    "node": "5.2.0"
+  },
   "description": "The web UI for Mesosphere's Marathon.",
   "main": "dist/main.js",
   "keywords": [
@@ -78,7 +81,7 @@
     "build": "gulp",
     "clean": "rm -rf dist release",
     "dist": "export GULP_ENV=\"production\" && npm run clean && npm run test && npm run build",
-    "shrinkwrap": "npm-shrinkwrap --dev",
+    "shrinkwrap": "gulp version-check && npm-shrinkwrap --dev",
     "test": "mocha --ui exports --reporter src/test/reporter/reporterSwitch --require babel-core/register --require babel-polyfill --require src/test/environment/jsdom  src/test/**/*.test.* src/test/*.test.*",
     "lint": "eslint src/**/*.js*",
     "serve": "export GULP_ENV=\"development\" DISABLE_SOURCE_MAP=false && gulp serve",


### PR DESCRIPTION
@philipnrmn and I added a version check to gulp to prevent version divergence. This ensures that npm-shrinkwrap does not get corrupted by different versions of node. 