### PR TITLE
Remove dependency on internal state

### DIFF
--- a/src/js/components/SidebarComponent.jsx
+++ b/src/js/components/SidebarComponent.jsx
@@ -24,16 +24,6 @@ var SidebarComponent = React.createClass({
     groupId: React.PropTypes.string.isRequired
   },
 
-  getInitialState: function () {
-    return {
-      filters: {
-        [FilterTypes.HEALTH]: [],
-        [FilterTypes.LABELS]: [],
-        [FilterTypes.STATUS]: []
-      }
-    };
-  },
-
   render: function () {
     var path = this.context.router.getCurrentPathname();
     var props = this.props;

--- a/src/js/components/TabPanesComponent.jsx
+++ b/src/js/components/TabPanesComponent.jsx
@@ -23,8 +23,7 @@ var TabPanesComponent = React.createClass({
 
   getInitialState: function () {
     return {
-      currentGroup: "/",
-      filters: {}
+      currentGroup: "/"
     };
   },
 
@@ -38,16 +37,17 @@ var TabPanesComponent = React.createClass({
 
   getContextualBar: function () {
     var state = this.state;
+    var filters = this.getQueryParamObject();
 
-    if (state.filters[FilterTypes.TEXT] == null ||
-        Util.isStringAndEmpty(state.filters[FilterTypes.TEXT])) {
+    if (filters[FilterTypes.TEXT] == null ||
+        Util.isStringAndEmpty(filters[FilterTypes.TEXT])) {
       return <BreadcrumbComponent groupId={state.currentGroup} />;
     }
 
     return (
         <p className="breadcrumb">
           <span>
-            {`Search results for "${state.filters[FilterTypes.TEXT]}"`}
+            {`Search results for "${filters[FilterTypes.TEXT]}"`}
           </span>
           {this.getClearLinkForFilter(FilterTypes.TEXT,
             "Clear search",

--- a/src/js/mixins/QueryParamsMixin.jsx
+++ b/src/js/mixins/QueryParamsMixin.jsx
@@ -25,16 +25,16 @@ var QueryParamsMixin = {
   getClearLinkForFilter: function (filterQueryParamKey,
       caption = "Clear",
       className = null) {
-    var state = this.state;
-
-    if (state.filters[filterQueryParamKey].length === 0) {
-      return null;
-    }
 
     let router = this.context.router;
     let currentPathname = router.getCurrentPathname();
     let query = Object.assign({}, router.getCurrentQuery());
     let params = router.getCurrentParams();
+
+    if (query[filterQueryParamKey] == null ||
+        query[filterQueryParamKey].length === 0) {
+      return null;
+    }
 
     if (query[filterQueryParamKey] != null) {
       delete query[filterQueryParamKey];


### PR DESCRIPTION
As discussed in https://github.com/mesosphere/marathon-ui/pull/582#issuecomment-176701450

The QueryParamMixin must use the current route as a de-facto store for the filters.