### PR TITLE
Fix - 3054 app form dialog

### DIFF
--- a/src/js/stores/transforms/AppFormModelPostProcess.js
+++ b/src/js/stores/transforms/AppFormModelPostProcess.js
@@ -47,6 +47,17 @@ const AppFormModelPostProcess = {
       }
     }
   },
+  fetch: (app) => {
+    // This is a quickfix for mesosphere/marathon#3054
+    // Please remove this after there is a better solution
+    if (Util.isArray(app.fetch) && Util.isArray(app.uris)) {
+      if (app.fetch.length === 0) {
+        delete app.fetch;
+      } else if (app.uris.length === 0) {
+        delete app.uris;
+      }
+    }
+  },
   healthChecks: (app) => {
     var healthChecks = app.healthChecks;
 

--- a/src/test/appFormModelPostProcess.test.js
+++ b/src/test/appFormModelPostProcess.test.js
@@ -180,8 +180,28 @@ describe("App Form Model Post Process", function () {
 
     });
 
+  });
 
+  it("only contains an uris array", function () {
+    var app = {
+      fetch: [],
+      uris: ["test"]
+    };
 
+    AppFormModelPostProcess.fetch(app);
+
+    expect(app.fetch).to.be.undefined;
+  });
+
+  it("only contains an fetch array", function () {
+    var app = {
+      fetch: ["test"],
+      uris: []
+    };
+
+    AppFormModelPostProcess.fetch(app);
+
+    expect(app.uris).to.be.undefined;
   });
 
 });


### PR DESCRIPTION
This is a quickfix for https://github.com/mesosphere/marathon/issues/3054

Seems that the "fetch"-attribute was introduced in 0.15 at the application definition. This made some hiccups to the form modal.

It shouldn't close the issue for now, I think the issue has to be discussed.

Maybe we need to make a bugfix release with this.