### PR TITLE
Restore label filtering functionality

### DIFF
--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -226,7 +226,7 @@ var AppListComponent = React.createClass({
         }
 
         return filterLabels.some(label => {
-          let [key, value] = label;
+          let [key, value] = label.split(":");
           return labels[key] === value;
         });
       });

--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -226,7 +226,7 @@ var AppListComponent = React.createClass({
         }
 
         return filterLabels.some(label => {
-          let [key, value] = label.split(":");
+          let [key, value] = this.decodeQueryParamArray(label);
           return labels[key] === value;
         });
       });

--- a/src/js/components/SidebarLabelsFilterComponent.jsx
+++ b/src/js/components/SidebarLabelsFilterComponent.jsx
@@ -90,7 +90,7 @@ var SidebarLabelsFilterComponent = React.createClass({
       selectedLabels = [];
     } else {
       selectedLabels = selectedLabels
-        .map(label => label.split(":"))
+        .map(label => this.decodeQueryParamArray(label))
         .filter(label => lazy(state.availableLabels).find(label) != null);
     }
 

--- a/src/js/mixins/QueryParamsMixin.jsx
+++ b/src/js/mixins/QueryParamsMixin.jsx
@@ -7,7 +7,7 @@ function encodeValuesToURIComponents(values) {
   if (Util.isArray(values)) {
     return values.map((param) => {
       var uriComponent = Util.isArray(param)
-        ? param.join(":")
+        ? param.map(segment => encodeURIComponent(segment)).join(":")
         : param.toString();
 
       return encodeURIComponent(uriComponent);
@@ -79,6 +79,10 @@ var QueryParamsMixin = {
     }
 
     router.transitionTo(router.getCurrentPathname(), {}, queryParams);
+  },
+
+  decodeQueryParamArray: function (array) {
+    return array.split(":").map(segment => decodeURIComponent(segment));
   }
 };
 


### PR DESCRIPTION
The filtering refactoring introduced in https://github.com/mesosphere/marathon-ui/pull/582/files#diff-096ce513790b28998732cebef945fddcL47 unfortunately broke the label filters. 

This PR addresses the issue. 