### PR TITLE
Fix - 3064 labels dropdown doens't show up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unversioned
 ### Fixed
 - \#3605 - Prevent ctrl-c keyboard shortcut from showing the Create modal dialog
+- \#3054 - Empty - non set- application attributes are accidentaly submited
+  by the UI
+- \#3064 - Labels dropdown menu not showing up
 
 ## 0.15.0 - 2016-01-20
 ### Added

--- a/src/css/components/labels.less
+++ b/src/css/components/labels.less
@@ -30,7 +30,6 @@
 
   .labels-dropdown {
     background-color: @navbar-bg-color;
-    display: none;
     left: 100%;
     margin-left: @base-spacing-unit*2;
     margin-top: -@base-spacing-unit*2;


### PR DESCRIPTION
This closes https://github.com/mesosphere/marathon/issues/3064


I've forgot to add the changelog for the #3054 and added it here too.. Laziness.