### PR TITLE
Defensively check against malformed task ipAddresses

### DIFF
--- a/src/js/components/TaskDetailComponent.jsx
+++ b/src/js/components/TaskDetailComponent.jsx
@@ -89,13 +89,15 @@ var TaskDetailComponent = React.createClass({
     var task = props.task;
     var ipAddresses = task.ipAddresses;
 
-    if (ipAddresses == null) {
+    if (ipAddresses == null || ipAddresses.length === 0) {
       return null;
     }
 
-    return ipAddresses.map(address => (
-      <dd key={address.ipAddress}>{address.ipAddress}</dd>
-    ));
+    return ipAddresses
+      .filter(address => address.ipAddress != null)
+      .map(address => (
+        <dd key={address.ipAddress}>{address.ipAddress}</dd>
+      ));
   },
 
   getPorts: function () {


### PR DESCRIPTION
This fixes mesosphere/marathon#2973

Marathon will just return what Mesos gives it and the `ipAddress` field in Mesos is optional.

*Please Note*

We should probably create a 0.14.3 bugfix release with this. 

After this PR gets merged, I will create the new release branch `release/0.14.3` with the cherrypicked merge commit + the missing CHANGELOG entry.  I will then create another PR to upmerge the 0.14.3 CHANGELOG section into `master`.
Makes sense?