### PR TITLE
Fix/3164 uncaught errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - \#3093 - Don't display "Create an Application" together with "Loading error"
 - \#2907 - Add tooltip with help links to Status and Health columns in App list
 - \#3160 - Show server-side validation errors for invalid constraints
+- \#3164 - Show server-side validation errors for invalid object
 
 ## 0.15.3 - 2016-02-03
 ### Fixed

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -295,16 +295,15 @@ function processResponseErrors(responseErrors, response, statusCode) {
       AppFormErrorMessages.getGeneralMessage("unknownServerError");
 
   } else if (statusCode === 422 && response != null &&
-      Util.isArray(response.errors)) {
-
-    response.errors.forEach((error) => {
-      var attributePath = error.attribute.length
-        ? error.attribute
+      Util.isArray(response.details)) {
+    response.details.forEach(detail => {
+      var attributePath = detail.attribute.length
+        ? detail.attribute
         : "general";
       var fieldId = resolveResponseAttributePathToFieldId(attributePath) ||
         attributePath;
       responseErrors[fieldId] =
-        AppFormErrorMessages.lookupServerResponseMessage(error.error);
+        AppFormErrorMessages.lookupServerResponseMessage(detail.error);
     });
 
   } else if (statusCode === 409 && responseHasDeployments) {
@@ -343,13 +342,13 @@ function processResponseErrors(responseErrors, response, statusCode) {
   } else if (statusCode === 400 && response != null &&
       Util.isArray(response.details)) {
 
-    response.details.forEach((detail) => {
+    response.details.forEach(detail => {
       var attributePath = detail.path.length
         ? detail.path
         : "general";
       var fieldId = resolveResponseAttributePathToFieldId(attributePath) ||
         attributePath;
-      responseErrors[fieldId] = detail.errors.map((error) => {
+      responseErrors[fieldId] = detail.errors.map(error => {
         return AppFormErrorMessages.lookupServerResponseMessage(error);
       }).join(", ");
     });

--- a/src/js/stores/validators/AppFormValidators.js
+++ b/src/js/stores/validators/AppFormValidators.js
@@ -26,7 +26,7 @@ const AppFormValidators = {
 
   appIdNoWhitespaces: (str) => str.match(/ /g) == null,
 
-  appIdValidChars: (str) => str.match(/[^a-z0-9\-_\.\/]/g) == null,
+  appIdValidChars: (str) => str.match(/[^a-z0-9\-\.\/]/g) == null,
 
   appIdWellFormedPath: (str) => {
     // This RegExp is taken from the ID field explanation described here:

--- a/src/test/scenarios/createApplication.test.js
+++ b/src/test/scenarios/createApplication.test.js
@@ -115,7 +115,7 @@ describe("Create Application", function () {
         nock(config.apiURL)
           .post("/v2/apps")
           .reply(422, {
-            errors: [
+            details: [
               {
                 attribute: "id",
                 error: "attribute has invalid value"
@@ -125,8 +125,8 @@ describe("Create Application", function () {
 
         AppsStore.once(AppsEvents.CREATE_APP_ERROR, function (error) {
           expectAsync(function () {
-            expect(error.errors[0].attribute).to.equal("id");
-            expect(error.errors[0].error)
+            expect(error.details[0].attribute).to.equal("id");
+            expect(error.details[0].error)
               .to.equal("attribute has invalid value");
           }, done);
         });
@@ -237,7 +237,7 @@ describe("Create Application", function () {
         nock(config.apiURL)
           .post("/v2/apps")
           .reply(422, {
-            "errors": [{
+            "details": [{
               "attribute": "id",
               "error": "error on id attribute"
             }]
@@ -1231,7 +1231,7 @@ describe("Create Application", function () {
           nock(config.apiURL)
             .post("/v2/apps")
             .reply(422, {
-              "errors": [{
+              "details": [{
                 "attribute": "id",
                 "error": "error on id attribute"
               }]

--- a/src/test/units/AppFormValidators.test.js
+++ b/src/test/units/AppFormValidators.test.js
@@ -31,12 +31,13 @@ describe("App Form Validators", function () {
       });
 
       it("has no illegal characters", function () {
-        expect(this.validatior.appIdValidChars("./app-1_b")).to.be.true;
+        expect(this.validatior.appIdValidChars("./app-1.b")).to.be.true;
       });
 
       it("has illegal characters", function () {
         expect(this.validatior.appIdValidChars("Uppercase")).to.be.false;
         expect(this.validatior.appIdValidChars("app#1")).to.be.false;
+        expect(this.validatior.appIdValidChars("app_1")).to.be.false;
         expect(this.validatior.appIdValidChars("+1")).to.be.false;
       });
 


### PR DESCRIPTION
This fixes https://github.com/mesosphere/marathon/issues/3164
The changes introduced in https://github.com/mesosphere/marathon/pull/2975/files#diff-7bb478205fd47f472265c276e29b7cfaR227 broke our `422` error parsing scripts.

Additionally, it removes the `_` from the list of allowed chars in the `id` validation rules. 

**PLEASE NOTE** This should most likely be part of 0.15.4