### PR TITLE
Improve label filter dropdown usability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 - \#3078 - Always show download button for logs
 - \#3077 - Future timestamps
+- \#3124 - Improve usability of labels filter dropdown
 
 ### Fixed
 - \#3093 - Don't display "Create an Application" together with "Loading error"

--- a/src/css/components/dropdown.less
+++ b/src/css/components/dropdown.less
@@ -22,6 +22,8 @@
     border-color: @dropdown-bg-color;
     border-radius: 2px;
     display: block;
+    max-height: @sidebar-width*2;
+    overflow-y: scroll;
     z-index: 1001; /* Override Bootstrap's 1000 base value */
 
     .checkbox {

--- a/src/css/components/dropdown.less
+++ b/src/css/components/dropdown.less
@@ -39,7 +39,7 @@
           display: block;
           overflow: hidden;
           text-overflow: ellipsis;
-          width: @sidebar-width*0.5;
+          max-width: @sidebar-width*2;
           white-space: nowrap;
         }
       }

--- a/src/css/components/pane.less
+++ b/src/css/components/pane.less
@@ -60,7 +60,7 @@
       padding: @base-spacing-unit*2;
       width: @sidebar-width;
 
-      .btn-success, .dropdown-toggle, .dropdown-menu {
+      .btn-success, .dropdown-toggle {
         margin: 0 0 @base-spacing-unit 0;
         text-align: left;
         width: 100%;

--- a/src/js/components/SidebarComponent.jsx
+++ b/src/js/components/SidebarComponent.jsx
@@ -54,10 +54,6 @@ var SidebarComponent = React.createClass({
           {this.getClearLinkForFilter(FilterTypes.HEALTH)}
         </div>
         <SidebarHealthFilterComponent />
-        <div className="flex-row">
-          <h3 className="small-caps">Label</h3>
-          {this.getClearLinkForFilter(FilterTypes.LABELS)}
-        </div>
         <SidebarLabelsFilterComponent />
       </nav>
     );

--- a/src/js/components/SidebarLabelsFilterComponent.jsx
+++ b/src/js/components/SidebarLabelsFilterComponent.jsx
@@ -1,6 +1,4 @@
-import classNames from "classnames";
 import lazy from "lazy.js";
-import OnClickOutsideMixin from "react-onclickoutside";
 import React from "react/addons";
 
 import AppsStore from "../stores/AppsStore";
@@ -9,19 +7,18 @@ import FilterTypes from "../constants/FilterTypes";
 
 import QueryParamsMixin from "../mixins/QueryParamsMixin";
 
+import SidebarLabelsFilterDropdownComponent
+  from "./SidebarLabelsFilterDropdownComponent";
+
 var SidebarLabelsFilterComponent = React.createClass({
   displayName: "SidebarLabelsFilterComponent",
 
-  mixins: [OnClickOutsideMixin, QueryParamsMixin],
+  mixins: [QueryParamsMixin],
 
   getInitialState: function () {
-    var labels = this.getAvailableLabels();
-
     return {
-      activated: false,
-      availableLabels: labels,
-      selectedLabels: [],
-      filterText: ""
+      availableLabels: this.getAvailableLabels(),
+      selectedLabels: []
     };
   },
 
@@ -39,12 +36,6 @@ var SidebarLabelsFilterComponent = React.createClass({
 
   componentWillUnmount: function () {
     AppsStore.removeListener(AppsEvents.CHANGE, this.onAppsChange);
-  },
-
-  componentDidUpdate: function () {
-    if (this.state.activated) {
-      React.findDOMNode(this.refs.filterText).focus();
-    }
   },
 
   getAvailableLabels: function () {
@@ -67,12 +58,6 @@ var SidebarLabelsFilterComponent = React.createClass({
         return memo;
       }, [])
       .sort();
-  },
-
-  handleClickOutside: function () {
-    this.setState({
-      activated: false
-    });
   },
 
   onAppsChange: function () {
@@ -101,7 +86,7 @@ var SidebarLabelsFilterComponent = React.createClass({
     }
   },
 
-  handleChange: function (label, event) {
+  handleChange: function (label, isSelected) {
     var state = this.state;
     var selectedLabels = [];
     var update = React.addons.update;
@@ -110,7 +95,7 @@ var SidebarLabelsFilterComponent = React.createClass({
       return currentLabel[0] === label[0] && currentLabel[1] === label[1];
     });
 
-    if (event.target.checked === true) {
+    if (isSelected) {
       if (labelIndex === -1) {
         selectedLabels = update(state.selectedLabels, {$push: [label]});
       }
@@ -125,143 +110,23 @@ var SidebarLabelsFilterComponent = React.createClass({
     this.setQueryParam(FilterTypes.LABELS, selectedLabels);
   },
 
-  handleFilterTextChange: function (event) {
-    var filterText = event.target.value;
-    this.setState({
-      filterText: filterText
-    });
-  },
-
-  handleKeyDown: function (event) {
-    if (event.key === "Escape") {
-      event.target.blur();
-      this.setState({
-        filterText: ""
-      });
-    }
-  },
-
-  toggleActivatedState: function () {
-    this.setState({
-      activated: !this.state.activated,
-      filterText: ""
-    });
-  },
-
-  getSelectedLabelsText: function (count = 1) {
-    var labelIndicator = "Label";
-    if (count > 1) {
-      labelIndicator = labelIndicator + "s";
-    }
-    return `${count} ${labelIndicator} Selected`;
-  },
-
-  getDropdownButton: function () {
+  render: function () {
     var state = this.state;
-    if (state.availableLabels == null || state.availableLabels.length === 0) {
-      return (
-        <button className="btn btn-default dropdown-toggle" disabled>
-          No labels
-        </button>
-      );
-    }
 
-    let selectedLabelsText = state.selectedLabels.length > 0
-      ? this.getSelectedLabelsText(state.selectedLabels.length)
-      : "Select";
-
-    return (
-      <div className="btn btn-default dropdown-toggle"
-          type="button"
-          onClick={this.toggleActivatedState}>
-        <div>{selectedLabelsText}</div>
-        <span className="caret" />
-      </div>
-    );
-  },
-
-  getOptions: function () {
-    var state = this.state;
-    var availableLabels = state.availableLabels.slice();
-
-    if (availableLabels == null || availableLabels.length === 0) {
+    if (state.availableLabels.length === 0) {
       return null;
     }
 
-    let options = availableLabels
-      .sort((a, b) => {
-        var isSelectedA = lazy(state.selectedLabels).find(a) != null;
-        var isSelectedB = lazy(state.selectedLabels).find(b) != null;
-
-        if (isSelectedA && isSelectedB) {
-          return a[0].localeCompare(b[0]);
-        }
-
-        if (!isSelectedA && isSelectedB) {
-          return 1;
-        }
-
-        if (isSelectedA && !isSelectedB) {
-          return -1;
-        }
-      })
-      .map((label, i) => {
-        var [key, value] = label;
-        var optionText = key;
-        var filterText = state.filterText;
-
-        if (value != null && value !== "") {
-          optionText = `${key}:${value}`;
-        }
-
-        if (filterText !== "" &&
-          optionText.search(new RegExp(filterText, "i")) === -1) {
-          return null;
-        }
-
-        var isSelected = lazy(state.selectedLabels).find(label) != null;
-
-        var checkboxProps = {
-          type: "checkbox",
-          id: `label-${optionText}-${i}`,
-          checked: isSelected
-        };
-
-        return (
-          <li className="checkbox" key={i}>
-            <input {...checkboxProps}
-              onChange={this.handleChange.bind(this, label)} />
-            <label htmlFor={`label-${optionText}-${i}`} title={optionText}>
-              <span>{optionText}</span>
-            </label>
-          </li>
-        );
-      });
-
-    let dropdownClassSet = classNames({
-      "hidden": !this.state.activated
-    }, "dropdown-menu list-group filters");
-
     return (
-      <ul className={dropdownClassSet}>
-        <li className="search">
-          <input type="text"
-            ref="filterText"
-            value={state.filterText}
-            placeholder="Filter labels"
-            onChange={this.handleFilterTextChange}
-            onKeyDown={this.handleKeyDown} />
-        </li>
-        {options}
-      </ul>
-    );
-  },
-
-  render: function () {
-    return (
-      <div className="dropdown">
-        {this.getDropdownButton()}
-        {this.getOptions()}
+      <div>
+        <div className="flex-row">
+          <h3 className="small-caps">Label</h3>
+          {this.getClearLinkForFilter(FilterTypes.LABELS)}
+        </div>
+        <SidebarLabelsFilterDropdownComponent
+          handleChange={this.handleChange}
+          availableLabels={state.availableLabels}
+          selectedLabels={state.selectedLabels} />
       </div>
     );
   }

--- a/src/js/components/SidebarLabelsFilterComponent.jsx
+++ b/src/js/components/SidebarLabelsFilterComponent.jsx
@@ -148,6 +148,14 @@ var SidebarLabelsFilterComponent = React.createClass({
     });
   },
 
+  getSelectedLabelsText: function (count = 1) {
+    var labelIndicator = "Label";
+    if (count > 1) {
+      labelIndicator = labelIndicator + "s";
+    }
+    return `${count} ${labelIndicator} Selected`;
+  },
+
   getDropdownButton: function () {
     var state = this.state;
     if (state.availableLabels == null || state.availableLabels.length === 0) {
@@ -158,25 +166,9 @@ var SidebarLabelsFilterComponent = React.createClass({
       );
     }
 
-    let selectedLabelsText = state.selectedLabels.reduce((memo, label) => {
-      let [key, value] = label;
-      let labelText = key;
-      if (value != null) {
-        labelText = `${key}:${value}`;
-      }
-
-      if (memo.length === 0) {
-        memo = labelText;
-        return memo;
-      }
-
-      memo = `${memo}, ${labelText}`;
-      return memo;
-    }, "");
-
-    if (selectedLabelsText === "") {
-      selectedLabelsText = "Select";
-    }
+    let selectedLabelsText = state.selectedLabels.length > 0
+      ? this.getSelectedLabelsText(state.selectedLabels.length)
+      : "Select";
 
     return (
       <div className="btn btn-default dropdown-toggle"

--- a/src/js/components/SidebarLabelsFilterComponent.jsx
+++ b/src/js/components/SidebarLabelsFilterComponent.jsx
@@ -182,40 +182,61 @@ var SidebarLabelsFilterComponent = React.createClass({
 
   getOptions: function () {
     var state = this.state;
-    if (state.availableLabels == null || state.availableLabels.length === 0) {
+    var availableLabels = state.availableLabels.slice();
+
+    if (availableLabels == null || availableLabels.length === 0) {
       return null;
     }
 
-    let options = state.availableLabels.map((label, i) => {
-      let [key, value] = label;
-      let optionText = key;
-      let filterText = state.filterText;
+    let options = availableLabels
+      .sort((a, b) => {
+        var isSelectedA = lazy(state.selectedLabels).find(a) != null;
+        var isSelectedB = lazy(state.selectedLabels).find(b) != null;
 
-      if (value != null && value !== "") {
-        optionText = `${key}:${value}`;
-      }
+        if (isSelectedA && isSelectedB) {
+          return a[0].localeCompare(b[0]);
+        }
 
-      if (filterText !== "" &&
-        optionText.search(new RegExp(filterText, "i")) === -1) {
-        return null;
-      }
+        if (!isSelectedA && isSelectedB) {
+          return 1;
+        }
 
-      let checkboxProps = {
-        type: "checkbox",
-        id: `label-${optionText}-${i}`,
-        checked: lazy(state.selectedLabels).find(label) != null
-      };
+        if (isSelectedA && !isSelectedB) {
+          return -1;
+        }
+      })
+      .map((label, i) => {
+        var [key, value] = label;
+        var optionText = key;
+        var filterText = state.filterText;
 
-      return (
-        <li className="checkbox" key={i}>
-          <input {...checkboxProps}
-            onChange={this.handleChange.bind(this, label)} />
-          <label htmlFor={`label-${optionText}-${i}`} title={optionText}>
-            <span>{optionText}</span>
-          </label>
-        </li>
-      );
-    });
+        if (value != null && value !== "") {
+          optionText = `${key}:${value}`;
+        }
+
+        if (filterText !== "" &&
+          optionText.search(new RegExp(filterText, "i")) === -1) {
+          return null;
+        }
+
+        var isSelected = lazy(state.selectedLabels).find(label) != null;
+
+        var checkboxProps = {
+          type: "checkbox",
+          id: `label-${optionText}-${i}`,
+          checked: isSelected
+        };
+
+        return (
+          <li className="checkbox" key={i}>
+            <input {...checkboxProps}
+              onChange={this.handleChange.bind(this, label)} />
+            <label htmlFor={`label-${optionText}-${i}`} title={optionText}>
+              <span>{optionText}</span>
+            </label>
+          </li>
+        );
+      });
 
     let dropdownClassSet = classNames({
       "hidden": !this.state.activated

--- a/src/js/components/SidebarLabelsFilterDropdownComponent.jsx
+++ b/src/js/components/SidebarLabelsFilterDropdownComponent.jsx
@@ -1,0 +1,176 @@
+import classNames from "classnames";
+import lazy from "lazy.js";
+import React from "react/addons";
+import OnClickOutsideMixin from "react-onclickoutside";
+
+var SidebarLabelsFilterDropdownComponent = React.createClass({
+  displayName: "SidebarLabelsFilterDropdownComponent",
+
+  mixins: [OnClickOutsideMixin],
+
+  propTypes: {
+    availableLabels: React.PropTypes.array,
+    handleChange: React.PropTypes.func,
+    selectedLabels: React.PropTypes.array
+  },
+
+  getInitialState: function () {
+    return {
+      isVisible: false,
+      filterText: ""
+    };
+  },
+
+  componentDidUpdate: function () {
+    if (this.state.isVisible) {
+      React.findDOMNode(this.refs.filterText).focus();
+    }
+  },
+
+  handleClickOutside: function () {
+    this.setState({
+      isVisible: false
+    });
+  },
+
+  getDropdownButton: function () {
+    var props = this.props;
+
+    let selectedLabelsText = props.selectedLabels.length > 0
+      ? this.getSelectedLabelsText(props.selectedLabels.length)
+      : "Select";
+
+    return (
+      <div className="btn btn-default dropdown-toggle"
+          type="button"
+          onClick={this.toggleActivatedState}>
+        <div>{selectedLabelsText}</div>
+        <span className="caret" />
+      </div>
+    );
+  },
+
+  getOptions: function () {
+    var props = this.props;
+    var state = this.state;
+    var availableLabels = props.availableLabels.slice();
+
+    if (availableLabels == null || availableLabels.length === 0) {
+      return null;
+    }
+
+    let options = availableLabels
+      .sort((a, b) => {
+        var isSelectedA = lazy(props.selectedLabels).find(a) != null;
+        var isSelectedB = lazy(props.selectedLabels).find(b) != null;
+
+        if (isSelectedA && isSelectedB) {
+          return a[0].localeCompare(b[0]);
+        }
+
+        if (!isSelectedA && isSelectedB) {
+          return 1;
+        }
+
+        if (isSelectedA && !isSelectedB) {
+          return -1;
+        }
+      })
+      .map((label, i) => {
+        var [key, value] = label;
+        var optionText = key;
+        var filterText = state.filterText;
+
+        if (value != null && value !== "") {
+          optionText = `${key}:${value}`;
+        }
+
+        if (filterText !== "" &&
+          optionText.search(new RegExp(filterText, "i")) === -1) {
+          return null;
+        }
+
+        var isSelected = lazy(props.selectedLabels).find(label) != null;
+
+        var checkboxProps = {
+          type: "checkbox",
+          id: `label-${optionText}-${i}`,
+          checked: isSelected
+        };
+
+        return (
+          <li className="checkbox" key={i}>
+            <input {...checkboxProps}
+              onChange={this.handleChange.bind(this, label)} />
+            <label htmlFor={`label-${optionText}-${i}`} title={optionText}>
+              <span>{optionText}</span>
+            </label>
+          </li>
+        );
+      });
+
+    let dropdownClassSet = classNames({
+      "hidden": !state.isVisible
+    }, "dropdown-menu list-group filters");
+
+    return (
+      <ul className={dropdownClassSet}>
+        <li className="search">
+          <input type="text"
+            ref="filterText"
+            value={state.filterText}
+            placeholder="Filter labels"
+            onChange={this.handleFilterTextChange}
+            onKeyDown={this.handleKeyDown} />
+        </li>
+        {options}
+      </ul>
+    );
+  },
+
+  getSelectedLabelsText: function (count = 1) {
+    var labelIndicator = "Label";
+    if (count > 1) {
+      labelIndicator = labelIndicator + "s";
+    }
+    return `${count} ${labelIndicator} Selected`;
+  },
+
+  handleChange: function (label, event) {
+    this.props.handleChange(label, event.target.checked);
+  },
+
+  handleFilterTextChange: function (event) {
+    var filterText = event.target.value;
+    this.setState({
+      filterText: filterText
+    });
+  },
+
+  handleKeyDown: function (event) {
+    if (event.key === "Escape") {
+      event.target.blur();
+      this.setState({
+        filterText: ""
+      });
+    }
+  },
+
+  toggleActivatedState: function () {
+    this.setState({
+      isVisible: !this.state.isVisible,
+      filterText: ""
+    });
+  },
+
+  render: function () {
+    return (
+      <div className="dropdown">
+        {this.getDropdownButton()}
+        {this.getOptions()}
+      </div>
+    );
+  }
+});
+
+module.exports = SidebarLabelsFilterDropdownComponent;


### PR DESCRIPTION
This ~~(partially)~~ fixes mesosphere/marathon#3124

~~**Missing**: hide Labels filter when no labels are specified
This AC will be implemented once https://github.com/mesosphere/marathon-ui/pull/600 gets merged.~~

Update

Here is the final result:

@leemunroe please take a look. Following the ACs specified in the issue results in this:

![filtersbehaviour](https://cloud.githubusercontent.com/assets/1078545/12677377/d57ac454-c698-11e5-85e7-ab6404186d82.gif)

The selected labels are promoted to the top of the list and sorted alphabetically (AC #2). 
Can you confirm this is what you expected?



