### PR TITLE
Bump node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_script:
   - npm cache clear
   - npm install -g gulp
 node_js:
-  - "5.2.0"
+  - "5.4.1"
 script: npm install && npm run dist
 after_success: npm run cover:report
 notifications:

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,1650 +2,134 @@
   "name": "marathon-ui",
   "version": "0.16.0",
   "npm-shrinkwrap-version": "200.4.0",
-  "node-version": "v5.2.0",
+  "node-version": "v5.4.1",
   "dependencies": {
+    "abbrev": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+    },
     "acorn": {
       "version": "2.6.4",
+      "from": "acorn@https://registry.npmjs.org/acorn/-/acorn-2.6.4.tgz",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.6.4.tgz"
     },
     "acorn-globals": {
       "version": "1.0.9",
+      "from": "acorn-globals@https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz"
+    },
+    "align-text": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+      "dependencies": {
+        "kind-of": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz"
+        }
+      }
     },
     "amdefine": {
       "version": "1.0.0",
+      "from": "amdefine@https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
     },
     "ansi-regex": {
       "version": "2.0.0",
+      "from": "ansi-regex@https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
     },
     "ansi-styles": {
       "version": "2.1.0",
+      "from": "ansi-styles@https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+    },
+    "anymatch": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz"
+    },
+    "argparse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.4.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.0.0.tgz"
+        }
+      }
+    },
+    "arr-diff": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
+    },
+    "arr-flatten": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+    },
+    "array-uniq": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+    },
+    "array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
     },
     "asn1": {
       "version": "0.2.3",
+      "from": "asn1@https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
     },
     "assert-plus": {
       "version": "0.1.5",
+      "from": "assert-plus@https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
     },
     "async": {
       "version": "1.5.0",
+      "from": "async@https://registry.npmjs.org/async/-/async-1.5.0.tgz",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+    },
+    "async-each": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
     },
     "aws-sign2": {
       "version": "0.6.0",
+      "from": "aws-sign2@https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
     },
-    "babel": {
-      "version": "5.8.34",
-      "from": "babel@https://registry.npmjs.org/babel/-/babel-5.8.34.tgz",
-      "resolved": "https://registry.npmjs.org/babel/-/babel-5.8.34.tgz",
+    "babel-cli": {
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.4.5.tgz",
       "dependencies": {
         "babel-core": {
-          "version": "5.8.34",
-          "from": "babel-core@https://registry.npmjs.org/babel-core/-/babel-core-5.8.34.tgz",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.34.tgz",
-          "dependencies": {
-            "babel-plugin-constant-folding": {
-              "version": "1.0.1",
-              "from": "babel-plugin-constant-folding@https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
-            },
-            "babel-plugin-dead-code-elimination": {
-              "version": "1.0.2",
-              "from": "babel-plugin-dead-code-elimination@https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
-            },
-            "babel-plugin-eval": {
-              "version": "1.0.1",
-              "from": "babel-plugin-eval@https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
-            },
-            "babel-plugin-inline-environment-variables": {
-              "version": "1.0.1",
-              "from": "babel-plugin-inline-environment-variables@https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
-            },
-            "babel-plugin-jscript": {
-              "version": "1.0.4",
-              "from": "babel-plugin-jscript@https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
-            },
-            "babel-plugin-member-expression-literals": {
-              "version": "1.0.1",
-              "from": "babel-plugin-member-expression-literals@https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
-            },
-            "babel-plugin-property-literals": {
-              "version": "1.0.1",
-              "from": "babel-plugin-property-literals@https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
-            },
-            "babel-plugin-proto-to-assign": {
-              "version": "1.0.4",
-              "from": "babel-plugin-proto-to-assign@https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
-            },
-            "babel-plugin-react-constant-elements": {
-              "version": "1.0.3",
-              "from": "babel-plugin-react-constant-elements@https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
-            },
-            "babel-plugin-react-display-name": {
-              "version": "1.0.3",
-              "from": "babel-plugin-react-display-name@https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
-            },
-            "babel-plugin-remove-console": {
-              "version": "1.0.1",
-              "from": "babel-plugin-remove-console@https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
-            },
-            "babel-plugin-remove-debugger": {
-              "version": "1.0.1",
-              "from": "babel-plugin-remove-debugger@https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
-            },
-            "babel-plugin-runtime": {
-              "version": "1.0.7",
-              "from": "babel-plugin-runtime@https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
-            },
-            "babel-plugin-undeclared-variables-check": {
-              "version": "1.0.2",
-              "from": "babel-plugin-undeclared-variables-check@https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
-              "dependencies": {
-                "leven": {
-                  "version": "1.0.2",
-                  "from": "leven@https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
-                }
-              }
-            },
-            "babel-plugin-undefined-to-void": {
-              "version": "1.1.6",
-              "from": "babel-plugin-undefined-to-void@https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
-            },
-            "babylon": {
-              "version": "5.8.34",
-              "from": "babylon@https://registry.npmjs.org/babylon/-/babylon-5.8.34.tgz",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.34.tgz"
-            },
-            "bluebird": {
-              "version": "2.10.2",
-              "from": "bluebird@https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
-              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
-            },
-            "chalk": {
-              "version": "1.1.1",
-              "from": "chalk@https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.1.0",
-                  "from": "ansi-styles@https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.3",
-                  "from": "escape-string-regexp@http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "from": "has-ansi@https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "ansi-regex@https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.0",
-                  "from": "strip-ansi@https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "ansi-regex@https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                }
-              }
-            },
-            "core-js": {
-              "version": "1.2.6",
-              "from": "core-js@https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-            },
-            "debug": {
-              "version": "2.2.0",
-              "from": "debug@https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "dependencies": {
-                "ms": {
-                  "version": "0.7.1",
-                  "from": "ms@https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                }
-              }
-            },
-            "detect-indent": {
-              "version": "3.0.1",
-              "from": "detect-indent@https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-              "dependencies": {
-                "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "get-stdin@http://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-                  "resolved": "http://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                },
-                "minimist": {
-                  "version": "1.2.0",
-                  "from": "minimist@https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                }
-              }
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "from": "esutils@https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-            },
-            "globals": {
-              "version": "6.4.1",
-              "from": "globals@https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
-            },
-            "home-or-tmp": {
-              "version": "1.0.0",
-              "from": "home-or-tmp@https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-              "dependencies": {
-                "os-tmpdir": {
-                  "version": "1.0.1",
-                  "from": "os-tmpdir@https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-                },
-                "user-home": {
-                  "version": "1.1.1",
-                  "from": "user-home@https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
-                }
-              }
-            },
-            "is-integer": {
-              "version": "1.0.6",
-              "from": "is-integer@https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
-              "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
-              "dependencies": {
-                "is-finite": {
-                  "version": "1.0.1",
-                  "from": "is-finite@https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "from": "number-is-nan@https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "js-tokens": {
-              "version": "1.0.1",
-              "from": "js-tokens@https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
-            },
-            "json5": {
-              "version": "0.4.0",
-              "from": "json5@https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
-            },
-            "line-numbers": {
-              "version": "0.2.0",
-              "from": "line-numbers@https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-              "dependencies": {
-                "left-pad": {
-                  "version": "0.0.3",
-                  "from": "left-pad@https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                }
-              }
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "from": "minimatch@https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.1",
-                  "from": "brace-expansion@https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.2.1",
-                      "from": "balanced-match@https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "private": {
-              "version": "0.1.6",
-              "from": "private@https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-              "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
-            },
-            "regenerator": {
-              "version": "0.8.40",
-              "from": "regenerator@https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
-              "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
-              "dependencies": {
-                "commoner": {
-                  "version": "0.10.4",
-                  "from": "commoner@https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
-                  "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
-                  "dependencies": {
-                    "detective": {
-                      "version": "4.3.1",
-                      "from": "detective@https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
-                      "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
-                      "dependencies": {
-                        "acorn": {
-                          "version": "1.2.2",
-                          "from": "acorn@https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
-                          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
-                        },
-                        "defined": {
-                          "version": "1.0.0",
-                          "from": "defined@https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "graceful-fs": {
-                      "version": "4.1.2",
-                      "from": "graceful-fs@https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                    },
-                    "iconv-lite": {
-                      "version": "0.4.13",
-                      "from": "iconv-lite@https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
-                    },
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "from": "mkdirp@https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "0.0.8",
-                          "from": "minimist@https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                        }
-                      }
-                    },
-                    "q": {
-                      "version": "1.4.1",
-                      "from": "q@https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
-                    }
-                  }
-                },
-                "defs": {
-                  "version": "1.1.1",
-                  "from": "defs@https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
-                  "dependencies": {
-                    "alter": {
-                      "version": "0.2.0",
-                      "from": "alter@https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
-                      "dependencies": {
-                        "stable": {
-                          "version": "0.1.5",
-                          "from": "stable@https://registry.npmjs.org/stable/-/stable-0.1.5.tgz",
-                          "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
-                        }
-                      }
-                    },
-                    "ast-traverse": {
-                      "version": "0.1.1",
-                      "from": "ast-traverse@https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
-                    },
-                    "breakable": {
-                      "version": "1.0.0",
-                      "from": "breakable@https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
-                    },
-                    "simple-fmt": {
-                      "version": "0.1.0",
-                      "from": "simple-fmt@https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
-                    },
-                    "simple-is": {
-                      "version": "0.2.0",
-                      "from": "simple-is@https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
-                    },
-                    "stringmap": {
-                      "version": "0.2.2",
-                      "from": "stringmap@https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
-                    },
-                    "stringset": {
-                      "version": "0.2.1",
-                      "from": "stringset@https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
-                    },
-                    "tryor": {
-                      "version": "0.1.2",
-                      "from": "tryor@https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
-                    },
-                    "yargs": {
-                      "version": "3.27.0",
-                      "from": "yargs@https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
-                      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
-                      "dependencies": {
-                        "camelcase": {
-                          "version": "1.2.1",
-                          "from": "camelcase@https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                        },
-                        "cliui": {
-                          "version": "2.1.0",
-                          "from": "cliui@https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                          "dependencies": {
-                            "center-align": {
-                              "version": "0.1.2",
-                              "from": "center-align@https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
-                              "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
-                              "dependencies": {
-                                "align-text": {
-                                  "version": "0.1.3",
-                                  "from": "align-text@https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                                  "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                                  "dependencies": {
-                                    "kind-of": {
-                                      "version": "2.0.1",
-                                      "from": "kind-of@https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-                                      "dependencies": {
-                                        "is-buffer": {
-                                          "version": "1.1.0",
-                                          "from": "is-buffer@https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "longest": {
-                                      "version": "1.0.1",
-                                      "from": "longest@https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                                    },
-                                    "repeat-string": {
-                                      "version": "1.5.2",
-                                      "from": "repeat-string@https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
-                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
-                                    }
-                                  }
-                                },
-                                "lazy-cache": {
-                                  "version": "0.2.4",
-                                  "from": "lazy-cache@https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.4.tgz",
-                                  "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.4.tgz"
-                                }
-                              }
-                            },
-                            "right-align": {
-                              "version": "0.1.3",
-                              "from": "right-align@https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                              "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                              "dependencies": {
-                                "align-text": {
-                                  "version": "0.1.3",
-                                  "from": "align-text@https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                                  "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                                  "dependencies": {
-                                    "kind-of": {
-                                      "version": "2.0.1",
-                                      "from": "kind-of@https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-                                      "dependencies": {
-                                        "is-buffer": {
-                                          "version": "1.1.0",
-                                          "from": "is-buffer@https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "longest": {
-                                      "version": "1.0.1",
-                                      "from": "longest@https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                                    },
-                                    "repeat-string": {
-                                      "version": "1.5.2",
-                                      "from": "repeat-string@https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
-                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "wordwrap": {
-                              "version": "0.0.2",
-                              "from": "wordwrap@https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                            }
-                          }
-                        },
-                        "decamelize": {
-                          "version": "1.1.1",
-                          "from": "decamelize@https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
-                        },
-                        "os-locale": {
-                          "version": "1.4.0",
-                          "from": "os-locale@https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-                          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-                          "dependencies": {
-                            "lcid": {
-                              "version": "1.0.0",
-                              "from": "lcid@https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-                              "dependencies": {
-                                "invert-kv": {
-                                  "version": "1.0.0",
-                                  "from": "invert-kv@https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "window-size": {
-                          "version": "0.1.4",
-                          "from": "window-size@https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-                          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
-                        },
-                        "y18n": {
-                          "version": "3.2.0",
-                          "from": "y18n@https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz",
-                          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "esprima-fb": {
-                  "version": "15001.1001.0-dev-harmony-fb",
-                  "from": "esprima-fb@https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
-                },
-                "recast": {
-                  "version": "0.10.33",
-                  "from": "recast@https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
-                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
-                  "dependencies": {
-                    "ast-types": {
-                      "version": "0.8.12",
-                      "from": "ast-types@https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
-                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
-                    }
-                  }
-                },
-                "through": {
-                  "version": "2.3.8",
-                  "from": "through@https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-                }
-              }
-            },
-            "regexpu": {
-              "version": "1.3.0",
-              "from": "regexpu@https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
-              "dependencies": {
-                "esprima": {
-                  "version": "2.7.0",
-                  "from": "esprima@https://registry.npmjs.org/esprima/-/esprima-2.7.0.tgz",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.0.tgz"
-                },
-                "recast": {
-                  "version": "0.10.39",
-                  "from": "recast@https://registry.npmjs.org/recast/-/recast-0.10.39.tgz",
-                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.39.tgz",
-                  "dependencies": {
-                    "ast-types": {
-                      "version": "0.8.12",
-                      "from": "ast-types@https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
-                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
-                    },
-                    "esprima-fb": {
-                      "version": "15001.1001.0-dev-harmony-fb",
-                      "from": "esprima-fb@https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
-                    }
-                  }
-                },
-                "regenerate": {
-                  "version": "1.2.1",
-                  "from": "regenerate@https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
-                },
-                "regjsgen": {
-                  "version": "0.2.0",
-                  "from": "regjsgen@https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
-                },
-                "regjsparser": {
-                  "version": "0.1.5",
-                  "from": "regjsparser@https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-                  "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-                  "dependencies": {
-                    "jsesc": {
-                      "version": "0.5.0",
-                      "from": "jsesc@https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-                      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "repeating": {
-              "version": "1.1.3",
-              "from": "repeating@https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-              "dependencies": {
-                "is-finite": {
-                  "version": "1.0.1",
-                  "from": "is-finite@https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "from": "number-is-nan@https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "resolve": {
-              "version": "1.1.6",
-              "from": "resolve@https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
-            },
-            "shebang-regex": {
-              "version": "1.0.0",
-              "from": "shebang-regex@https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
-            },
-            "source-map-support": {
-              "version": "0.2.10",
-              "from": "source-map-support@https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-              "dependencies": {
-                "source-map": {
-                  "version": "0.1.32",
-                  "from": "source-map@https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "1.0.0",
-                      "from": "amdefine@https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "to-fast-properties": {
-              "version": "1.0.1",
-              "from": "to-fast-properties@https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-            },
-            "trim-right": {
-              "version": "1.0.1",
-              "from": "trim-right@https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
-            },
-            "try-resolve": {
-              "version": "1.0.1",
-              "from": "try-resolve@https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
-            }
-          }
+          "version": "6.4.5",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.4.5.tgz"
         },
-        "chokidar": {
-          "version": "1.3.0",
-          "from": "chokidar@https://registry.npmjs.org/chokidar/-/chokidar-1.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.3.0.tgz",
-          "dependencies": {
-            "anymatch": {
-              "version": "1.3.0",
-              "from": "anymatch@https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-              "dependencies": {
-                "arrify": {
-                  "version": "1.0.0",
-                  "from": "arrify@https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
-                },
-                "micromatch": {
-                  "version": "2.3.2",
-                  "from": "micromatch@https://registry.npmjs.org/micromatch/-/micromatch-2.3.2.tgz",
-                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.2.tgz",
-                  "dependencies": {
-                    "arr-diff": {
-                      "version": "1.1.0",
-                      "from": "arr-diff@https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
-                      "dependencies": {
-                        "arr-flatten": {
-                          "version": "1.0.1",
-                          "from": "arr-flatten@https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
-                        },
-                        "array-slice": {
-                          "version": "0.2.3",
-                          "from": "array-slice@https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
-                          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
-                        }
-                      }
-                    },
-                    "array-unique": {
-                      "version": "0.2.1",
-                      "from": "array-unique@https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
-                    },
-                    "braces": {
-                      "version": "1.8.2",
-                      "from": "braces@https://registry.npmjs.org/braces/-/braces-1.8.2.tgz",
-                      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.2.tgz",
-                      "dependencies": {
-                        "expand-range": {
-                          "version": "1.8.1",
-                          "from": "expand-range@https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
-                          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
-                          "dependencies": {
-                            "fill-range": {
-                              "version": "2.2.2",
-                              "from": "fill-range@https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
-                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
-                              "dependencies": {
-                                "is-number": {
-                                  "version": "1.1.2",
-                                  "from": "is-number@https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
-                                },
-                                "isobject": {
-                                  "version": "1.0.2",
-                                  "from": "isobject@https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
-                                },
-                                "randomatic": {
-                                  "version": "1.1.3",
-                                  "from": "randomatic@https://registry.npmjs.org/randomatic/-/randomatic-1.1.3.tgz",
-                                  "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.3.tgz",
-                                  "dependencies": {
-                                    "is-number": {
-                                      "version": "2.1.0",
-                                      "from": "is-number@https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-                                      "dependencies": {
-                                        "kind-of": {
-                                          "version": "3.0.2",
-                                          "from": "kind-of@https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-                                          "dependencies": {
-                                            "is-buffer": {
-                                              "version": "1.1.0",
-                                              "from": "is-buffer@https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
-                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
-                                            }
-                                          }
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "repeat-string": {
-                                  "version": "1.5.2",
-                                  "from": "repeat-string@https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "preserve": {
-                          "version": "0.2.0",
-                          "from": "preserve@https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-                          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
-                        },
-                        "repeat-element": {
-                          "version": "1.1.2",
-                          "from": "repeat-element@https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-                          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
-                        }
-                      }
-                    },
-                    "expand-brackets": {
-                      "version": "0.1.4",
-                      "from": "expand-brackets@https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz",
-                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
-                    },
-                    "extglob": {
-                      "version": "0.3.1",
-                      "from": "extglob@https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
-                      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
-                      "dependencies": {
-                        "ansi-green": {
-                          "version": "0.1.1",
-                          "from": "ansi-green@https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
-                          "dependencies": {
-                            "ansi-wrap": {
-                              "version": "0.1.0",
-                              "from": "ansi-wrap@https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-                              "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
-                            }
-                          }
-                        },
-                        "success-symbol": {
-                          "version": "0.1.0",
-                          "from": "success-symbol@https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz"
-                        }
-                      }
-                    },
-                    "filename-regex": {
-                      "version": "2.0.0",
-                      "from": "filename-regex@https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
-                    },
-                    "is-extglob": {
-                      "version": "1.0.0",
-                      "from": "is-extglob@https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-                    },
-                    "kind-of": {
-                      "version": "2.0.1",
-                      "from": "kind-of@https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-                      "dependencies": {
-                        "is-buffer": {
-                          "version": "1.1.0",
-                          "from": "is-buffer@https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
-                        }
-                      }
-                    },
-                    "lazy-cache": {
-                      "version": "0.2.4",
-                      "from": "lazy-cache@https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.4.tgz",
-                      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.4.tgz"
-                    },
-                    "normalize-path": {
-                      "version": "2.0.1",
-                      "from": "normalize-path@https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
-                    },
-                    "object.omit": {
-                      "version": "2.0.0",
-                      "from": "object.omit@https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-                      "dependencies": {
-                        "for-own": {
-                          "version": "0.1.3",
-                          "from": "for-own@https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
-                          "dependencies": {
-                            "for-in": {
-                              "version": "0.1.4",
-                              "from": "for-in@https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz",
-                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
-                            }
-                          }
-                        },
-                        "is-extendable": {
-                          "version": "0.1.1",
-                          "from": "is-extendable@https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
-                        }
-                      }
-                    },
-                    "parse-glob": {
-                      "version": "3.0.4",
-                      "from": "parse-glob@https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-                      "dependencies": {
-                        "glob-base": {
-                          "version": "0.3.0",
-                          "from": "glob-base@https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-                          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
-                        },
-                        "is-dotfile": {
-                          "version": "1.0.2",
-                          "from": "is-dotfile@https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
-                        }
-                      }
-                    },
-                    "regex-cache": {
-                      "version": "0.4.2",
-                      "from": "regex-cache@https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
-                      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
-                      "dependencies": {
-                        "is-equal-shallow": {
-                          "version": "0.1.3",
-                          "from": "is-equal-shallow@https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
-                        },
-                        "is-primitive": {
-                          "version": "2.0.0",
-                          "from": "is-primitive@https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "async-each": {
-              "version": "0.1.6",
-              "from": "async-each@https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
-              "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
-            },
-            "fsevents": {
-              "version": "1.0.5",
-              "from": "fsevents@https://registry.npmjs.org/fsevents/-/fsevents-1.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.5.tgz",
-              "dependencies": {
-                "abbrev": {
-                  "version": "1.0.7",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-                },
-                "ansi": {
-                  "version": "0.3.0",
-                  "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
-                },
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                },
-                "ansi-styles": {
-                  "version": "2.1.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                },
-                "are-we-there-yet": {
-                  "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz"
-                },
-                "asn1": {
-                  "version": "0.1.11",
-                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                },
-                "assert-plus": {
-                  "version": "0.1.5",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                },
-                "async": {
-                  "version": "1.5.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
-                },
-                "aws-sign2": {
-                  "version": "0.6.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-                },
-                "balanced-match": {
-                  "version": "0.2.1",
-                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
-                },
-                "bl": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "2.0.4",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.3",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "block-stream": {
-                  "version": "0.0.8",
-                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
-                },
-                "boom": {
-                  "version": "2.10.1",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                },
-                "brace-expansion": {
-                  "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz"
-                },
-                "caseless": {
-                  "version": "0.11.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-                },
-                "chalk": {
-                  "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
-                },
-                "combined-stream": {
-                  "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
-                },
-                "commander": {
-                  "version": "2.9.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
-                },
-                "concat-map": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                },
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "cryptiles": {
-                  "version": "2.0.5",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                },
-                "ctype": {
-                  "version": "0.5.3",
-                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-                },
-                "debug": {
-                  "version": "0.7.4",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-                },
-                "deep-extend": {
-                  "version": "0.2.11",
-                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
-                },
-                "delayed-stream": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                },
-                "delegates": {
-                  "version": "0.1.0",
-                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                },
-                "extend": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-                },
-                "forever-agent": {
-                  "version": "0.6.1",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-                },
-                "form-data": {
-                  "version": "1.0.0-rc3",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
-                },
-                "fstream": {
-                  "version": "1.0.8",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
-                },
-                "fstream-ignore": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz",
-                  "dependencies": {
-                    "minimatch": {
-                      "version": "3.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
-                    }
-                  }
-                },
-                "gauge": {
-                  "version": "1.2.2",
-                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz"
-                },
-                "generate-function": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-                },
-                "generate-object-property": {
-                  "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
-                },
-                "graceful-fs": {
-                  "version": "4.1.2",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                },
-                "graceful-readlink": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                },
-                "har-validator": {
-                  "version": "2.0.2",
-                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.2.tgz"
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
-                },
-                "has-unicode": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
-                },
-                "hawk": {
-                  "version": "3.1.0",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz"
-                },
-                "hoek": {
-                  "version": "2.16.3",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                },
-                "http-signature": {
-                  "version": "0.11.0",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz"
-                },
-                "inflight": {
-                  "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "once": {
-                      "version": "1.3.2",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "ini": {
-                  "version": "1.3.4",
-                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-                },
-                "is-my-json-valid": {
-                  "version": "2.12.2",
-                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz"
-                },
-                "is-property": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "isstream": {
-                  "version": "0.1.2",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-                },
-                "jsonpointer": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
-                },
-                "lodash._basetostring": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
-                },
-                "lodash._createpadding": {
-                  "version": "3.6.1",
-                  "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
-                },
-                "lodash.pad": {
-                  "version": "3.1.1",
-                  "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
-                },
-                "lodash.padleft": {
-                  "version": "3.1.1",
-                  "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
-                },
-                "lodash.padright": {
-                  "version": "3.1.1",
-                  "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
-                },
-                "lodash.repeat": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
-                },
-                "mime-db": {
-                  "version": "1.19.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
-                },
-                "mime-types": {
-                  "version": "2.1.7",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz"
-                },
-                "minimist": {
-                  "version": "0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                },
-                "mkdirp": {
-                  "version": "0.5.1",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-                },
-                "nan": {
-                  "version": "2.1.0",
-                  "from": "nan@https://registry.npmjs.org/nan/-/nan-2.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
-                },
-                "node-pre-gyp": {
-                  "version": "0.6.15",
-                  "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.15.tgz",
-                  "dependencies": {
-                    "nopt": {
-                      "version": "3.0.4",
-                      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz"
-                    }
-                  }
-                },
-                "node-uuid": {
-                  "version": "1.4.3",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
-                },
-                "npmlog": {
-                  "version": "1.2.1",
-                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz"
-                },
-                "oauth-sign": {
-                  "version": "0.8.0",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
-                },
-                "once": {
-                  "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                },
-                "pinkie": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
-                },
-                "pinkie-promise": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz"
-                },
-                "qs": {
-                  "version": "5.2.0",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
-                },
-                "rc": {
-                  "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.2.tgz",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "1.2.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
-                },
-                "request": {
-                  "version": "2.65.0",
-                  "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz"
-                },
-                "rimraf": {
-                  "version": "2.4.3",
-                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
-                  "dependencies": {
-                    "glob": {
-                      "version": "5.0.15",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
-                    },
-                    "minimatch": {
-                      "version": "3.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
-                    },
-                    "once": {
-                      "version": "1.3.2",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz"
-                    }
-                  }
-                },
-                "semver": {
-                  "version": "5.0.3",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
-                },
-                "sntp": {
-                  "version": "1.0.9",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "stringstream": {
-                  "version": "0.0.5",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-                },
-                "strip-ansi": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
-                },
-                "strip-json-comments": {
-                  "version": "0.1.3",
-                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
-                },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                },
-                "tar": {
-                  "version": "2.2.1",
-                  "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
-                },
-                "tar-pack": {
-                  "version": "3.1.0",
-                  "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.0.tgz",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.0.33",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        }
-                      }
-                    },
-                    "rimraf": {
-                      "version": "2.2.8",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-                    }
-                  }
-                },
-                "tough-cookie": {
-                  "version": "2.2.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.1",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
-                },
-                "uid-number": {
-                  "version": "0.0.3",
-                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
-                },
-                "wrappy": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                },
-                "xtend": {
-                  "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                }
-              }
-            },
-            "glob-parent": {
-              "version": "2.0.0",
-              "from": "glob-parent@https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
-            },
-            "is-binary-path": {
-              "version": "1.0.1",
-              "from": "is-binary-path@https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-              "dependencies": {
-                "binary-extensions": {
-                  "version": "1.4.0",
-                  "from": "binary-extensions@https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz",
-                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
-                }
-              }
-            },
-            "is-glob": {
-              "version": "2.0.1",
-              "from": "is-glob@https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-              "dependencies": {
-                "is-extglob": {
-                  "version": "1.0.0",
-                  "from": "is-extglob@https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-                }
-              }
-            },
-            "readdirp": {
-              "version": "2.0.0",
-              "from": "readdirp@https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "4.1.2",
-                  "from": "graceful-fs@https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                },
-                "minimatch": {
-                  "version": "2.0.10",
-                  "from": "minimatch@https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.1",
-                      "from": "brace-expansion@https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.2.1",
-                          "from": "balanced-match@https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "2.0.4",
-                  "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.3",
-                      "from": "process-nextick-args@https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "util-deprecate@https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
+        "babel-polyfill": {
+          "version": "6.3.14",
+          "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.3.14.tgz"
         },
-        "commander": {
-          "version": "2.9.0",
-          "from": "commander@https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "dependencies": {
-            "graceful-readlink": {
-              "version": "1.0.1",
-              "from": "graceful-readlink@https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-            }
-          }
-        },
-        "convert-source-map": {
-          "version": "1.1.2",
-          "from": "convert-source-map@https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz"
-        },
-        "fs-readdir-recursive": {
-          "version": "0.1.2",
-          "from": "fs-readdir-recursive@https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
-        },
-        "glob": {
-          "version": "5.0.15",
-          "from": "glob@https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "dependencies": {
-            "inflight": {
-              "version": "1.0.4",
-              "from": "inflight@https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "from": "wrappy@https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "minimatch": {
-              "version": "3.0.0",
-              "from": "minimatch@https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.1",
-                  "from": "brace-expansion@https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.2.1",
-                      "from": "balanced-match@https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.3.3",
-              "from": "once@https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "from": "wrappy@https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "from": "lodash@https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-        },
-        "output-file-sync": {
+        "chalk": {
           "version": "1.1.1",
-          "from": "output-file-sync@https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
-          "dependencies": {
-            "mkdirp": {
-              "version": "0.5.1",
-              "from": "mkdirp@https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "minimist@https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "from": "xtend@https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-          }
-        },
-        "path-exists": {
-          "version": "1.0.0",
-          "from": "path-exists@https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
-        },
-        "path-is-absolute": {
-          "version": "1.0.0",
-          "from": "path-is-absolute@https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-        },
-        "slash": {
-          "version": "1.0.0",
-          "from": "slash@https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
         },
         "source-map": {
           "version": "0.5.3",
-          "from": "source-map@https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+        }
+      }
+    },
+    "babel-code-frame": {
+      "version": "6.3.13",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
         }
       }
     },
@@ -2954,6 +1438,20 @@
         }
       }
     },
+    "babel-generator": {
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.4.5.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+        }
+      }
+    },
+    "babel-helpers": {
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.4.5.tgz"
+    },
     "babel-loader": {
       "version": "6.2.0",
       "from": "babel-loader@https://registry.npmjs.org/babel-loader/-/babel-loader-6.2.0.tgz",
@@ -2982,6 +1480,10 @@
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
         }
       }
+    },
+    "babel-messages": {
+      "version": "6.3.18",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
     },
     "babel-polyfill": {
       "version": "6.2.0",
@@ -8073,26 +6575,103 @@
         }
       }
     },
+    "babel-regenerator-runtime": {
+      "version": "6.3.13",
+      "resolved": "https://registry.npmjs.org/babel-regenerator-runtime/-/babel-regenerator-runtime-6.3.13.tgz"
+    },
+    "babel-register": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.4.3.tgz",
+      "dependencies": {
+        "babel-core": {
+          "version": "6.4.5",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.4.5.tgz"
+        },
+        "source-map": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+        }
+      }
+    },
+    "babel-runtime": {
+      "version": "5.8.34",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz"
+    },
+    "babel-template": {
+      "version": "6.3.13",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz"
+    },
+    "babel-traverse": {
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz"
+    },
+    "babel-types": {
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz"
+    },
+    "babylon": {
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz"
+    },
+    "balanced-match": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+    },
+    "bin-version": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz"
+    },
+    "bin-version-check": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+        },
+        "semver": {
+          "version": "4.3.6",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+        }
+      }
+    },
+    "binary-extensions": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
+    },
     "bl": {
       "version": "1.0.0",
+      "from": "bl@https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
       "dependencies": {
         "readable-stream": {
           "version": "2.0.5",
+          "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
         }
       }
     },
     "boolbase": {
       "version": "1.0.0",
+      "from": "boolbase@https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
     },
     "boom": {
       "version": "2.10.1",
+      "from": "boom@https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+    },
+    "brace-expansion": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz"
+    },
+    "braces": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz"
     },
     "browser-request": {
       "version": "0.3.3",
+      "from": "browser-request@https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
       "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz"
     },
     "browser-sync": {
@@ -8102,10 +6681,12 @@
       "dependencies": {
         "ansi-regex": {
           "version": "0.2.1",
+          "from": "ansi-regex@https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
         },
         "ansi-styles": {
           "version": "1.1.0",
+          "from": "ansi-styles@https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
         },
         "anymatch": {
@@ -8475,10 +7056,12 @@
         },
         "chalk": {
           "version": "0.5.1",
+          "from": "chalk@https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "escape-string-regexp": {
               "version": "1.0.3",
+              "from": "escape-string-regexp@http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
               "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             }
           }
@@ -9426,6 +8009,7 @@
         },
         "has-ansi": {
           "version": "0.1.0",
+          "from": "has-ansi@https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz"
         },
         "immutable": {
@@ -10681,10 +9265,12 @@
         },
         "strip-ansi": {
           "version": "0.3.0",
+          "from": "strip-ansi@https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz"
         },
         "supports-color": {
           "version": "0.2.0",
+          "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
         },
         "ua-parser-js": {
@@ -10699,9 +9285,26 @@
         }
       }
     },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+    },
+    "camelcase": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz"
+    },
+    "camelcase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz"
+    },
     "caseless": {
       "version": "0.11.0",
+      "from": "caseless@https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+    },
+    "center-align": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz"
     },
     "chai": {
       "version": "3.4.1",
@@ -10734,111 +9337,206 @@
     },
     "chalk": {
       "version": "0.5.1",
+      "from": "chalk@https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
       "dependencies": {
         "ansi-regex": {
           "version": "0.2.1",
+          "from": "ansi-regex@https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
         },
         "ansi-styles": {
           "version": "1.1.0",
+          "from": "ansi-styles@https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
         },
         "has-ansi": {
           "version": "0.1.0",
+          "from": "has-ansi@https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz"
         },
         "strip-ansi": {
           "version": "0.3.0",
+          "from": "strip-ansi@https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz"
         },
         "supports-color": {
           "version": "0.2.0",
+          "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
         }
       }
+    },
+    "chokidar": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.2.tgz"
     },
     "classnames": {
       "version": "2.2.0",
       "from": "classnames@https://registry.npmjs.org/classnames/-/classnames-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.0.tgz"
     },
+    "cliui": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+        }
+      }
+    },
+    "clone": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+    },
     "combined-stream": {
       "version": "1.0.5",
+      "from": "combined-stream@https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
     },
     "commander": {
       "version": "2.9.0",
+      "from": "commander@https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+    },
+    "convert-source-map": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
+    },
+    "core-js": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
     },
     "core-util-is": {
       "version": "1.0.2",
+      "from": "core-util-is@https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+    },
+    "coveralls": {
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.11.6.tgz",
+      "dependencies": {
+        "argparse": {
+          "version": "0.1.16",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz"
+        },
+        "esprima": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+        },
+        "js-yaml": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.1.tgz"
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+        },
+        "underscore": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+        }
+      }
     },
     "cryptiles": {
       "version": "2.0.5",
+      "from": "cryptiles@https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
     },
     "css-select": {
       "version": "1.0.0",
+      "from": "css-select@https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz"
     },
     "css-what": {
       "version": "1.0.0",
+      "from": "css-what@https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz"
     },
     "cssom": {
       "version": "0.3.0",
+      "from": "cssom@https://registry.npmjs.org/cssom/-/cssom-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.0.tgz"
     },
     "cssstyle": {
       "version": "0.2.30",
+      "from": "cssstyle@https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.30.tgz",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.30.tgz"
     },
     "dashdash": {
       "version": "1.10.1",
+      "from": "dashdash@https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz"
     },
     "debug": {
       "version": "2.2.0",
+      "from": "debug@https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+    },
+    "decamelize": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz"
     },
     "deep-equal": {
       "version": "1.0.1",
+      "from": "deep-equal@https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
     },
     "deep-is": {
       "version": "0.1.3",
+      "from": "deep-is@https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
     },
     "delayed-stream": {
       "version": "1.0.0",
+      "from": "delayed-stream@https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+    },
+    "detect-indent": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+        }
+      }
     },
     "dom-serializer": {
       "version": "0.1.0",
+      "from": "dom-serializer@http://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "resolved": "http://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
+          "from": "domelementtype@https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
         }
       }
     },
     "domelementtype": {
       "version": "1.3.0",
+      "from": "domelementtype@https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
     },
     "domhandler": {
       "version": "2.3.0",
+      "from": "domhandler@https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
     },
     "domutils": {
       "version": "1.4.3",
+      "from": "domutils@https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz"
     },
     "ecc-jsbn": {
       "version": "0.1.1",
+      "from": "ecc-jsbn@https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
     },
     "encoding": {
@@ -10848,6 +9546,7 @@
     },
     "entities": {
       "version": "1.1.1",
+      "from": "entities@https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
     },
     "envify": {
@@ -10893,20 +9592,28 @@
     },
     "enzyme": {
       "version": "1.2.0",
+      "from": "enzyme@https://registry.npmjs.org/enzyme/-/enzyme-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-1.2.0.tgz",
       "dependencies": {
         "cheerio": {
           "version": "0.19.0",
+          "from": "cheerio@https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz",
           "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz"
         }
       }
     },
+    "error-ex": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
+    },
     "escape-string-regexp": {
       "version": "1.0.4",
+      "from": "escape-string-regexp@https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
     },
     "escodegen": {
       "version": "1.7.1",
+      "from": "escodegen@https://registry.npmjs.org/escodegen/-/escodegen-1.7.1.tgz",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.1.tgz"
     },
     "eslint": {
@@ -12108,27 +10815,71 @@
     },
     "esprima": {
       "version": "1.2.5",
+      "from": "esprima@https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
     },
     "estraverse": {
       "version": "1.9.3",
+      "from": "estraverse@https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
     },
     "esutils": {
       "version": "2.0.2",
+      "from": "esutils@https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+    },
+    "expand-brackets": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
+    },
+    "expand-range": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz"
     },
     "extend": {
       "version": "3.0.0",
+      "from": "extend@https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
     },
     "extsprintf": {
       "version": "1.0.2",
+      "from": "extsprintf@https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
     },
     "fast-levenshtein": {
       "version": "1.0.7",
+      "from": "fast-levenshtein@https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
+    },
+    "filename-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+    },
+    "fileset": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz"
+    },
+    "fill-range": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
+    },
+    "find-up": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+      "dependencies": {
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+        }
+      }
+    },
+    "find-versions": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-1.2.1.tgz"
     },
     "flux": {
       "version": "2.1.1",
@@ -12176,24 +10927,601 @@
         }
       }
     },
+    "for-in": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+    },
+    "for-own": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz"
+    },
     "forever-agent": {
       "version": "0.6.1",
+      "from": "forever-agent@https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
     },
     "form-data": {
       "version": "1.0.0-rc3",
+      "from": "form-data@https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
+    },
+    "fs-readdir-recursive": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
+    },
+    "fsevents": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.6.tgz",
+      "dependencies": {
+        "ansi": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+        },
+        "ansi-regex": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+        },
+        "ansi-styles": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+        },
+        "are-we-there-yet": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz"
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+        },
+        "assert-plus": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+        },
+        "async": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+        },
+        "bl": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "block-stream": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+        },
+        "chalk": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+        },
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+        },
+        "dashdash": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz"
+        },
+        "debug": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+        },
+        "deep-extend": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz"
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+        },
+        "delegates": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+        },
+        "escape-string-regexp": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+        },
+        "extend": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+        },
+        "form-data": {
+          "version": "1.0.0-rc3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
+        },
+        "fstream": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
+        },
+        "fstream-ignore": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz",
+          "dependencies": {
+            "minimatch": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.1",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "gauge": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz"
+        },
+        "generate-function": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+        },
+        "generate-object-property": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+        },
+        "graceful-fs": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+        },
+        "graceful-readlink": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+        },
+        "har-validator": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz"
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+        },
+        "has-unicode": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
+        },
+        "hawk": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz"
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+        },
+        "http-signature": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz"
+        },
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+        },
+        "ini": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+        },
+        "is-my-json-valid": {
+          "version": "2.12.3",
+          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz"
+        },
+        "is-property": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+        },
+        "jsbn": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+        },
+        "json-schema": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+        },
+        "jsonpointer": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+        },
+        "jsprim": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
+        },
+        "lodash._basetostring": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+        },
+        "lodash._createpadding": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
+        },
+        "lodash.pad": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
+        },
+        "lodash.padleft": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
+        },
+        "lodash.padright": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
+        },
+        "lodash.repeat": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+        },
+        "mime-db": {
+          "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+        },
+        "mime-types": {
+          "version": "2.1.7",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz"
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+        },
+        "node-pre-gyp": {
+          "version": "0.6.17",
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.17.tgz",
+          "dependencies": {
+            "nopt": {
+              "version": "3.0.6",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.7",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                }
+              }
+            }
+          }
+        },
+        "node-uuid": {
+          "version": "1.4.7",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+        },
+        "npmlog": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.0.tgz"
+        },
+        "oauth-sign": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+        },
+        "once": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+        },
+        "pinkie": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+        },
+        "pinkie-promise": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
+        },
+        "qs": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+        },
+        "rc": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.5.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
+        },
+        "request": {
+          "version": "2.67.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz"
+        },
+        "rimraf": {
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.4.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "5.0.15",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.1",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.3",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "semver": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+        },
+        "sshpk": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.0.tgz",
+          "dependencies": {
+            "assert-plus": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+        },
+        "strip-ansi": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+        },
+        "tar": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+        },
+        "tar-pack": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.0.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                }
+              }
+            },
+            "rimraf": {
+              "version": "2.2.8",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+            }
+          }
+        },
+        "tough-cookie": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+        },
+        "tunnel-agent": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+        },
+        "tweetnacl": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
+        },
+        "uid-number": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
+        },
+        "verror": {
+          "version": "1.3.6",
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+        }
+      }
     },
     "generate-function": {
       "version": "2.0.0",
+      "from": "generate-function@https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
     },
     "generate-object-property": {
       "version": "1.2.0",
+      "from": "generate-object-property@https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "http://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+    },
+    "glob": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+    },
+    "glob-parent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+    },
+    "globals": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
+    },
+    "graceful-fs": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
     },
     "graceful-readlink": {
       "version": "1.0.1",
+      "from": "graceful-readlink@https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
     },
     "gulp": {
@@ -12824,14 +12152,17 @@
       "dependencies": {
         "ansi-regex": {
           "version": "0.2.1",
+          "from": "ansi-regex@https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
         },
         "ansi-styles": {
           "version": "1.1.0",
+          "from": "ansi-styles@https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
         },
         "chalk": {
           "version": "0.5.1",
+          "from": "chalk@https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz"
         },
         "connect": {
@@ -13665,14 +12996,17 @@
         },
         "has-ansi": {
           "version": "0.1.0",
+          "from": "has-ansi@https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz"
         },
         "strip-ansi": {
           "version": "0.3.0",
+          "from": "strip-ansi@https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz"
         },
         "supports-color": {
           "version": "0.2.0",
+          "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
         },
         "tiny-lr": {
@@ -13725,14 +13059,17 @@
       "dependencies": {
         "ansi-regex": {
           "version": "0.2.1",
+          "from": "ansi-regex@https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
         },
         "ansi-styles": {
           "version": "1.1.0",
+          "from": "ansi-styles@https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
         },
         "chalk": {
           "version": "0.5.1",
+          "from": "chalk@https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz"
         },
         "gulp-util": {
@@ -14240,14 +13577,17 @@
         },
         "has-ansi": {
           "version": "0.1.0",
+          "from": "has-ansi@https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz"
         },
         "strip-ansi": {
           "version": "0.3.0",
+          "from": "strip-ansi@https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz"
         },
         "supports-color": {
           "version": "0.2.0",
+          "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
         },
         "through": {
@@ -17131,22 +16471,40 @@
         }
       }
     },
+    "handlebars": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+        }
+      }
+    },
     "har-validator": {
       "version": "2.0.3",
+      "from": "har-validator@https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.1",
+          "from": "chalk@https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
         }
       }
     },
     "has-ansi": {
       "version": "2.0.0",
+      "from": "has-ansi@https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
     },
     "hawk": {
       "version": "3.1.2",
+      "from": "hawk@https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz"
     },
     "highlight.js": {
@@ -17156,24 +16514,37 @@
     },
     "hoek": {
       "version": "2.16.3",
+      "from": "hoek@https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+    },
+    "home-or-tmp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz"
+    },
+    "hosted-git-info": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
     },
     "htmlparser2": {
       "version": "3.8.3",
+      "from": "htmlparser2@https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
       "dependencies": {
         "domutils": {
           "version": "1.5.1",
+          "from": "domutils@http://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
           "resolved": "http://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
         },
         "entities": {
           "version": "1.0.0",
+          "from": "entities@https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
         }
       }
     },
     "http-signature": {
       "version": "1.1.0",
+      "from": "http-signature@https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz"
     },
     "iconv-lite": {
@@ -17181,30 +16552,121 @@
       "from": "iconv-lite@https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
     },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "dependencies": {
+        "repeating": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz"
+        }
+      }
+    },
+    "inflight": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz"
+    },
     "inherits": {
       "version": "2.0.1",
+      "from": "inherits@https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+    },
+    "invariant": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz"
     },
     "ionicons": {
       "version": "2.0.1",
       "from": "ionicons@https://registry.npmjs.org/ionicons/-/ionicons-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-2.0.1.tgz"
     },
+    "is-absolute": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz"
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+    },
+    "is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz"
+    },
+    "is-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.1.tgz"
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
+    },
+    "is-dotfile": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+    },
+    "is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+    },
+    "is-finite": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
+    },
+    "is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+    },
+    "is-integer": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz"
+    },
     "is-my-json-valid": {
       "version": "2.12.3",
+      "from": "is-my-json-valid@https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz"
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
     },
     "is-property": {
       "version": "1.0.2",
+      "from": "is-property@https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+    },
+    "is-relative": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
     },
     "is-typedarray": {
       "version": "1.0.0",
+      "from": "is-typedarray@https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
     },
     "isarray": {
       "version": "0.0.1",
+      "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+    },
+    "isobject": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz"
     },
     "isomorphic-fetch": {
       "version": "2.2.0",
@@ -17213,18 +16675,106 @@
     },
     "isstream": {
       "version": "0.1.2",
+      "from": "isstream@http://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "resolved": "http://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+    },
+    "istanbul": {
+      "version": "1.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-1.0.0-alpha.2.tgz",
+      "dependencies": {
+        "wordwrap": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+        }
+      }
+    },
+    "istanbul-api": {
+      "version": "1.0.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.0.0-alpha.9.tgz"
+    },
+    "istanbul-coveralls": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-coveralls/-/istanbul-coveralls-1.0.3.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+        }
+      }
+    },
+    "istanbul-lib-coverage": {
+      "version": "1.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.0-alpha.4.tgz"
+    },
+    "istanbul-lib-hook": {
+      "version": "1.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.0-alpha.3.tgz"
+    },
+    "istanbul-lib-instrument": {
+      "version": "1.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.0.0-alpha.5.tgz",
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
+        }
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "1.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.0.0-alpha.3.tgz",
+      "dependencies": {
+        "supports-color": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "1.0.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.0.0-alpha.9.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+        }
+      }
+    },
+    "istanbul-reports": {
+      "version": "1.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.0.0-alpha.4.tgz"
     },
     "jodid25519": {
       "version": "1.0.2",
+      "from": "jodid25519@https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+    },
+    "js-tokens": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+    },
+    "js-yaml": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.2.tgz",
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
+        }
+      }
     },
     "jsbn": {
       "version": "0.1.0",
+      "from": "jsbn@https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
     },
     "jsdom": {
       "version": "6.5.1",
+      "from": "jsdom@https://registry.npmjs.org/jsdom/-/jsdom-6.5.1.tgz",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-6.5.1.tgz"
     },
     "json-loader": {
@@ -17234,47 +16784,133 @@
     },
     "json-schema": {
       "version": "0.2.2",
+      "from": "json-schema@https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
     },
     "json-stringify-safe": {
       "version": "5.0.1",
+      "from": "json-stringify-safe@https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+    },
+    "json5": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
     },
     "jsonpointer": {
       "version": "2.0.0",
+      "from": "jsonpointer@https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
     },
     "jsprim": {
       "version": "1.2.2",
+      "from": "jsprim@https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
+    },
+    "kind-of": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz"
+    },
+    "lazy-cache": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
     },
     "lazy.js": {
       "version": "0.4.2",
       "from": "lazy.js@https://registry.npmjs.org/lazy.js/-/lazy.js-0.4.2.tgz",
       "resolved": "https://registry.npmjs.org/lazy.js/-/lazy.js-0.4.2.tgz"
     },
+    "lcov-parse": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.6.tgz"
+    },
+    "left-pad": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+    },
     "levn": {
       "version": "0.2.5",
+      "from": "levn@https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+    },
+    "line-numbers": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz"
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz"
     },
     "lodash": {
       "version": "3.10.1",
+      "from": "lodash@https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+    },
+    "log-driver": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.4.tgz"
+    },
+    "log-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
+        }
+      }
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+    },
+    "loose-envify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz"
+    },
+    "loud-rejection": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz"
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+        }
+      }
+    },
+    "micromatch": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz"
     },
     "mime-db": {
       "version": "1.20.0",
+      "from": "mime-db@https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
     },
     "mime-types": {
       "version": "2.1.8",
+      "from": "mime-types@https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz"
+    },
+    "minimatch": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
     },
     "minimist": {
       "version": "0.0.8",
+      "from": "minimist@https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
     },
     "mkdirp": {
       "version": "0.5.1",
+      "from": "mkdirp@https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
     },
     "mocha": {
@@ -17386,6 +17022,7 @@
     },
     "mocha-jsdom": {
       "version": "1.0.0",
+      "from": "mocha-jsdom@https://registry.npmjs.org/mocha-jsdom/-/mocha-jsdom-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/mocha-jsdom/-/mocha-jsdom-1.0.0.tgz"
     },
     "mocha-teamcity-reporter": {
@@ -17405,14 +17042,21 @@
     },
     "ms": {
       "version": "0.7.1",
+      "from": "ms@https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+    },
+    "nan": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz"
     },
     "nock": {
       "version": "3.5.0",
+      "from": "nock@https://registry.npmjs.org/nock/-/nock-3.5.0.tgz",
       "resolved": "https://registry.npmjs.org/nock/-/nock-3.5.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "2.4.1",
+          "from": "lodash@https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         }
       }
@@ -17424,7 +17068,20 @@
     },
     "node-uuid": {
       "version": "1.4.7",
+      "from": "node-uuid@https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
+    },
+    "normalize-package-data": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
+    },
+    "normalize-path": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
     },
     "npm-shrinkwrap": {
       "version": "200.4.0",
@@ -18777,52 +18434,131 @@
     },
     "nth-check": {
       "version": "1.0.1",
+      "from": "nth-check@https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz"
+    },
+    "number-is-nan": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
     },
     "nwmatcher": {
       "version": "1.3.7",
+      "from": "nwmatcher@https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.7.tgz",
       "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.7.tgz"
     },
     "oauth-sign": {
       "version": "0.8.0",
+      "from": "oauth-sign@https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+    },
+    "object-assign": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
     },
     "object-path": {
       "version": "0.9.2",
       "from": "object-path@https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
       "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz"
     },
+    "object.omit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz"
+    },
+    "once": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz"
+    },
     "optionator": {
       "version": "0.5.0",
+      "from": "optionator@https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz"
+    },
+    "os-tmpdir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+    },
+    "output-file-sync": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz"
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
     },
     "parse5": {
       "version": "1.5.1",
+      "from": "parse5@https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz"
+    },
+    "path-exists": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+    },
+    "path-is-absolute": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
     },
     "pinkie": {
       "version": "2.0.1",
+      "from": "pinkie@https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
     },
     "pinkie-promise": {
       "version": "2.0.0",
+      "from": "pinkie-promise@https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
     },
     "prelude-ls": {
       "version": "1.1.2",
+      "from": "prelude-ls@https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+    },
+    "private": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
     },
     "process-nextick-args": {
       "version": "1.0.6",
+      "from": "process-nextick-args@https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
     },
     "propagate": {
       "version": "0.3.1",
+      "from": "propagate@https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz"
     },
     "qs": {
       "version": "5.2.0",
+      "from": "qs@https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
       "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+    },
+    "randomatic": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
     },
     "react": {
       "version": "0.13.3",
@@ -19066,18 +18802,88 @@
         }
       }
     },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
+    },
     "readable-stream": {
       "version": "1.1.13",
+      "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
+    },
+    "readdirp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
+        }
+      }
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz"
+    },
+    "regex-cache": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz"
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+    },
+    "repeat-string": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+    },
+    "repeating": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
     },
     "request": {
       "version": "2.67.0",
+      "from": "request@https://registry.npmjs.org/request/-/request-2.67.0.tgz",
       "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz"
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
+    },
+    "rimraf": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.0.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz"
+        }
+      }
     },
     "semver": {
       "version": "5.1.0",
       "from": "semver@https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+    },
+    "semver-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz"
+    },
+    "semver-truncate": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.0.tgz"
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+    },
+    "signal-exit": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
     },
     "sinon": {
       "version": "1.17.2",
@@ -19113,12 +18919,18 @@
         }
       }
     },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+    },
     "sntp": {
       "version": "1.0.9",
+      "from": "sntp@http://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "resolved": "http://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
     },
     "source-map": {
       "version": "0.2.0",
+      "from": "source-map@http://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
       "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz"
     },
     "source-map-loader": {
@@ -19162,47 +18974,108 @@
         }
       }
     },
+    "source-map-support": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.32",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz"
+        }
+      }
+    },
     "source-sans-pro": {
       "version": "2.0.10",
       "from": "source-sans-pro@https://registry.npmjs.org/source-sans-pro/-/source-sans-pro-2.0.10.tgz",
       "resolved": "https://registry.npmjs.org/source-sans-pro/-/source-sans-pro-2.0.10.tgz"
     },
+    "spdx-correct": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
+    },
+    "spdx-exceptions": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
+    },
+    "spdx-expression-parse": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz"
+    },
+    "spdx-license-ids": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+    },
     "sshpk": {
       "version": "1.7.1",
+      "from": "sshpk@https://registry.npmjs.org/sshpk/-/sshpk-1.7.1.tgz",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.1.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "0.2.0",
+          "from": "assert-plus@https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
         }
       }
     },
     "string_decoder": {
       "version": "0.10.31",
+      "from": "string_decoder@https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
     },
     "stringstream": {
       "version": "0.0.5",
+      "from": "stringstream@https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
     },
     "strip-ansi": {
       "version": "3.0.0",
+      "from": "strip-ansi@https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+    },
+    "sum-up": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
+        }
+      }
     },
     "supports-color": {
       "version": "2.0.0",
+      "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
     },
     "symbol-tree": {
       "version": "3.1.4",
+      "from": "symbol-tree@https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.1.4.tgz",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.1.4.tgz"
+    },
+    "to-fast-properties": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
     },
     "tough-cookie": {
       "version": "2.2.1",
+      "from": "tough-cookie@https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
     },
     "tr46": {
       "version": "0.0.2",
+      "from": "tr46@https://registry.npmjs.org/tr46/-/tr46-0.0.2.tgz",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.2.tgz"
     },
     "transform-loader": {
@@ -19210,29 +19083,76 @@
       "from": "transform-loader@https://registry.npmjs.org/transform-loader/-/transform-loader-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/transform-loader/-/transform-loader-0.2.3.tgz"
     },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+    },
     "tunnel-agent": {
       "version": "0.4.2",
+      "from": "tunnel-agent@https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
     },
     "tweetnacl": {
       "version": "0.13.2",
+      "from": "tweetnacl@https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
     },
     "type-check": {
       "version": "0.3.1",
+      "from": "type-check@https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+    },
+    "uglify-js": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        },
+        "source-map": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
     },
     "underscore": {
       "version": "1.8.3",
       "from": "underscore@https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
     },
+    "underscore.string": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
+    },
+    "user-home": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+    },
     "util-deprecate": {
       "version": "1.0.2",
+      "from": "util-deprecate@https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+    },
+    "v8flags": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz"
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
     },
     "verror": {
       "version": "1.3.6",
+      "from": "verror@https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
     },
     "webpack": {
@@ -20618,23 +20538,50 @@
     },
     "whatwg-url-compat": {
       "version": "0.6.5",
+      "from": "whatwg-url-compat@https://registry.npmjs.org/whatwg-url-compat/-/whatwg-url-compat-0.6.5.tgz",
       "resolved": "https://registry.npmjs.org/whatwg-url-compat/-/whatwg-url-compat-0.6.5.tgz"
+    },
+    "which": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.1.tgz"
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
     },
     "wordwrap": {
       "version": "0.0.3",
+      "from": "wordwrap@https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+    },
+    "wrappy": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
     },
     "xml-name-validator": {
       "version": "2.0.1",
+      "from": "xml-name-validator@https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz"
     },
     "xmlhttprequest": {
       "version": "1.8.0",
+      "from": "xmlhttprequest@https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz"
     },
     "xtend": {
       "version": "4.0.1",
+      "from": "xtend@https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+    },
+    "yargs": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "dependencies": {
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marathon-ui",
   "version": "0.16.0",
   "engines": {
-    "node": "5.2.0"
+    "node": "5.4.1"
   },
   "description": "The web UI for Mesosphere's Marathon.",
   "main": "dist/main.js",


### PR DESCRIPTION
Update to node v5.4.1 and create shrinkwrap

shrinkwrap had diverged and so this a larger update we hope that the update to the build task in the #568  PR will prevent this from happening again.