### PR TITLE
Make URLs in validation error messages clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unversioned
 ### Added
 - \#3017 - Move application Search Bar to the Header
+- \#3082 - Make URLs in form validation error messages clickable
 
 ### Changed
 - \#3078 - Always show download button for logs

--- a/src/js/components/AutolinkComponent.jsx
+++ b/src/js/components/AutolinkComponent.jsx
@@ -1,0 +1,48 @@
+var React = require("react/addons");
+
+const URLDelimiter = /(https?:\/\/[^\s]+)/gi;
+
+var AutolinkComponent = React.createClass({
+  displayName: "AutolinkComponent",
+
+  propTypes: {
+    options: React.PropTypes.object,
+    text: React.PropTypes.string.isRequired
+  },
+
+  getDefaultProps: function () {
+    return {
+      options: {
+        target: "_blank"
+      }
+    };
+  },
+
+  autolink: function () {
+    return this.props.text
+      .split(URLDelimiter)
+      .map(word => {
+        var match = word.match(URLDelimiter);
+        if (match) {
+          let url = match[0];
+
+          return React.createElement("a",
+            Object.assign({}, {
+              key: `autolink-${url}`,
+              href: url
+            }, this.props.options),
+            url
+          );
+        }
+        return word;
+      });
+  },
+
+  render: function () {
+    return (
+      <span>{this.autolink()}</span>
+    );
+  }
+});
+
+module.exports = AutolinkComponent;

--- a/src/js/components/FormGroupComponent.jsx
+++ b/src/js/components/FormGroupComponent.jsx
@@ -1,6 +1,8 @@
 import classNames from "classnames";
 import React from "react/addons";
 
+import AutolinkComponent from "./AutolinkComponent";
+
 var FormGroupComponent = React.createClass({
   displayName: "FormGroupComponent",
 
@@ -33,7 +35,7 @@ var FormGroupComponent = React.createClass({
 
     return (
       <div className="help-block">
-        <strong>{props.errorMessage}</strong>
+        <AutolinkComponent text={props.errorMessage} />
       </div>
     );
   },

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -6,6 +6,7 @@ import AppsActions from "../../actions/AppsActions";
 import AppsEvents from "../../events/AppsEvents";
 import AppFormErrorMessages from "../../constants/AppFormErrorMessages";
 import AppFormStore from "../../stores/AppFormStore";
+import AutolinkComponent from "../AutolinkComponent";
 import AppsStore from "../../stores/AppsStore";
 import CollapsiblePanelComponent
   from "../../components/CollapsiblePanelComponent";
@@ -177,7 +178,7 @@ var AppModalComponent = React.createClass({
 
     return (
       <p className="text-danger">
-        <strong>{error}</strong>
+        <AutolinkComponent text={error} />
       </p>
     );
   },

--- a/src/js/constants/AppFormErrorMessages.js
+++ b/src/js/constants/AppFormErrorMessages.js
@@ -14,7 +14,7 @@ const applicationFieldValidationErrors = Util.deepFreeze({
   constraints: [
     "Invalid constraints format or operator. Supported operators are " +
     ValidConstraints.map((c) => `'${c}'`).join(", ") +
-    ". See https://mesosphere.github.io/marathon/docs/constraints.html."
+    ". See https://mesosphere.github.io/marathon/docs/constraints.html"
   ],
   containerVolumes: [
     "Container Path must be a valid path",

--- a/src/test/units/AutolinkComponent.test.js
+++ b/src/test/units/AutolinkComponent.test.js
@@ -1,0 +1,32 @@
+import {expect} from "chai";
+import {shallow} from "enzyme";
+
+import React from "react/addons";
+
+import AutolinkComponent from "../../js/components/AutolinkComponent";
+
+describe("AutolinkComponent", function () {
+
+  it("detects URLs in strings", function () {
+    var url = "http://www.test.com/page";
+    var text = `Example test that has a hidden ${url} URL.`;
+    this.component = shallow(<AutolinkComponent text={text}/>);
+    expect(this.component.find("a").props().href).to.equal(url);
+  });
+
+  it("does not create anchors when no URL is found", function () {
+    var url = "not a url";
+    var text = `Example test that has a hidden ${url} URL.`;
+    this.component = shallow(<AutolinkComponent text={text}/>);
+    expect(this.component.find("a")).length.to.be(0);
+  });
+
+  it("handles tricky URLs", function () {
+    var url = "https://test.com/ütf8/röcks/";
+    var text = `Example test that has a hidden ${url} URL.`;
+    this.component = shallow(<AutolinkComponent text={text}/>);
+    expect(this.component.find("a").props().href).to.equal(url);
+  });
+
+
+});


### PR DESCRIPTION
This fixes https://github.com/mesosphere/marathon/issues/3082 

![autolink](https://cloud.githubusercontent.com/assets/1078545/12743057/3b376b54-c98b-11e5-967e-c0898d9dae38.gif)

(for some reason the gif does not like the color red)