### PR TITLE
Remove danger border color from default button

### DIFF
--- a/src/css/components/modal.less
+++ b/src/css/components/modal.less
@@ -158,10 +158,6 @@
       color: @modal-dialog-danger-color
     }
 
-    .modal-footer .btn-default:hover {
-      border-color: @modal-dialog-danger-color;
-    }
-
     .modal-content::before, .modal-footer .btn-success {
       background-color: @modal-dialog-danger-color;
       border-color: @modal-dialog-danger-color;


### PR DESCRIPTION
Before the cancel button border was turning red on hover. This fixes that.

![cancel](https://cloud.githubusercontent.com/assets/15963/12844772/cbd1a01c-cc01-11e5-87b8-ed4af3db4944.gif)
