### PR TITLE
Refactor - 3148 Introduce getters in AppFormStore

### DIFF
--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -87,7 +87,9 @@ var AppModalComponent = React.createClass({
         force: true
       });
     } else {
-      this.setState({error: AppFormStore.responseErrors["general"]});
+      this.setState({
+        error: AppFormStore.getResponseErrors()["general"]
+      });
     }
   },
 

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -88,7 +88,7 @@ var AppModalComponent = React.createClass({
       });
     } else {
       this.setState({
-        error: AppFormStore.getResponseErrors()["general"]
+        error: AppFormStore.responseErrors["general"]
       });
     }
   },
@@ -97,7 +97,7 @@ var AppModalComponent = React.createClass({
     event.preventDefault();
 
     if (this.state.appIsValid) {
-      const app = AppFormStore.getApp();
+      const app = AppFormStore.app;
 
       if (this.props.app != null) {
         AppsActions.applySettingsOnApp(app.id, app, true, this.state.force);

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -241,6 +241,24 @@ function deleteErrorIndices(errorIndices, fieldId, consecutiveKey) {
   }
 }
 
+// Update validationErrorIndices for given field - insert error if one exists,
+// delete any existent error if no error exists.
+// Returns true if an error was found.
+function updateErrorIndices(fieldId, value, errorIndices) {
+  var errorIndex = getValidationErrorIndex(fieldId, value);
+  if (errorIndex > -1) {
+    if (value.consecutiveKey != null) {
+      Util.initKeyValue(errorIndices, fieldId, []);
+      errorIndices[fieldId][value.consecutiveKey] = errorIndex;
+    } else {
+      errorIndices[fieldId] = errorIndex;
+    }
+    return true;
+  }
+  deleteErrorIndices(errorIndices, fieldId, value.consecutiveKey);
+  return false;
+}
+
 function rebuildModelFromFields(app, fields, fieldId) {
   const key = resolveFieldIdToAppKeyMap[fieldId];
   if (key) {
@@ -461,24 +479,6 @@ function executeAction(action, setFieldFunction) {
   } else {
     AppFormStore.emit(FormEvents.FIELD_VALIDATION_ERROR);
   }
-}
-
-// Update validationErrorIndices for given field - insert error if one exists,
-// delete any existent error if no error exists.
-// Returns true if an error was found.
-function updateErrorIndices(fieldId, value, errorIndices) {
-  var errorIndex = getValidationErrorIndex(fieldId, value);
-  if (errorIndex > -1) {
-    if (value.consecutiveKey != null) {
-      Util.initKeyValue(errorIndices, fieldId, []);
-      errorIndices[fieldId][value.consecutiveKey] = errorIndex;
-    } else {
-      errorIndices[fieldId] = errorIndex;
-    }
-    return true;
-  }
-  deleteErrorIndices(errorIndices, fieldId, value.consecutiveKey);
-  return false;
 }
 
 function onAppsErrorResponse(response, statusCode) {

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -14,7 +14,8 @@ import FormEvents from "../events/FormEvents";
 
 const storeData = {
   app: {},
-  fields: {}
+  fields: {},
+  responseErrors: {}
 };
 
 const defaultFieldValues = Object.freeze({
@@ -410,7 +411,9 @@ var AppFormStore = lazy(EventEmitter.prototype).extend({
   getFields: function () {
     return Util.deepCopy(storeData.fields);
   },
-  responseErrors: {},
+  getResponseErrors: function () {
+    return Util.deepCopy(storeData.responseErrors);
+  },
   validationErrorIndices: {},
   initAndReset: function () {
     storeData.app = {};
@@ -475,8 +478,8 @@ function updateErrorIndices(fieldId, value, errorIndices) {
 }
 
 function onAppsErrorResponse(response, statusCode) {
-  AppFormStore.responseErrors = {};
-  processResponseErrors(AppFormStore.responseErrors, response, statusCode);
+  storeData.responseErrors = {};
+  processResponseErrors(storeData.responseErrors, response, statusCode);
 }
 
 AppsStore.on(AppsEvents.CREATE_APP_ERROR, function (data, status) {
@@ -486,10 +489,10 @@ AppsStore.on(AppsEvents.APPLY_APP_ERROR, function (data, isEditing, status) {
   onAppsErrorResponse(data, status);
 });
 AppsStore.on(AppsEvents.CREATE_APP, function () {
-  AppFormStore.responseErrors = {};
+  storeData.responseErrors = {};
 });
 AppsStore.on(AppsEvents.APPLY_APP, function () {
-  AppFormStore.responseErrors = {};
+  storeData.responseErrors = {};
 });
 
 AppDispatcher.register(function (action) {

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -13,7 +13,8 @@ import AppsEvents from "../events/AppsEvents";
 import FormEvents from "../events/FormEvents";
 
 const storeData = {
-  app: {}
+  app: {},
+  fields: {}
 };
 
 const defaultFieldValues = Object.freeze({
@@ -394,7 +395,6 @@ function processResponseErrors(responseErrors, response, statusCode) {
 }
 
 var AppFormStore = lazy(EventEmitter.prototype).extend({
-  fields: {},
   getApp: function () {
     var app = Util.deepCopy(storeData.app);
 
@@ -407,21 +407,24 @@ var AppFormStore = lazy(EventEmitter.prototype).extend({
 
     return app;
   },
+  getFields: function () {
+    return Util.deepCopy(storeData.fields);
+  },
   responseErrors: {},
   validationErrorIndices: {},
   initAndReset: function () {
     storeData.app = {};
-    this.fields = {};
+    storeData.fields = {};
     this.validationErrorIndices = {};
 
     Object.keys(defaultFieldValues).forEach((fieldId) => {
-      this.fields[fieldId] = defaultFieldValues[fieldId];
-      rebuildModelFromFields(storeData.app, this.fields, fieldId);
+      storeData.fields[fieldId] = defaultFieldValues[fieldId];
+      rebuildModelFromFields(storeData.app, storeData.fields, fieldId);
     });
   },
   populateFieldsFromAppDefinition: function (app) {
     storeData.app = app;
-    populateFieldsFromModel(Util.deepCopy(storeData.app), this.fields);
+    populateFieldsFromModel(Util.deepCopy(storeData.app), storeData.fields);
 
     if (!checkAllFieldsForValidity(storeData.fields)) {
       AppFormStore.emit(FormEvents.FIELD_VALIDATION_ERROR);
@@ -443,10 +446,10 @@ function executeAction(action, setFieldFunction) {
     deleteErrorIndices(errorIndices, fieldId, value.consecutiveKey);
   }
 
-  setFieldFunction(AppFormStore.fields, fieldId, index, value);
+  setFieldFunction(storeData.fields, fieldId, index, value);
 
   if (!errorOccurred) {
-    rebuildModelFromFields(storeData.app, AppFormStore.fields, fieldId);
+    rebuildModelFromFields(storeData.app, storeData.fields, fieldId);
     AppFormStore.emit(FormEvents.CHANGE, fieldId);
   } else {
     AppFormStore.emit(FormEvents.FIELD_VALIDATION_ERROR);

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -15,7 +15,8 @@ import FormEvents from "../events/FormEvents";
 const storeData = {
   app: {},
   fields: {},
-  responseErrors: {}
+  responseErrors: {},
+  validationErrorIndices: {}
 };
 
 const defaultFieldValues = Object.freeze({
@@ -414,11 +415,14 @@ var AppFormStore = lazy(EventEmitter.prototype).extend({
   getResponseErrors: function () {
     return Util.deepCopy(storeData.responseErrors);
   },
-  validationErrorIndices: {},
+  getValidationErrorIndices: function () {
+    return Util.deepCopy(storeData.validationErrorIndices);
+  },
   initAndReset: function () {
     storeData.app = {};
     storeData.fields = {};
-    this.validationErrorIndices = {};
+    storeData.responseErrors = {};
+    storeData.validationErrorIndices = {};
 
     Object.keys(defaultFieldValues).forEach((fieldId) => {
       storeData.fields[fieldId] = defaultFieldValues[fieldId];
@@ -440,7 +444,7 @@ function executeAction(action, setFieldFunction) {
   var fieldId = action.fieldId;
   var value = action.value;
   var index = action.index;
-  var errorIndices = AppFormStore.validationErrorIndices;
+  var errorIndices = storeData.validationErrorIndices;
   var errorOccurred = false;
 
   if (actionType === FormEvents.INSERT || actionType === FormEvents.UPDATE) {

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -12,6 +12,10 @@ import AppsStore from "./AppsStore";
 import AppsEvents from "../events/AppsEvents";
 import FormEvents from "../events/FormEvents";
 
+const storeData = {
+  app: {}
+};
+
 const defaultFieldValues = Object.freeze({
   cpus: 0.1,
   mem: 16,
@@ -390,10 +394,9 @@ function processResponseErrors(responseErrors, response, statusCode) {
 }
 
 var AppFormStore = lazy(EventEmitter.prototype).extend({
-  app: {},
   fields: {},
   getApp: function () {
-    var app = Util.deepCopy(this.app);
+    var app = Util.deepCopy(storeData.app);
 
     Object.keys(app).forEach((appKey) => {
       var postProcessor = AppFormModelPostProcess[appKey];
@@ -407,20 +410,20 @@ var AppFormStore = lazy(EventEmitter.prototype).extend({
   responseErrors: {},
   validationErrorIndices: {},
   initAndReset: function () {
-    this.app = {};
+    storeData.app = {};
     this.fields = {};
     this.validationErrorIndices = {};
 
     Object.keys(defaultFieldValues).forEach((fieldId) => {
       this.fields[fieldId] = defaultFieldValues[fieldId];
-      rebuildModelFromFields(this.app, this.fields, fieldId);
+      rebuildModelFromFields(storeData.app, this.fields, fieldId);
     });
   },
   populateFieldsFromAppDefinition: function (app) {
-    this.app = app;
-    populateFieldsFromModel(Util.deepCopy(app), this.fields);
+    storeData.app = app;
+    populateFieldsFromModel(Util.deepCopy(storeData.app), this.fields);
 
-    if (!checkAllFieldsForValidity(this.fields)) {
+    if (!checkAllFieldsForValidity(storeData.fields)) {
       AppFormStore.emit(FormEvents.FIELD_VALIDATION_ERROR);
     }
   }
@@ -443,7 +446,7 @@ function executeAction(action, setFieldFunction) {
   setFieldFunction(AppFormStore.fields, fieldId, index, value);
 
   if (!errorOccurred) {
-    rebuildModelFromFields(AppFormStore.app, AppFormStore.fields, fieldId);
+    rebuildModelFromFields(storeData.app, AppFormStore.fields, fieldId);
     AppFormStore.emit(FormEvents.CHANGE, fieldId);
   } else {
     AppFormStore.emit(FormEvents.FIELD_VALIDATION_ERROR);

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -1,5 +1,4 @@
 import {EventEmitter} from "events";
-import lazy from "lazy.js";
 import objectPath from "object-path";
 import Util from "../helpers/Util";
 
@@ -396,8 +395,8 @@ function processResponseErrors(responseErrors, response, statusCode) {
   }
 }
 
-var AppFormStore = lazy(EventEmitter.prototype).extend({
-  getApp: function () {
+var AppFormStore = Util.extendObject(EventEmitter.prototype, {
+  get app() {
     var app = Util.deepCopy(storeData.app);
 
     Object.keys(app).forEach((appKey) => {
@@ -409,15 +408,16 @@ var AppFormStore = lazy(EventEmitter.prototype).extend({
 
     return app;
   },
-  getFields: function () {
+  get fields() {
     return Util.deepCopy(storeData.fields);
   },
-  getResponseErrors: function () {
+  get responseErrors() {
     return Util.deepCopy(storeData.responseErrors);
   },
-  getValidationErrorIndices: function () {
+  get validationErrorIndices() {
     return Util.deepCopy(storeData.validationErrorIndices);
   },
+
   initAndReset: function () {
     storeData.app = {};
     storeData.fields = {};
@@ -437,7 +437,7 @@ var AppFormStore = lazy(EventEmitter.prototype).extend({
       AppFormStore.emit(FormEvents.FIELD_VALIDATION_ERROR);
     }
   }
-}).value();
+});
 
 function executeAction(action, setFieldFunction) {
   var actionType = action.actionType;

--- a/src/test/scenarios/createApplication.test.js
+++ b/src/test/scenarios/createApplication.test.js
@@ -425,8 +425,7 @@ describe("Create Application", function () {
       describe("the model", function () {
 
         after(function () {
-          AppFormStore.app = {};
-          AppFormStore.fields = {};
+          AppFormStore.initAndReset();
         });
 
         it("updates correctly", function (done) {
@@ -440,10 +439,10 @@ describe("Create Application", function () {
         });
 
         it("preserves unknown properties", function (done) {
-          AppFormStore.app = {
+          AppFormStore.populateFieldsFromAppDefinition({
             id: "/app-1",
             unknownProperty: "unknown"
-          };
+          });
 
           AppFormStore.once(FormEvents.CHANGE, function () {
             expectAsync(function () {
@@ -456,13 +455,13 @@ describe("Create Application", function () {
         });
 
         it("preserves unknown nested properties", function (done) {
-          AppFormStore.app = {
+          AppFormStore.populateFieldsFromAppDefinition({
             container: {
               docker: {
                 unknownProperty: "unknown"
               }
             }
-          };
+          });
 
           AppFormStore.once(FormEvents.CHANGE, function () {
             expectAsync(function () {

--- a/src/test/scenarios/createApplication.test.js
+++ b/src/test/scenarios/createApplication.test.js
@@ -160,7 +160,7 @@ describe("Create Application", function () {
 
         AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
           expectAsync(function () {
-            expect(AppFormStore.responseErrors.instances)
+            expect(AppFormStore.getResponseErrors().instances)
               .to.equal("error.expected.jsnumber");
           }, done);
         });
@@ -187,7 +187,7 @@ describe("Create Application", function () {
 
         AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
           expectAsync(function () {
-            expect(AppFormStore.responseErrors.general)
+            expect(AppFormStore.getResponseErrors().general)
               .to.equal(expectedMessage);
           }, done);
         });
@@ -211,7 +211,7 @@ describe("Create Application", function () {
 
         AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
           expectAsync(function () {
-            expect(AppFormStore.responseErrors.general)
+            expect(AppFormStore.getResponseErrors().general)
               .to.equal(expectedMessage);
           }, done);
         });
@@ -229,7 +229,7 @@ describe("Create Application", function () {
 
         AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
           expectAsync(function () {
-            expect(AppFormStore.responseErrors.appId)
+            expect(AppFormStore.getResponseErrors().appId)
               .to.equal("error on id attribute");
           }, done);
         });
@@ -253,7 +253,7 @@ describe("Create Application", function () {
 
           AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
             expectAsync(function () {
-              expect(AppFormStore.responseErrors.general)
+              expect(AppFormStore.getResponseErrors().general)
                 .to.equal(
                   AppFormErrorMessages.getGeneralMessage("appCreation")
                 );
@@ -274,7 +274,7 @@ describe("Create Application", function () {
 
           AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
             expectAsync(function () {
-              expect(AppFormStore.responseErrors.general).to.equal(
+              expect(AppFormStore.getResponseErrors().general).to.equal(
                 AppFormErrorMessages.getGeneralMessage("unauthorizedAccess")
               );
             }, done);
@@ -294,7 +294,7 @@ describe("Create Application", function () {
 
           AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
             expectAsync(function () {
-              expect(AppFormStore.responseErrors.general).to.equal(
+              expect(AppFormStore.getResponseErrors().general).to.equal(
                 AppFormErrorMessages.getGeneralMessage("errorPrefix")
                 + " something strange"
               );
@@ -315,7 +315,7 @@ describe("Create Application", function () {
 
           AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
             expectAsync(function () {
-              expect(AppFormStore.responseErrors.general).to.equal(
+              expect(AppFormStore.getResponseErrors().general).to.equal(
                 AppFormErrorMessages.getGeneralMessage("forbiddenAccess")
               );
             }, done);
@@ -335,7 +335,7 @@ describe("Create Application", function () {
 
           AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
             expectAsync(function () {
-              expect(AppFormStore.responseErrors.general).to.equal(
+              expect(AppFormStore.getResponseErrors().general).to.equal(
                 AppFormErrorMessages.getGeneralMessage("errorPrefix")
                 + " something strange"
               );
@@ -354,7 +354,7 @@ describe("Create Application", function () {
       it("processes error response codes >= 500 correctly", function (done) {
         AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
           expectAsync(function () {
-            expect(AppFormStore.responseErrors.general)
+            expect(AppFormStore.getResponseErrors().general)
               .to.equal(
               AppFormErrorMessages.getGeneralMessage("unknownServerError")
             );
@@ -373,7 +373,7 @@ describe("Create Application", function () {
       it("has no response errors on success", function (done) {
         AppsStore.once(AppsEvents.CHANGE, function () {
           expectAsync(function () {
-            expect(Object.keys(AppFormStore.responseErrors).length).to.equal(0);
+            expect(Object.keys(AppFormStore.getResponseErrors()).length).to.equal(0);
           }, done);
         });
 
@@ -1159,7 +1159,7 @@ describe("Create Application", function () {
 
           AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
             expectAsync(function () {
-              expect(AppFormStore.responseErrors.instances)
+              expect(AppFormStore.getResponseErrors().instances)
                 .to.equal("error.expected.jsnumber");
             }, done);
           });
@@ -1186,7 +1186,7 @@ describe("Create Application", function () {
 
           AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
             expectAsync(function () {
-              expect(AppFormStore.responseErrors.general)
+              expect(AppFormStore.getResponseErrors().general)
                 .to.equal(expectedMessage);
             }, done);
           });
@@ -1210,7 +1210,7 @@ describe("Create Application", function () {
 
           AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
             expectAsync(function () {
-              expect(AppFormStore.responseErrors.general)
+              expect(AppFormStore.getResponseErrors().general)
                 .to.equal(expectedMessage);
             }, done);
           });
@@ -1228,7 +1228,7 @@ describe("Create Application", function () {
 
           AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
             expectAsync(function () {
-              expect(AppFormStore.responseErrors.appId)
+              expect(AppFormStore.getResponseErrors().appId)
                 .to.equal("error on id attribute");
             }, done);
           });
@@ -1252,7 +1252,7 @@ describe("Create Application", function () {
 
             AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
               expectAsync(function () {
-                expect(AppFormStore.responseErrors.general).to.equal(
+                expect(AppFormStore.getResponseErrors().general).to.equal(
                   AppFormErrorMessages.getGeneralMessage("appCreation")
                 );
               }, done);
@@ -1272,7 +1272,7 @@ describe("Create Application", function () {
 
             AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
               expectAsync(function () {
-                expect(AppFormStore.responseErrors.general).to.equal(
+                expect(AppFormStore.getResponseErrors().general).to.equal(
                   AppFormErrorMessages.getGeneralMessage("unauthorizedAccess")
                 );
               }, done);
@@ -1292,7 +1292,7 @@ describe("Create Application", function () {
 
             AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
               expectAsync(function () {
-                expect(AppFormStore.responseErrors.general).to.equal(
+                expect(AppFormStore.getResponseErrors().general).to.equal(
                   AppFormErrorMessages.getGeneralMessage("errorPrefix")
                   + " something strange"
                 );
@@ -1313,7 +1313,7 @@ describe("Create Application", function () {
 
             AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
               expectAsync(function () {
-                expect(AppFormStore.responseErrors.general).to.equal(
+                expect(AppFormStore.getResponseErrors().general).to.equal(
                   AppFormErrorMessages.getGeneralMessage("forbiddenAccess")
                 );
               }, done);
@@ -1333,7 +1333,7 @@ describe("Create Application", function () {
 
             AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
               expectAsync(function () {
-                expect(AppFormStore.responseErrors.general).to.equal(
+                expect(AppFormStore.getResponseErrors().general).to.equal(
                   AppFormErrorMessages.getGeneralMessage("errorPrefix")
                   + " something strange");
               }, done);
@@ -1351,7 +1351,7 @@ describe("Create Application", function () {
         it("processes error response codes >= 500 correctly", function (done) {
           AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
             expectAsync(function () {
-              expect(AppFormStore.responseErrors.general).to.equal(
+              expect(AppFormStore.getResponseErrors().general).to.equal(
                 AppFormErrorMessages.getGeneralMessage("unknownServerError")
               );
             }, done);
@@ -1369,7 +1369,7 @@ describe("Create Application", function () {
         it("has no response errors on success", function (done) {
           AppsStore.once(AppsEvents.CHANGE, function () {
             expectAsync(function () {
-              expect(Object.keys(AppFormStore.responseErrors).length)
+              expect(Object.keys(AppFormStore.getResponseErrors()).length)
                 .to.equal(0);
             }, done);
           });

--- a/src/test/scenarios/createApplication.test.js
+++ b/src/test/scenarios/createApplication.test.js
@@ -159,7 +159,7 @@ describe("Create Application", function () {
 
         AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
           expectAsync(function () {
-            expect(AppFormStore.getResponseErrors().instances)
+            expect(AppFormStore.responseErrors.instances)
               .to.equal("error.expected.jsnumber");
           }, done);
         });
@@ -186,7 +186,7 @@ describe("Create Application", function () {
 
         AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
           expectAsync(function () {
-            expect(AppFormStore.getResponseErrors().general)
+            expect(AppFormStore.responseErrors.general)
               .to.equal(expectedMessage);
           }, done);
         });
@@ -210,7 +210,7 @@ describe("Create Application", function () {
 
         AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
           expectAsync(function () {
-            expect(AppFormStore.getResponseErrors().general)
+            expect(AppFormStore.responseErrors.general)
               .to.equal(expectedMessage);
           }, done);
         });
@@ -228,7 +228,7 @@ describe("Create Application", function () {
 
         AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
           expectAsync(function () {
-            expect(AppFormStore.getResponseErrors().appId)
+            expect(AppFormStore.responseErrors.appId)
               .to.equal("error on id attribute");
           }, done);
         });
@@ -252,7 +252,7 @@ describe("Create Application", function () {
 
           AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
             expectAsync(function () {
-              expect(AppFormStore.getResponseErrors().general)
+              expect(AppFormStore.responseErrors.general)
                 .to.equal(
                   AppFormErrorMessages.getGeneralMessage("appCreation")
                 );
@@ -273,7 +273,7 @@ describe("Create Application", function () {
 
           AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
             expectAsync(function () {
-              expect(AppFormStore.getResponseErrors().general).to.equal(
+              expect(AppFormStore.responseErrors.general).to.equal(
                 AppFormErrorMessages.getGeneralMessage("unauthorizedAccess")
               );
             }, done);
@@ -293,7 +293,7 @@ describe("Create Application", function () {
 
           AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
             expectAsync(function () {
-              expect(AppFormStore.getResponseErrors().general).to.equal(
+              expect(AppFormStore.responseErrors.general).to.equal(
                 AppFormErrorMessages.getGeneralMessage("errorPrefix")
                 + " something strange"
               );
@@ -314,7 +314,7 @@ describe("Create Application", function () {
 
           AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
             expectAsync(function () {
-              expect(AppFormStore.getResponseErrors().general).to.equal(
+              expect(AppFormStore.responseErrors.general).to.equal(
                 AppFormErrorMessages.getGeneralMessage("forbiddenAccess")
               );
             }, done);
@@ -334,7 +334,7 @@ describe("Create Application", function () {
 
           AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
             expectAsync(function () {
-              expect(AppFormStore.getResponseErrors().general).to.equal(
+              expect(AppFormStore.responseErrors.general).to.equal(
                 AppFormErrorMessages.getGeneralMessage("errorPrefix")
                 + " something strange"
               );
@@ -353,7 +353,7 @@ describe("Create Application", function () {
       it("processes error response codes >= 500 correctly", function (done) {
         AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
           expectAsync(function () {
-            expect(AppFormStore.getResponseErrors().general)
+            expect(AppFormStore.responseErrors.general)
               .to.equal(
               AppFormErrorMessages.getGeneralMessage("unknownServerError")
             );
@@ -372,7 +372,7 @@ describe("Create Application", function () {
       it("has no response errors on success", function (done) {
         AppsStore.once(AppsEvents.CHANGE, function () {
           expectAsync(function () {
-            expect(Object.keys(AppFormStore.getResponseErrors()).length)
+            expect(Object.keys(AppFormStore.responseErrors).length)
               .to.equal(0);
           }, done);
         });
@@ -400,9 +400,9 @@ describe("Create Application", function () {
           function (done) {
             AppFormStore.once(FormEvents.FIELD_VALIDATION_ERROR, function () {
               expectAsync(function () {
-                expect(AppFormStore.getValidationErrorIndices())
+                expect(AppFormStore.validationErrorIndices)
                   .to.have.property("appId");
-                expect(AppFormStore.getValidationErrorIndices().appId)
+                expect(AppFormStore.validationErrorIndices.appId)
                   .to.equal(0);
               }, done);
             });
@@ -414,9 +414,9 @@ describe("Create Application", function () {
           function (done) {
             AppFormStore.once(FormEvents.FIELD_VALIDATION_ERROR, function () {
               expectAsync(function () {
-                expect(AppFormStore.getValidationErrorIndices())
+                expect(AppFormStore.validationErrorIndices)
                   .to.have.property("appId");
-                expect(AppFormStore.getValidationErrorIndices().appId)
+                expect(AppFormStore.validationErrorIndices.appId)
                   .to.equal(1);
               }, done);
             });
@@ -435,7 +435,7 @@ describe("Create Application", function () {
         it("updates correctly", function (done) {
           AppFormStore.once(FormEvents.CHANGE, function () {
             expectAsync(function () {
-              expect(AppFormStore.getApp().id).to.equal("/app-1");
+              expect(AppFormStore.app.id).to.equal("/app-1");
             }, done);
           });
 
@@ -450,8 +450,8 @@ describe("Create Application", function () {
 
           AppFormStore.once(FormEvents.CHANGE, function () {
             expectAsync(function () {
-              expect(AppFormStore.getApp().id).to.equal("/app-2");
-              expect(AppFormStore.getApp().unknownProperty).to.equal("unknown");
+              expect(AppFormStore.app.id).to.equal("/app-2");
+              expect(AppFormStore.app.unknownProperty).to.equal("unknown");
             }, done);
           });
 
@@ -469,7 +469,7 @@ describe("Create Application", function () {
 
           AppFormStore.once(FormEvents.CHANGE, function () {
             expectAsync(function () {
-              expect(AppFormStore.getApp().container.docker.unknownProperty)
+              expect(AppFormStore.app.container.docker.unknownProperty)
                 .to.equal("unknown");
             }, done);
           });
@@ -482,7 +482,7 @@ describe("Create Application", function () {
           it("updates correctly", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.getApp().cpus).to.equal(1.1);
+                expect(AppFormStore.app.cpus).to.equal(1.1);
               }, done);
             });
 
@@ -494,7 +494,7 @@ describe("Create Application", function () {
           it("updates correctly", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.getApp().disk).to.equal(256);
+                expect(AppFormStore.app.disk).to.equal(256);
               }, done);
             });
 
@@ -506,7 +506,7 @@ describe("Create Application", function () {
           it("updates correctly", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.getApp().cmd).to.equal("sleep 1");
+                expect(AppFormStore.app.cmd).to.equal("sleep 1");
               }, done);
             });
 
@@ -519,7 +519,7 @@ describe("Create Application", function () {
           it("inserts a key-value pair", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.getApp().env.ENV_KEY_1)
+                expect(AppFormStore.app.env.ENV_KEY_1)
                   .to.equal("ENV_VALUE_1");
               }, done);
             });
@@ -530,9 +530,9 @@ describe("Create Application", function () {
           it("inserts another key-value pair", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.getApp().env.ENV_KEY_1)
+                expect(AppFormStore.app.env.ENV_KEY_1)
                   .to.equal("ENV_VALUE_1");
-                expect(AppFormStore.getApp().env.ENV_KEY_2)
+                expect(AppFormStore.app.env.ENV_KEY_2)
                   .to.equal("ENV_VALUE_2");
               }, done);
             });
@@ -543,7 +543,7 @@ describe("Create Application", function () {
           it("updates a key-value pair", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.getApp().env.ENV_KEY_1)
+                expect(AppFormStore.app.env.ENV_KEY_1)
                   .to.equal("ENV_VALUE_1A");
               }, done);
             });
@@ -557,7 +557,7 @@ describe("Create Application", function () {
           it("deletes a key-value pair", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.getApp().env)
+                expect(AppFormStore.app.env)
                   .to.not.have.property("ENV_VALUE_1A");
               }, done);
             });
@@ -572,7 +572,7 @@ describe("Create Application", function () {
           it("inserts a key-value pair", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.getApp().labels.L_KEY_1)
+                expect(AppFormStore.app.labels.L_KEY_1)
                   .to.equal("L_VALUE_1");
               }, done);
             });
@@ -583,9 +583,9 @@ describe("Create Application", function () {
           it("inserts another key-value pair", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.getApp().labels.L_KEY_1)
+                expect(AppFormStore.app.labels.L_KEY_1)
                   .to.equal("L_VALUE_1");
-                expect(AppFormStore.getApp().labels.L_KEY_2)
+                expect(AppFormStore.app.labels.L_KEY_2)
                   .to.equal("L_VALUE_2");
               }, done);
             });
@@ -596,7 +596,7 @@ describe("Create Application", function () {
           it("updates a key-value pair", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.getApp().labels.L_KEY_1)
+                expect(AppFormStore.app.labels.L_KEY_1)
                   .to.equal("L_VALUE_1A");
               }, done);
             });
@@ -610,7 +610,7 @@ describe("Create Application", function () {
           it("deletes a key-value pair", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.getApp().labels)
+                expect(AppFormStore.app.labels)
                   .to.not.have.property("L_VALUE_1A");
               }, done);
             });
@@ -625,7 +625,7 @@ describe("Create Application", function () {
           it("updates correctly", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.getApp().mem).to.equal(32);
+                expect(AppFormStore.app.mem).to.equal(32);
               }, done);
             });
 
@@ -637,7 +637,7 @@ describe("Create Application", function () {
           it("updates correctly", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.getApp().instances).to.equal(2);
+                expect(AppFormStore.app.instances).to.equal(2);
               }, done);
             });
 
@@ -649,7 +649,7 @@ describe("Create Application", function () {
           it("doesn't update on invalid value", function (done) {
             AppFormStore.once(FormEvents.FIELD_VALIDATION_ERROR, function () {
               expectAsync(function () {
-                expect(AppFormStore.getApp().executor).to.be.undefined;
+                expect(AppFormStore.app.executor).to.be.undefined;
               }, done);
             });
 
@@ -663,7 +663,7 @@ describe("Create Application", function () {
         it("updates correctly", function (done) {
           AppFormStore.once(FormEvents.CHANGE, function () {
             expectAsync(function () {
-              expect(AppFormStore.getFields().appId).to.equal("/app-1");
+              expect(AppFormStore.fields.appId).to.equal("/app-1");
             }, done);
           });
 
@@ -676,7 +676,7 @@ describe("Create Application", function () {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
 
-                expect(AppFormStore.getFields().cpus).to.equal(1.1);
+                expect(AppFormStore.fields.cpus).to.equal(1.1);
               }, done);
             });
 
@@ -688,7 +688,7 @@ describe("Create Application", function () {
           it("updates correctly", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.getFields().disk).to.equal(256);
+                expect(AppFormStore.fields.disk).to.equal(256);
               }, done);
             });
 
@@ -701,7 +701,7 @@ describe("Create Application", function () {
           it("updates correctly", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.getFields().cmd).to.equal("sleep 1");
+                expect(AppFormStore.fields.cmd).to.equal("sleep 1");
               }, done);
             });
 
@@ -715,7 +715,7 @@ describe("Create Application", function () {
             it("updates correctly", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  expect(AppFormStore.getFields().dockerForcePullImage)
+                  expect(AppFormStore.fields.dockerForcePullImage)
                     .to.equal(true);
                 }, done);
               });
@@ -728,7 +728,7 @@ describe("Create Application", function () {
             it("updates correctly", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  expect(AppFormStore.getFields().dockerImage)
+                  expect(AppFormStore.fields.dockerImage)
                     .to.equal("/image");
                 }, done);
               });
@@ -741,7 +741,7 @@ describe("Create Application", function () {
             it("updates correctly", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  expect(AppFormStore.getFields().dockerNetwork)
+                  expect(AppFormStore.fields.dockerNetwork)
                     .to.equal("BRIDGE");
                 }, done);
               });
@@ -754,7 +754,7 @@ describe("Create Application", function () {
             it("updates correctly", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  expect(AppFormStore.getFields().dockerPrivileged)
+                  expect(AppFormStore.fields.dockerPrivileged)
                     .to.equal(true);
                 }, done);
               });
@@ -768,7 +768,7 @@ describe("Create Application", function () {
             it("inserts a new row", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  expect(AppFormStore.getFields().dockerPortMappings[0])
+                  expect(AppFormStore.fields.dockerPortMappings[0])
                     .to.deep.equal({
                       containerPort: 8000,
                       hostPort: 8001,
@@ -789,7 +789,7 @@ describe("Create Application", function () {
             it("inserts another row", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  expect(AppFormStore.getFields().dockerPortMappings[0])
+                  expect(AppFormStore.fields.dockerPortMappings[0])
                     .to.deep.equal({
                       containerPort: 8000,
                       hostPort: 8001,
@@ -797,7 +797,7 @@ describe("Create Application", function () {
                       protocol: "udp"
                     });
 
-                  expect(AppFormStore.getFields().dockerPortMappings[1])
+                  expect(AppFormStore.fields.dockerPortMappings[1])
                     .to.deep.equal({
                       containerPort: 9000,
                       hostPort: 9001,
@@ -818,7 +818,7 @@ describe("Create Application", function () {
             it("updates a row at index", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  let row = AppFormStore.getFields().dockerPortMappings[0];
+                  let row = AppFormStore.fields.dockerPortMappings[0];
                   expect(row.containerPort).to.equal(9000);
                   expect(row.hostPort).to.equal(9001);
                   expect(row.servicePort).to.equal(8101);
@@ -837,8 +837,8 @@ describe("Create Application", function () {
             it("deletes a row at index", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  let row = AppFormStore.getFields().dockerPortMappings[0];
-                  expect(AppFormStore.getFields().dockerPortMappings.length)
+                  let row = AppFormStore.fields.dockerPortMappings[0];
+                  expect(AppFormStore.fields.dockerPortMappings.length)
                     .to.equal(1);
                   expect(row).to.deep.equal({
                     containerPort: 9000,
@@ -859,7 +859,7 @@ describe("Create Application", function () {
             it("inserts a new row", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  expect(AppFormStore.getFields().dockerParameters[0])
+                  expect(AppFormStore.fields.dockerParameters[0])
                     .to.deep.equal({
                       key: "DOCKER_KEY",
                       value: "DOCKER_VALUE"
@@ -877,7 +877,7 @@ describe("Create Application", function () {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
 
-                  expect(AppFormStore.getFields().dockerParameters[1])
+                  expect(AppFormStore.fields.dockerParameters[1])
                     .to.deep.equal({
                       key: "DOCKER_KEY_1",
                       value: "DOCKER_VALUE_1"
@@ -894,7 +894,7 @@ describe("Create Application", function () {
             it("updates a row at index", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  let row = AppFormStore.getFields().dockerParameters[0];
+                  let row = AppFormStore.fields.dockerParameters[0];
                   expect(row.key).to.equal("DOCKER_KEY_1A");
                   expect(row.value).to.equal("DOCKER_VALUE_1");
                 }, done);
@@ -908,8 +908,8 @@ describe("Create Application", function () {
             it("deletes a row at index", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  let row = AppFormStore.getFields().dockerParameters[0];
-                  expect(AppFormStore.getFields().dockerParameters.length)
+                  let row = AppFormStore.fields.dockerParameters[0];
+                  expect(AppFormStore.fields.dockerParameters.length)
                     .to.equal(1);
                   expect(row).to.deep.equal({
                     key: "DOCKER_KEY_1",
@@ -928,7 +928,7 @@ describe("Create Application", function () {
             it("inserts a new row", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  expect(AppFormStore.getFields().containerVolumes[0])
+                  expect(AppFormStore.fields.containerVolumes[0])
                     .to.deep.equal({
                       containerPath: "/container-0",
                       hostPath: "/host-0",
@@ -948,7 +948,7 @@ describe("Create Application", function () {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
 
-                  expect(AppFormStore.getFields().containerVolumes[1])
+                  expect(AppFormStore.fields.containerVolumes[1])
                     .to.deep.equal({
                       containerPath: "/container-1",
                       hostPath: "/host-1",
@@ -967,7 +967,7 @@ describe("Create Application", function () {
             it("updates a row at index", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  let row = AppFormStore.getFields().containerVolumes[0];
+                  let row = AppFormStore.fields.containerVolumes[0];
                   expect(row.mode).to.equal("RW");
                 }, done);
               });
@@ -978,8 +978,8 @@ describe("Create Application", function () {
             it("deletes a row at index", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  let row = AppFormStore.getFields().containerVolumes[0];
-                  expect(AppFormStore.getFields().containerVolumes.length)
+                  let row = AppFormStore.fields.containerVolumes[0];
+                  expect(AppFormStore.fields.containerVolumes.length)
                     .to.equal(1);
                   expect(row).to.deep.equal({
                     containerPath: "/container-1",
@@ -1000,7 +1000,7 @@ describe("Create Application", function () {
           it("inserts a key-value pair", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.getFields().env[0]).to.deep.equal({
+                expect(AppFormStore.fields.env[0]).to.deep.equal({
                   key: "ENV_KEY_1",
                   value: "ENV_VALUE_1"
                 });
@@ -1012,7 +1012,7 @@ describe("Create Application", function () {
           it("updates a key-value pair at index", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.getFields().env[0]).to.deep.equal({
+                expect(AppFormStore.fields.env[0]).to.deep.equal({
                   key: "ENV_KEY_2",
                   value: "ENV_VALUE_1"
                 });
@@ -1028,12 +1028,12 @@ describe("Create Application", function () {
 
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.getFields().env.length).to.equal(2);
-                expect(AppFormStore.getFields().env[0]).to.deep.equal({
+                expect(AppFormStore.fields.env.length).to.equal(2);
+                expect(AppFormStore.fields.env[0]).to.deep.equal({
                   key: "ENV_KEY_3",
                   value: "ENV_VALUE_3"
                 });
-                expect(AppFormStore.getFields().env[1]).to.deep.equal({
+                expect(AppFormStore.fields.env[1]).to.deep.equal({
                   key: "ENV_KEY_2",
                   value: "ENV_VALUE_1"
                 });
@@ -1050,8 +1050,8 @@ describe("Create Application", function () {
           it("deletes a key-value pair at index", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.getFields().env.length).to.equal(1);
-                expect(AppFormStore.getFields().env[0]).to.deep.equal({
+                expect(AppFormStore.fields.env.length).to.equal(1);
+                expect(AppFormStore.fields.env[0]).to.deep.equal({
                   key: "ENV_KEY_2",
                   value: "ENV_VALUE_1"
                 });
@@ -1067,7 +1067,7 @@ describe("Create Application", function () {
           it("updates correctly", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.getFields().mem).to.equal(32);
+                expect(AppFormStore.fields.mem).to.equal(32);
               }, done);
             });
 
@@ -1079,7 +1079,7 @@ describe("Create Application", function () {
           it("updates correctly", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.getFields().instances).to.equal(2);
+                expect(AppFormStore.fields.instances).to.equal(2);
               }, done);
             });
 
@@ -1091,7 +1091,7 @@ describe("Create Application", function () {
           it("updates correctly", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.getFields().executor).to.equal("//cmd");
+                expect(AppFormStore.fields.executor).to.equal("//cmd");
               }, done);
             });
 
@@ -1103,7 +1103,7 @@ describe("Create Application", function () {
           it("updates correctly", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.getFields().ports).to.equal("23, 24, 25");
+                expect(AppFormStore.fields.ports).to.equal("23, 24, 25");
               }, done);
             });
 
@@ -1115,7 +1115,7 @@ describe("Create Application", function () {
           it("updates correctly", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.getFields().uris)
+                expect(AppFormStore.fields.uris)
                   .to.equal("abc, http://dcfe");
               }, done);
             });
@@ -1128,7 +1128,7 @@ describe("Create Application", function () {
           it("updates correctly", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.getFields().contraints).to
+                expect(AppFormStore.fields.contraints).to
                   .equal("hostname:UNIQUE, test:LIKE");
               }, done);
             });
@@ -1161,7 +1161,7 @@ describe("Create Application", function () {
 
           AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
             expectAsync(function () {
-              expect(AppFormStore.getResponseErrors().instances)
+              expect(AppFormStore.responseErrors.instances)
                 .to.equal("error.expected.jsnumber");
             }, done);
           });
@@ -1188,7 +1188,7 @@ describe("Create Application", function () {
 
           AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
             expectAsync(function () {
-              expect(AppFormStore.getResponseErrors().general)
+              expect(AppFormStore.responseErrors.general)
                 .to.equal(expectedMessage);
             }, done);
           });
@@ -1212,7 +1212,7 @@ describe("Create Application", function () {
 
           AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
             expectAsync(function () {
-              expect(AppFormStore.getResponseErrors().general)
+              expect(AppFormStore.responseErrors.general)
                 .to.equal(expectedMessage);
             }, done);
           });
@@ -1230,7 +1230,7 @@ describe("Create Application", function () {
 
           AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
             expectAsync(function () {
-              expect(AppFormStore.getResponseErrors().appId)
+              expect(AppFormStore.responseErrors.appId)
                 .to.equal("error on id attribute");
             }, done);
           });
@@ -1254,7 +1254,7 @@ describe("Create Application", function () {
 
             AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
               expectAsync(function () {
-                expect(AppFormStore.getResponseErrors().general).to.equal(
+                expect(AppFormStore.responseErrors.general).to.equal(
                   AppFormErrorMessages.getGeneralMessage("appCreation")
                 );
               }, done);
@@ -1274,7 +1274,7 @@ describe("Create Application", function () {
 
             AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
               expectAsync(function () {
-                expect(AppFormStore.getResponseErrors().general).to.equal(
+                expect(AppFormStore.responseErrors.general).to.equal(
                   AppFormErrorMessages.getGeneralMessage("unauthorizedAccess")
                 );
               }, done);
@@ -1294,7 +1294,7 @@ describe("Create Application", function () {
 
             AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
               expectAsync(function () {
-                expect(AppFormStore.getResponseErrors().general).to.equal(
+                expect(AppFormStore.responseErrors.general).to.equal(
                   AppFormErrorMessages.getGeneralMessage("errorPrefix")
                   + " something strange"
                 );
@@ -1315,7 +1315,7 @@ describe("Create Application", function () {
 
             AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
               expectAsync(function () {
-                expect(AppFormStore.getResponseErrors().general).to.equal(
+                expect(AppFormStore.responseErrors.general).to.equal(
                   AppFormErrorMessages.getGeneralMessage("forbiddenAccess")
                 );
               }, done);
@@ -1335,7 +1335,7 @@ describe("Create Application", function () {
 
             AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
               expectAsync(function () {
-                expect(AppFormStore.getResponseErrors().general).to.equal(
+                expect(AppFormStore.responseErrors.general).to.equal(
                   AppFormErrorMessages.getGeneralMessage("errorPrefix")
                   + " something strange");
               }, done);
@@ -1353,7 +1353,7 @@ describe("Create Application", function () {
         it("processes error response codes >= 500 correctly", function (done) {
           AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
             expectAsync(function () {
-              expect(AppFormStore.getResponseErrors().general).to.equal(
+              expect(AppFormStore.responseErrors.general).to.equal(
                 AppFormErrorMessages.getGeneralMessage("unknownServerError")
               );
             }, done);
@@ -1371,7 +1371,7 @@ describe("Create Application", function () {
         it("has no response errors on success", function (done) {
           AppsStore.once(AppsEvents.CHANGE, function () {
             expectAsync(function () {
-              expect(Object.keys(AppFormStore.getResponseErrors()).length)
+              expect(Object.keys(AppFormStore.responseErrors).length)
                 .to.equal(0);
             }, done);
           });

--- a/src/test/scenarios/createApplication.test.js
+++ b/src/test/scenarios/createApplication.test.js
@@ -254,7 +254,9 @@ describe("Create Application", function () {
           AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
             expectAsync(function () {
               expect(AppFormStore.responseErrors.general)
-                .to.equal(AppFormErrorMessages.getGeneralMessage("appCreation"));
+                .to.equal(
+                  AppFormErrorMessages.getGeneralMessage("appCreation")
+                );
             }, done);
           });
 
@@ -659,7 +661,7 @@ describe("Create Application", function () {
         it("updates correctly", function (done) {
           AppFormStore.once(FormEvents.CHANGE, function () {
             expectAsync(function () {
-              expect(AppFormStore.fields.appId).to.equal("/app-1");
+              expect(AppFormStore.getFields().appId).to.equal("/app-1");
             }, done);
           });
 
@@ -672,7 +674,7 @@ describe("Create Application", function () {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
 
-                expect(AppFormStore.fields.cpus).to.equal(1.1);
+                expect(AppFormStore.getFields().cpus).to.equal(1.1);
               }, done);
             });
 
@@ -684,7 +686,7 @@ describe("Create Application", function () {
           it("updates correctly", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.fields.disk).to.equal(256);
+                expect(AppFormStore.getFields().disk).to.equal(256);
               }, done);
             });
 
@@ -697,7 +699,7 @@ describe("Create Application", function () {
           it("updates correctly", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.fields.cmd).to.equal("sleep 1");
+                expect(AppFormStore.getFields().cmd).to.equal("sleep 1");
               }, done);
             });
 
@@ -711,7 +713,7 @@ describe("Create Application", function () {
             it("updates correctly", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  expect(AppFormStore.fields.dockerForcePullImage)
+                  expect(AppFormStore.getFields().dockerForcePullImage)
                     .to.equal(true);
                 }, done);
               });
@@ -724,7 +726,8 @@ describe("Create Application", function () {
             it("updates correctly", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  expect(AppFormStore.fields.dockerImage).to.equal("/image");
+                  expect(AppFormStore.getFields().dockerImage)
+                    .to.equal("/image");
                 }, done);
               });
 
@@ -736,7 +739,8 @@ describe("Create Application", function () {
             it("updates correctly", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  expect(AppFormStore.fields.dockerNetwork).to.equal("BRIDGE");
+                  expect(AppFormStore.getFields().dockerNetwork)
+                    .to.equal("BRIDGE");
                 }, done);
               });
 
@@ -748,7 +752,8 @@ describe("Create Application", function () {
             it("updates correctly", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  expect(AppFormStore.fields.dockerPrivileged).to.equal(true);
+                  expect(AppFormStore.getFields().dockerPrivileged)
+                    .to.equal(true);
                 }, done);
               });
 
@@ -761,7 +766,7 @@ describe("Create Application", function () {
             it("inserts a new row", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  expect(AppFormStore.fields.dockerPortMappings[0])
+                  expect(AppFormStore.getFields().dockerPortMappings[0])
                     .to.deep.equal({
                       containerPort: 8000,
                       hostPort: 8001,
@@ -782,7 +787,7 @@ describe("Create Application", function () {
             it("inserts another row", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  expect(AppFormStore.fields.dockerPortMappings[0])
+                  expect(AppFormStore.getFields().dockerPortMappings[0])
                     .to.deep.equal({
                       containerPort: 8000,
                       hostPort: 8001,
@@ -790,7 +795,7 @@ describe("Create Application", function () {
                       protocol: "udp"
                     });
 
-                  expect(AppFormStore.fields.dockerPortMappings[1])
+                  expect(AppFormStore.getFields().dockerPortMappings[1])
                     .to.deep.equal({
                       containerPort: 9000,
                       hostPort: 9001,
@@ -811,7 +816,7 @@ describe("Create Application", function () {
             it("updates a row at index", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  let row = AppFormStore.fields.dockerPortMappings[0];
+                  let row = AppFormStore.getFields().dockerPortMappings[0];
                   expect(row.containerPort).to.equal(9000);
                   expect(row.hostPort).to.equal(9001);
                   expect(row.servicePort).to.equal(8101);
@@ -830,8 +835,8 @@ describe("Create Application", function () {
             it("deletes a row at index", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  let row = AppFormStore.fields.dockerPortMappings[0];
-                  expect(AppFormStore.fields.dockerPortMappings.length)
+                  let row = AppFormStore.getFields().dockerPortMappings[0];
+                  expect(AppFormStore.getFields().dockerPortMappings.length)
                     .to.equal(1);
                   expect(row).to.deep.equal({
                     containerPort: 9000,
@@ -852,7 +857,7 @@ describe("Create Application", function () {
             it("inserts a new row", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  expect(AppFormStore.fields.dockerParameters[0])
+                  expect(AppFormStore.getFields().dockerParameters[0])
                     .to.deep.equal({
                       key: "DOCKER_KEY",
                       value: "DOCKER_VALUE"
@@ -870,7 +875,7 @@ describe("Create Application", function () {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
 
-                  expect(AppFormStore.fields.dockerParameters[1])
+                  expect(AppFormStore.getFields().dockerParameters[1])
                     .to.deep.equal({
                       key: "DOCKER_KEY_1",
                       value: "DOCKER_VALUE_1"
@@ -887,7 +892,7 @@ describe("Create Application", function () {
             it("updates a row at index", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  let row = AppFormStore.fields.dockerParameters[0];
+                  let row = AppFormStore.getFields().dockerParameters[0];
                   expect(row.key).to.equal("DOCKER_KEY_1A");
                   expect(row.value).to.equal("DOCKER_VALUE_1");
                 }, done);
@@ -901,8 +906,8 @@ describe("Create Application", function () {
             it("deletes a row at index", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  let row = AppFormStore.fields.dockerParameters[0];
-                  expect(AppFormStore.fields.dockerParameters.length)
+                  let row = AppFormStore.getFields().dockerParameters[0];
+                  expect(AppFormStore.getFields().dockerParameters.length)
                     .to.equal(1);
                   expect(row).to.deep.equal({
                     key: "DOCKER_KEY_1",
@@ -921,7 +926,7 @@ describe("Create Application", function () {
             it("inserts a new row", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  expect(AppFormStore.fields.containerVolumes[0])
+                  expect(AppFormStore.getFields().containerVolumes[0])
                     .to.deep.equal({
                       containerPath: "/container-0",
                       hostPath: "/host-0",
@@ -941,7 +946,7 @@ describe("Create Application", function () {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
 
-                  expect(AppFormStore.fields.containerVolumes[1])
+                  expect(AppFormStore.getFields().containerVolumes[1])
                     .to.deep.equal({
                       containerPath: "/container-1",
                       hostPath: "/host-1",
@@ -960,7 +965,7 @@ describe("Create Application", function () {
             it("updates a row at index", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  let row = AppFormStore.fields.containerVolumes[0];
+                  let row = AppFormStore.getFields().containerVolumes[0];
                   expect(row.mode).to.equal("RW");
                 }, done);
               });
@@ -971,8 +976,8 @@ describe("Create Application", function () {
             it("deletes a row at index", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
-                  let row = AppFormStore.fields.containerVolumes[0];
-                  expect(AppFormStore.fields.containerVolumes.length)
+                  let row = AppFormStore.getFields().containerVolumes[0];
+                  expect(AppFormStore.getFields().containerVolumes.length)
                     .to.equal(1);
                   expect(row).to.deep.equal({
                     containerPath: "/container-1",
@@ -993,7 +998,7 @@ describe("Create Application", function () {
           it("inserts a key-value pair", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.fields.env[0]).to.deep.equal({
+                expect(AppFormStore.getFields().env[0]).to.deep.equal({
                   key: "ENV_KEY_1",
                   value: "ENV_VALUE_1"
                 });
@@ -1005,7 +1010,7 @@ describe("Create Application", function () {
           it("updates a key-value pair at index", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.fields.env[0]).to.deep.equal({
+                expect(AppFormStore.getFields().env[0]).to.deep.equal({
                   key: "ENV_KEY_2",
                   value: "ENV_VALUE_1"
                 });
@@ -1021,12 +1026,12 @@ describe("Create Application", function () {
 
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.fields.env.length).to.equal(2);
-                expect(AppFormStore.fields.env[0]).to.deep.equal({
+                expect(AppFormStore.getFields().env.length).to.equal(2);
+                expect(AppFormStore.getFields().env[0]).to.deep.equal({
                   key: "ENV_KEY_3",
                   value: "ENV_VALUE_3"
                 });
-                expect(AppFormStore.fields.env[1]).to.deep.equal({
+                expect(AppFormStore.getFields().env[1]).to.deep.equal({
                   key: "ENV_KEY_2",
                   value: "ENV_VALUE_1"
                 });
@@ -1043,8 +1048,8 @@ describe("Create Application", function () {
           it("deletes a key-value pair at index", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.fields.env.length).to.equal(1);
-                expect(AppFormStore.fields.env[0]).to.deep.equal({
+                expect(AppFormStore.getFields().env.length).to.equal(1);
+                expect(AppFormStore.getFields().env[0]).to.deep.equal({
                   key: "ENV_KEY_2",
                   value: "ENV_VALUE_1"
                 });
@@ -1060,7 +1065,7 @@ describe("Create Application", function () {
           it("updates correctly", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.fields.mem).to.equal(32);
+                expect(AppFormStore.getFields().mem).to.equal(32);
               }, done);
             });
 
@@ -1072,7 +1077,7 @@ describe("Create Application", function () {
           it("updates correctly", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.fields.instances).to.equal(2);
+                expect(AppFormStore.getFields().instances).to.equal(2);
               }, done);
             });
 
@@ -1084,7 +1089,7 @@ describe("Create Application", function () {
           it("updates correctly", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.fields.executor).to.equal("//cmd");
+                expect(AppFormStore.getFields().executor).to.equal("//cmd");
               }, done);
             });
 
@@ -1096,7 +1101,7 @@ describe("Create Application", function () {
           it("updates correctly", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.fields.ports).to.equal("23, 24, 25");
+                expect(AppFormStore.getFields().ports).to.equal("23, 24, 25");
               }, done);
             });
 
@@ -1108,7 +1113,8 @@ describe("Create Application", function () {
           it("updates correctly", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.fields.uris).to.equal("abc, http://dcfe");
+                expect(AppFormStore.getFields().uris)
+                  .to.equal("abc, http://dcfe");
               }, done);
             });
 
@@ -1120,7 +1126,7 @@ describe("Create Application", function () {
           it("updates correctly", function (done) {
             AppFormStore.once(FormEvents.CHANGE, function () {
               expectAsync(function () {
-                expect(AppFormStore.fields.contraints).to
+                expect(AppFormStore.getFields().contraints).to
                   .equal("hostname:UNIQUE, test:LIKE");
               }, done);
             });

--- a/src/test/scenarios/createApplication.test.js
+++ b/src/test/scenarios/createApplication.test.js
@@ -5,7 +5,6 @@ import expectAsync from "./../helpers/expectAsync";
 
 import config from "../../js/config/config";
 
-import React from "../../../node_modules/react/addons";
 import FormActions from "../../js/actions/FormActions";
 import FormEvents from "../../js/events/FormEvents";
 import AppsActions from "../../js/actions/AppsActions";
@@ -373,7 +372,8 @@ describe("Create Application", function () {
       it("has no response errors on success", function (done) {
         AppsStore.once(AppsEvents.CHANGE, function () {
           expectAsync(function () {
-            expect(Object.keys(AppFormStore.getResponseErrors()).length).to.equal(0);
+            expect(Object.keys(AppFormStore.getResponseErrors()).length)
+              .to.equal(0);
           }, done);
         });
 
@@ -400,9 +400,10 @@ describe("Create Application", function () {
           function (done) {
             AppFormStore.once(FormEvents.FIELD_VALIDATION_ERROR, function () {
               expectAsync(function () {
-                expect(AppFormStore.validationErrorIndices)
+                expect(AppFormStore.getValidationErrorIndices())
                   .to.have.property("appId");
-                expect(AppFormStore.validationErrorIndices.appId).to.equal(0);
+                expect(AppFormStore.getValidationErrorIndices().appId)
+                  .to.equal(0);
               }, done);
             });
 
@@ -413,9 +414,10 @@ describe("Create Application", function () {
           function (done) {
             AppFormStore.once(FormEvents.FIELD_VALIDATION_ERROR, function () {
               expectAsync(function () {
-                expect(AppFormStore.validationErrorIndices)
+                expect(AppFormStore.getValidationErrorIndices())
                   .to.have.property("appId");
-                expect(AppFormStore.validationErrorIndices.appId).to.equal(1);
+                expect(AppFormStore.getValidationErrorIndices().appId)
+                  .to.equal(1);
               }, done);
             });
 

--- a/src/test/units/util.test.js
+++ b/src/test/units/util.test.js
@@ -214,10 +214,10 @@ describe("Util", function () {
       };
 
       expect(Util.detectObjectPaths(obj, "obj1", ["obj1.obj2"]))
-          .to.deep.equal([
-        "obj1.obj2",
-        "obj1.string2"
-      ]);
+        .to.deep.equal([
+          "obj1.obj2",
+          "obj1.string2"
+        ]);
     });
   });
 
@@ -516,6 +516,20 @@ describe("Util", function () {
       copiedObject.obj1.obj2 = null;
       expect(copiedObject).to.not.eql(originalObject);
       expect(originalObject2).to.eql(originalObject);
+    });
+
+    it("does not clone out of bounds arrays", function () {
+      var originalObject = {
+        obj1: {
+          array1: [1, 2]
+        }
+      };
+
+      var number = 83864234234;
+      originalObject.obj1.array1[number] = 3;
+
+      var copiedObject = Util.deepCopy(originalObject);
+      expect(copiedObject).to.not.eql(originalObject);
     });
   });
 });


### PR DESCRIPTION
This introduces getters for all exposed data-objects in the AppFormStore.

This closes https://github.com/mesosphere/marathon/issues/3148

These getters clone there data for better immutability, as requested here:
https://github.com/mesosphere/marathon/issues/3011

Also this closes a potentially bug:
https://github.com/mesosphere/marathon/issues/3158