### PR TITLE
Refactor - 3011 QueueStore getter and usage of accessor descriptor

### DIFF
--- a/src/js/helpers/Util.js
+++ b/src/js/helpers/Util.js
@@ -5,6 +5,22 @@ var consecutiveNumber = 0;
 // method can't be *call*ed on different objects in IE.
 var toString = Object.prototype.toString;
 
+function assignWithAccessors(target, ...sources) {
+  sources.forEach(source => {
+    Object.keys(source).forEach(key => {
+      let descriptor = Object.getOwnPropertyDescriptor(source, key);
+      if (descriptor.get == null && descriptor.set == null) {
+        descriptor.writable = true;
+      }
+      descriptor.configurable = true;
+      descriptor.enumerable = true;
+
+      Object.defineProperty(target, key, descriptor);
+    });
+  });
+  return target;
+}
+
 var Util = {
   initKeyValue: function (obj, key, value) {
     if (obj[key] === undefined) {
@@ -35,7 +51,7 @@ var Util = {
   },
   noop: function () {},
   extendObject: function (...sources) {
-    return Object.assign({}, ...sources);
+    return assignWithAccessors({}, ...sources);
   },
   getUniqueId: function () {
     return (++consecutiveNumber).toString() + (new Date()).getTime();

--- a/src/js/stores/QueueStore.js
+++ b/src/js/stores/QueueStore.js
@@ -6,6 +6,10 @@ import queueScheme from "./schemes/queueScheme";
 
 import Util from "../helpers/Util";
 
+const storeData = {
+  queue: []
+};
+
 function processQueue(queue = []) {
   return queue.map(function (entry) {
     return Util.extendObject(queueScheme, entry);
@@ -13,12 +17,14 @@ function processQueue(queue = []) {
 }
 
 var QueueStore = Util.extendObject(EventEmitter.prototype, {
-  queue: [],
+  get queue() {
+    return Util.deepCopy(storeData.queue);
+  },
 
   getDelayByAppId: function (appId) {
     var timeLeftSeconds = 0;
 
-    var queueEntry = this.queue.find(function (entry) {
+    var queueEntry = storeData.queue.find(function (entry) {
       return entry.app.id === appId && entry.delay != null;
     });
 
@@ -33,7 +39,7 @@ var QueueStore = Util.extendObject(EventEmitter.prototype, {
 AppDispatcher.register(function (action) {
   switch (action.actionType) {
     case QueueEvents.REQUEST:
-      QueueStore.queue = processQueue(action.data.body.queue);
+      storeData.queue = processQueue(action.data.body.queue);
       QueueStore.emit(QueueEvents.CHANGE);
       break;
     case QueueEvents.REQUEST_ERROR:

--- a/src/test/units/util.test.js
+++ b/src/test/units/util.test.js
@@ -41,6 +41,21 @@ describe("Util", function () {
       var result = Util.extendObject(["foo", "bar"], ["faz"]);
       expect(result).to.deep.equal(expectedResult);
     });
+
+    it("treats accessors", function () {
+      var counter = 0;
+
+      var obj = {
+        get count() {
+          return ++counter;
+        }
+      };
+
+      var newObj = Util.extendObject({}, obj);
+
+      expect(newObj.count).to.equal(1);
+      expect(newObj.count).to.equal(2);
+    });
   });
 
   describe("initKeyValue", function () {


### PR DESCRIPTION
This applies a read-only getter descriptior for `queue`at the QueueStore and internalises the storage.

The data is still accessible via `QueueStore.queue` like before, which is very sexy imho, nothing to adjust in the components.

The tests are improved now, to handle the read-only behavior correctly.
They were really flaky before.

`Util.extendObject` is modified to handle accessors correctly.
