### PR TITLE
Refactor - clean up code

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,13 +30,13 @@
     "indent": [2, 2, {"SwitchCase": 1, "VariableDeclarator": 1}],
     "camelcase": [2, {"properties": "always"}],
     "strict": [2, "never"], // <-- fix
-    "block-spacing": [1, "always"],
+    "block-spacing": [2, "always"],
     "no-mixed-spaces-and-tabs": [2],
     "no-trailing-spaces": [2, { "skipBlankLines": false }],
-    "no-underscore-dangle": 1,
+    "no-underscore-dangle": 2,
     "no-multiple-empty-lines": [2, {"max": 1}],
     "no-empty": [2],
-    "one-var": [1, "never"],
+    "one-var": [2, "never"],
     "object-curly-spacing": [2, "never"],
     "space-after-keywords": [2, "always"],
     "space-before-blocks": [2, "always"],
@@ -44,7 +44,7 @@
       "anonymous": "always", "named": "never"
     }],
     "spaced-comment": [2, "always", { "exceptions": ["*"]}],
-    "semi": [1, "always"],
+    "semi": [2, "always"],
     "max-len": [2, 80, 4],
     "valid-jsdoc": [2, {
       "requireReturn": false,

--- a/.eslintrc
+++ b/.eslintrc
@@ -23,6 +23,8 @@
   ],
 
   "rules": {
+    "no-unused-vars": [1],
+    "no-console": [1],
     "eqeqeq": [2, "smart"],
     "quotes": [2, "double"],
     "indent": [2, 2, {"SwitchCase": 1, "VariableDeclarator": 1}],

--- a/src/js/components/AlertDialogComponent.jsx
+++ b/src/js/components/AlertDialogComponent.jsx
@@ -23,7 +23,7 @@ var AlertDialogComponent = React.createClass({
     return {
       onAccept: Util.noop,
       onDismiss: Util.noop
-    }
+    };
   },
 
   componentDidMount: function () {

--- a/src/js/components/AppListItemLabelsComponent.jsx
+++ b/src/js/components/AppListItemLabelsComponent.jsx
@@ -6,11 +6,6 @@ import PopoverComponent from "./PopoverComponent";
 import OnClickOutsideMixin from "react-onclickoutside";
 import Util from "../helpers/Util";
 
-// Keep track of post-render initial margin value, on a per-reactid basis
-var _initialTopMargins = [];
-// Keep track of reversed dropdown state without modifying the DOM
-var _reversedDropdowns = [];
-
 var AppListItemLabelsComponent = React.createClass({
   displayName: "AppListItemLabelsComponent",
 

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -1,6 +1,5 @@
 import React from "react/addons";
 
-import AppsActions from "../actions/AppsActions";
 import AppsEvents from "../events/AppsEvents";
 import AppsStore from "../stores/AppsStore";
 import BreadcrumbComponent from "../components/BreadcrumbComponent";

--- a/src/js/components/CenteredInlineDialogComponent.jsx
+++ b/src/js/components/CenteredInlineDialogComponent.jsx
@@ -1,6 +1,5 @@
 import classNames from "classnames";
 import React from "react/addons";
-import {Link} from "react-router";
 
 import Util from "../helpers/Util";
 

--- a/src/js/components/CenteredInlineDialogComponent.jsx
+++ b/src/js/components/CenteredInlineDialogComponent.jsx
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import React from "react/addons";
 import {Link} from "react-router";
 
-import Util from "../helpers/Util"
+import Util from "../helpers/Util";
 
 var CenteredInlineDialogComponent = React.createClass({
   displayName: "CenteredInlineDialogComponent",

--- a/src/js/components/ConfirmDialoglComponent.jsx
+++ b/src/js/components/ConfirmDialoglComponent.jsx
@@ -23,7 +23,7 @@ var ConfirmDialogComponent = React.createClass({
     return {
       onAccept: Util.noop,
       onDismiss: Util.noop
-    }
+    };
   },
 
   componentDidMount: function () {

--- a/src/js/components/DeploymentsListComponent.jsx
+++ b/src/js/components/DeploymentsListComponent.jsx
@@ -1,6 +1,5 @@
 import classNames from "classnames";
 import lazy from "lazy.js";
-import {Link} from "react-router";
 import React from "react/addons";
 
 import Messages from "../constants/Messages";
@@ -119,11 +118,6 @@ var DeploymentListComponent = React.createClass({
       state.deployments.length === 0 &&
       state.fetchState !== States.STATE_UNAUTHORIZED &&
       state.fetchState !== States.STATE_FORBIDDEN;
-    var pageHasGenericError = state.fetchState === States.STATE_ERROR;
-    var pageHasUnauthorizedError =
-      state.fetchState === States.STATE_UNAUTHORIZED;
-    var pageHasForbiddenError = state.fetchState === States.STATE_FORBIDDEN;
-    var pageHasErrorMessage = state.errorMessage !== "";
 
     if (pageIsLoading) {
       let message = "Please wait while deployments are being retrieved";

--- a/src/js/components/Marathon.jsx
+++ b/src/js/components/Marathon.jsx
@@ -159,16 +159,16 @@ var Marathon = React.createClass({
   },
 
   startPolling: function () {
-    if (this._interval == null) {
+    if (this.interval == null) {
       this.poll();
-      this._interval = setInterval(this.poll, config.updateInterval);
+      this.interval = setInterval(this.poll, config.updateInterval);
     }
   },
 
   stopPolling: function () {
-    if (this._interval != null) {
-      clearInterval(this._interval);
-      this._interval = null;
+    if (this.interval != null) {
+      clearInterval(this.interval);
+      this.interval = null;
     }
   },
 

--- a/src/js/components/PromptDialogComponent.jsx
+++ b/src/js/components/PromptDialogComponent.jsx
@@ -24,7 +24,7 @@ var PromptDialogComponent = React.createClass({
     return {
       onAccept: Util.noop,
       onDismiss: Util.noop
-    }
+    };
   },
 
   componentDidMount: function () {

--- a/src/js/components/PromptDialogComponent.jsx
+++ b/src/js/components/PromptDialogComponent.jsx
@@ -1,7 +1,6 @@
 import React from "react/addons";
 import classNames from "classnames";
 
-import DialogSeverity from "../constants/DialogSeverity";
 import Util from "../helpers/Util";
 import ModalComponent from "../components/ModalComponent";
 

--- a/src/js/components/TaskDetailComponent.jsx
+++ b/src/js/components/TaskDetailComponent.jsx
@@ -170,7 +170,7 @@ var TaskDetailComponent = React.createClass({
 
     var ipAddressFields = this.getIpAddresses();
     if (ipAddressFields != null && ipAddressFields.length > 0) {
-      ipAddressFields.unshift(<dt key="ip-addresses">IP Addresses</dt>)
+      ipAddressFields.unshift(<dt key="ip-addresses">IP Addresses</dt>);
     }
 
     return (

--- a/src/js/components/TaskFileDownloadComponent.jsx
+++ b/src/js/components/TaskFileDownloadComponent.jsx
@@ -4,7 +4,6 @@ import classNames from "classnames";
 import MesosActions from "../actions/MesosActions";
 import MesosEvents from "../events/MesosEvents";
 import MesosStore from "../stores/MesosStore";
-import PopoverComponent from "../components/PopoverComponent";
 import TooltipComponent from "../components/TooltipComponent";
 
 var TaskFileDownloadComponent = React.createClass({

--- a/src/js/stores/DialogStore.js
+++ b/src/js/stores/DialogStore.js
@@ -4,7 +4,6 @@ import Util from "../helpers/Util";
 
 import AppDispatcher from "../AppDispatcher";
 import DialogEvents from "../events/DialogEvents";
-import DialogTypes from "../constants/DialogTypes";
 
 var dialogs = [];
 

--- a/src/js/stores/MesosStore.js
+++ b/src/js/stores/MesosStore.js
@@ -97,7 +97,7 @@ function getNodeURLFromState(nodeId, state) {
   }
 
   if (environment === DCOS_ENVIRONMENT) {
-    return `/slave/${nodeId}`
+    return `/slave/${nodeId}`;
   }
 
   let agent = state.slaves.find((slave) => {
@@ -126,9 +126,9 @@ function getExecutorDirectoryFromState(frameworkId, taskId, state) {
   let framework = null;
 
   if (state.frameworks != null) {
-    framework = state.frameworks.find(matchFramework)
+    framework = state.frameworks.find(matchFramework);
   } else if (state.completed_frameworks != null) {
-    framework = state.completed_frameworks.find(matchFramework)
+    framework = state.completed_frameworks.find(matchFramework);
   }
 
   if (framework == null) {
@@ -142,9 +142,9 @@ function getExecutorDirectoryFromState(frameworkId, taskId, state) {
   let executor = null;
 
   if (framework.executors != null) {
-    executor = framework.executors.find(matchExecutor)
+    executor = framework.executors.find(matchExecutor);
   } else if (framework.completed_executors != null) {
-    executor = framework.completed_executors.find(matchExecutor)
+    executor = framework.completed_executors.find(matchExecutor);
   }
 
   if (executor == null) {


### PR DESCRIPTION
This PR contains a couple of code clean up stuff:
  - Adds `no-unused-vars` and `no-console` as warnings to the `.eslintrc`.
  - Removes the dangling underscores
  - Adds missing semicolons
  - Changes the old warnings in the `.eslintrc` to errors.