### PR TITLE
Use spaces and not tab

### DIFF
--- a/coding-guidelines.md
+++ b/coding-guidelines.md
@@ -256,8 +256,8 @@ Rules:
 
 ```JS
 var title = !Util.isStringAndEmpty(props.title)
-	? <h3 className="h3">{props.title}</h3>
-	: null;
+  ? <h3 className="h3">{props.title}</h3>
+  : null;
 ```
 
 ## JSX


### PR DESCRIPTION
The tenernary examples used tab instead of spaces for indentation.
That looked wrong on GitHub.