### PR TITLE
Refactor - 3011 Getter for DeploymentStore

### DIFF
--- a/src/js/stores/DeploymentStore.js
+++ b/src/js/stores/DeploymentStore.js
@@ -6,6 +6,10 @@ import deploymentScheme from "./schemes/deploymentScheme";
 
 import Util from "../helpers/Util";
 
+const storeData = {
+  deployments: []
+};
+
 function processDeployments(deployments) {
   return deployments.map(function (deployment) {
     deployment = Util.extendObject(deploymentScheme, deployment);
@@ -22,13 +26,15 @@ function removeDeployment(deployments, deploymentId) {
 }
 
 var DeploymentStore = Util.extendObject(EventEmitter.prototype, {
-  deployments: []
+  get deployments() {
+    return Util.deepCopy(storeData.deployments);
+  }
 });
 
 AppDispatcher.register(function (action) {
   switch (action.actionType) {
     case DeploymentEvents.REQUEST:
-      DeploymentStore.deployments = processDeployments(action.data.body);
+      storeData.deployments = processDeployments(action.data.body);
       DeploymentStore.emit(DeploymentEvents.CHANGE);
       break;
     case DeploymentEvents.REQUEST_ERROR:
@@ -39,8 +45,8 @@ AppDispatcher.register(function (action) {
       );
       break;
     case DeploymentEvents.REVERT:
-      DeploymentStore.deployments =
-        removeDeployment(DeploymentStore.deployments, action.deploymentId);
+      storeData.deployments =
+        removeDeployment(storeData.deployments, action.deploymentId);
       DeploymentStore.emit(DeploymentEvents.CHANGE);
       break;
     case DeploymentEvents.REVERT_ERROR:
@@ -51,8 +57,8 @@ AppDispatcher.register(function (action) {
       );
       break;
     case DeploymentEvents.STOP:
-      DeploymentStore.deployments =
-        removeDeployment(DeploymentStore.deployments, action.deploymentId);
+      storeData.deployments =
+        removeDeployment(storeData.deployments, action.deploymentId);
       DeploymentStore.emit(DeploymentEvents.CHANGE);
       break;
     case DeploymentEvents.STOP_ERROR:

--- a/src/js/stores/DeploymentStore.js
+++ b/src/js/stores/DeploymentStore.js
@@ -1,30 +1,29 @@
 import {EventEmitter} from "events";
-import lazy from "lazy.js";
 
 import AppDispatcher from "../AppDispatcher";
 import DeploymentEvents from "../events/DeploymentEvents";
 import deploymentScheme from "./schemes/deploymentScheme";
 
+import Util from "../helpers/Util";
+
 function processDeployments(deployments) {
-  return lazy(deployments).map(function (deployment) {
-    deployment = lazy(deploymentScheme).extend(deployment).value();
+  return deployments.map(function (deployment) {
+    deployment = Util.extendObject(deploymentScheme, deployment);
 
     deployment.affectedAppsString = deployment.affectedApps.join(", ");
     deployment.currentActionsString = deployment.currentActions.join(", ");
 
     return deployment;
-  }).value();
+  });
 }
 
 function removeDeployment(deployments, deploymentId) {
-  return lazy(deployments).reject({
-    id: deploymentId
-  }).value();
+  return deployments.filter(deployment => deployment.id !== deploymentId);
 }
 
-var DeploymentStore = lazy(EventEmitter.prototype).extend({
+var DeploymentStore = Util.extendObject(EventEmitter.prototype, {
   deployments: []
-}).value();
+});
 
 AppDispatcher.register(function (action) {
   switch (action.actionType) {

--- a/src/js/stores/DialogStore.js
+++ b/src/js/stores/DialogStore.js
@@ -1,9 +1,9 @@
 import {EventEmitter} from "events";
-import lazy from "lazy.js";
-import Util from "../helpers/Util";
 
 import AppDispatcher from "../AppDispatcher";
 import DialogEvents from "../events/DialogEvents";
+
+import Util from "../helpers/Util";
 
 var dialogs = [];
 
@@ -22,7 +22,7 @@ function removeDialog(dialog) {
   });
 }
 
-var DialogStore = lazy(EventEmitter.prototype).extend({
+var DialogStore = Util.extendObject(EventEmitter.prototype, {
   handleUserResponse: function (dialogId,
     acceptCallback,
     dismissCallback = Util.noop
@@ -50,7 +50,7 @@ var DialogStore = lazy(EventEmitter.prototype).extend({
     DialogStore.on(DialogEvents.ACCEPT_DIALOG, onAccept);
     DialogStore.on(DialogEvents.DISMISS_DIALOG, onDismiss);
   }
-}).value();
+});
 
 AppDispatcher.register(function (action) {
   switch (action.actionType) {

--- a/src/test/units/NavTabsComponent.test.js
+++ b/src/test/units/NavTabsComponent.test.js
@@ -1,15 +1,18 @@
 import {expect} from "chai";
 import {shallow} from "enzyme";
-
 import React from "react/addons";
+
+import AppDispatcher from "../../js/AppDispatcher";
 import NavTabsComponent from "../../js/components/NavTabsComponent";
+import DeploymentEvents from "../../js/events/DeploymentEvents";
 import DeploymentStore from "../../js/stores/DeploymentStore";
+
 import tabs from "../../js/constants/tabs";
 
 describe("Deployments navigation badge", function () {
 
   before(function () {
-    DeploymentStore.deployments = [
+    var deployments = [
       {id: "deployment-1"},
       {id: "deployment-2"}
     ];
@@ -19,7 +22,14 @@ describe("Deployments navigation badge", function () {
       tabs: tabs
     };
 
-    this.component = shallow(<NavTabsComponent {...props} />);
+    DeploymentStore.once(DeploymentEvents.CHANGE, () => {
+      this.component = shallow(<NavTabsComponent {...props} />);
+    });
+
+    AppDispatcher.dispatch({
+      actionType: DeploymentEvents.REQUEST,
+      data: {body: deployments}
+    });
   });
 
   after(function () {


### PR DESCRIPTION
This is the last PR that refactors the stores to only have read-only getters and internalise it's data.
Every object got from a store will be deepCopied/cloned, so a change on the data outside of the store, doesn't affect the store itself.

This closes https://github.com/mesosphere/marathon/issues/3011