### PR TITLE
Never submit fetch, only uris

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - \#3093 - Don't display "Create an Application" together with "Loading error"
 - \#2907 - Add tooltip with help links to Status and Health columns in App list
+- \#3054 - Avoid manipulating `fetch` values directly; keep using `uris` field
 
 ## 0.15.1 - 2016-01-22
 ### Fixed

--- a/src/js/stores/transforms/AppFormModelPostProcess.js
+++ b/src/js/stores/transforms/AppFormModelPostProcess.js
@@ -48,15 +48,7 @@ const AppFormModelPostProcess = {
     }
   },
   fetch: (app) => {
-    // This is a quickfix for mesosphere/marathon#3054
-    // Please remove this after there is a better solution
-    if (Util.isArray(app.fetch) && Util.isArray(app.uris)) {
-      if (app.fetch.length === 0) {
-        delete app.fetch;
-      } else if (app.uris.length === 0) {
-        delete app.uris;
-      }
-    }
+    delete app.fetch;
   },
   healthChecks: (app) => {
     var healthChecks = app.healthChecks;

--- a/src/test/units/AppFormModelPostProcess.test.js
+++ b/src/test/units/AppFormModelPostProcess.test.js
@@ -193,15 +193,4 @@ describe("App Form Model Post Process", function () {
     expect(app.fetch).to.be.undefined;
   });
 
-  it("only contains an fetch array", function () {
-    var app = {
-      fetch: ["test"],
-      uris: []
-    };
-
-    AppFormModelPostProcess.fetch(app);
-
-    expect(app.uris).to.be.undefined;
-  });
-
 });


### PR DESCRIPTION
Although uris is deprecated, it is still supported in API v2.
For the time being, we can ignore fetch and stick to only mutating uris,
which are then guaranteed to be synced to fetch by the API.

This fixes mesosphere/marathon#3054 (for good)

*Please note*
Once this fix goes into master, we should cherry pick it into a 0.15.2 release.

Related, but ouf scope: https://github.com/mesosphere/marathon/issues/3087 