### PR TITLE
Desktop notifiy on webpack builds

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,6 +12,7 @@ var fs = require("fs");
 var replace = require("gulp-replace");
 var uglify = require("gulp-uglify");
 var webpack = require("webpack");
+var WebpackNotifierPlugin = require('webpack-notifier');
 var zip = require("gulp-zip");
 
 var packageInfo = require("./package");
@@ -105,6 +106,13 @@ var webpackConfig = {
   },
   watch: webpackWatch
 };
+
+if (process.env.NOTIFY === "true") {
+  webpackConfig.plugins.push(new WebpackNotifierPlugin({
+    alwaysNotify: true,
+    title: "Marathon UI - " + packageInfo.version
+  }));
+}
 
 // Use webpack to compile jsx into js,
 gulp.task("webpack", function (callback) {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "source-map-loader": "^0.1.5",
     "source-sans-pro": "^2.0.10",
     "transform-loader": "^0.2.2",
-    "webpack": "^1.12.9"
+    "webpack": "^1.12.9",
+    "webpack-notifier": "^1.2.1"
   },
   "scripts": {
     "build": "gulp",
@@ -83,6 +84,7 @@
     "test": "mocha --ui exports --reporter src/test/reporter/reporterSwitch --require babel-core/register --require babel-polyfill --require src/test/environment/jsdom  src/test/**/*.test.* src/test/*.test.*",
     "lint": "eslint src/**/*.js*",
     "serve": "export GULP_ENV=\"development\" DISABLE_SOURCE_MAP=false && gulp serve",
+    "serve-notify": "export NOTIFY=true && npm run serve",
     "livereload": "export GULP_ENV=\"development\" DISABLE_SOURCE_MAP=false && gulp livereload",
     "cover:prepare": "rm -Rf coverage",
     "cover:run": "babel-node ./node_modules/istanbul/lib/cli cover node_modules/mocha/bin/_mocha -- --require src/test/environment/jsdom src/test/*.test.* src/test/**/*.test.*",


### PR DESCRIPTION
This display a native desktop notification on webpack builds and rebuilds. 
Very useful if switching between desktops, e.g. from the IDE to the browser, and waiting on the build.