### PR TITLE
Don't warn on KONSOLE LOG

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,7 @@
 
   "rules": {
     "no-unused-vars": [1],
+    "no-console": [2],
     "eqeqeq": [2, "smart"],
     "quotes": [2, "double"],
     "indent": [2, 2, {"SwitchCase": 1, "VariableDeclarator": 1}],

--- a/.eslintrc
+++ b/.eslintrc
@@ -24,7 +24,6 @@
 
   "rules": {
     "no-unused-vars": [1],
-    "no-console": [1],
     "eqeqeq": [2, "smart"],
     "quotes": [2, "double"],
     "indent": [2, 2, {"SwitchCase": 1, "VariableDeclarator": 1}],

--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,9 @@
     "react"
   ],
 
+  // Some rules could be eventually overriden for the development environment
+  // in the gulpfile.js.
+  // Consider these rules to apply perfectly on a release/production.
   "rules": {
     "no-unused-vars": [1],
     "no-console": [2],

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,6 +41,8 @@ var files = {
   eslintRc: "./.eslintrc"
 };
 
+var eslintOverrides = {rules: {}};
+
 var webpackWatch = false;
 var configFilePath = path.resolve(dirs.js + "/config/config.js");
 if (process.env.GULP_ENV === "development") {
@@ -53,6 +55,8 @@ if (process.env.GULP_ENV === "development") {
     console.info("You could copy config.template.js to config.dev.js " +
       "to enable a development configuration.");
   }
+
+  eslintOverrides.rules["no-console"] = 0;
 }
 
 var webpackConfig = {
@@ -69,7 +73,7 @@ var webpackConfig = {
     preLoaders: [
       {
         test: /\.(js|jsx)$/,
-        loader: "eslint-loader",
+        loader: "eslint-loader?" + JSON.stringify(eslintOverrides),
         exclude: /node_modules/
       }
     ],


### PR DESCRIPTION
As a heavy user of KONSOLE LOG, this warning pollutes my LINUX KONSOLE, so I cannot see the other important warnings and errors anymore.

We could think about a different .eslintrc for DEVELOPMENT and PRODUCTION.