### PR TITLE
Fixing #3174, #3133, #3127

### DIFF
--- a/src/css/components/app-list.less
+++ b/src/css/components/app-list.less
@@ -24,7 +24,7 @@
     }
 
     &.status-col {
-      width: @base-spacing-unit*13;
+      width: @base-spacing-unit*14;
     }
 
     &.instances-col {

--- a/src/css/components/help-menu.less
+++ b/src/css/components/help-menu.less
@@ -10,6 +10,7 @@
   background-position: center left;
   line-height: 1;
   opacity: .4;
+  white-space: nowrap;
 
   .caret {
     margin-left: @horizontal-spacing-unit;

--- a/src/js/components/AppHealthBarComponent.jsx
+++ b/src/js/components/AppHealthBarComponent.jsx
@@ -31,7 +31,7 @@ var AppHealthBarComponent = React.createClass({
 
     let allZeroWidthBefore = true;
     return health.map(function (d, i) {
-      var width = roundWorkaround(d.quantity * 100 / dataSum);
+      var width = (dataSum == 0) ? 0 : roundWorkaround(d.quantity * 100 / dataSum);
       var classSet = {
         // set health-bar-inner class for bars in the stack which have a
         // non-zero-width left neightbar

--- a/src/js/components/AppHealthBarComponent.jsx
+++ b/src/js/components/AppHealthBarComponent.jsx
@@ -31,7 +31,8 @@ var AppHealthBarComponent = React.createClass({
 
     let allZeroWidthBefore = true;
     return health.map(function (d, i) {
-      var width = (dataSum == 0) ? 0 : roundWorkaround(d.quantity * 100 / dataSum);
+      var width = (dataSum === 0) ? 0 : // Make sure we don't get NaN
+                  roundWorkaround(d.quantity * 100 / dataSum);
       var classSet = {
         // set health-bar-inner class for bars in the stack which have a
         // non-zero-width left neightbar

--- a/src/js/components/AppHealthBarComponent.jsx
+++ b/src/js/components/AppHealthBarComponent.jsx
@@ -31,8 +31,9 @@ var AppHealthBarComponent = React.createClass({
 
     let allZeroWidthBefore = true;
     return health.map(function (d, i) {
-      var width = (dataSum === 0) ? 0 : // Make sure we don't get NaN
-                  roundWorkaround(d.quantity * 100 / dataSum);
+      var width = (dataSum === 0)
+        ? 0  // Make sure we don't divide by zero
+        : roundWorkaround(d.quantity * 100 / dataSum);
       var classSet = {
         // set health-bar-inner class for bars in the stack which have a
         // non-zero-width left neightbar

--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -14,6 +14,7 @@ import States from "../constants/States";
 import AppListItemComponent from "./AppListItemComponent";
 import CenteredInlineDialogComponent from "./CenteredInlineDialogComponent";
 import TooltipComponent from "../components/TooltipComponent";
+import PathUtil from "../helpers/PathUtil";
 
 import AppsActions from "../actions/AppsActions";
 import AppsStore from "../stores/AppsStore";
@@ -100,7 +101,14 @@ function sortByKeyWithGroups( sortKey, sortDirection, a, b ) {
   } else if (b.isGroup && !a.isGroup) {
     return 1;
   } else {
-    return a[sortKey] > b[sortKey]
+    let valA = a[sortKey];
+    let valB = b[sortKey];
+    // Get last app name when sorting by ID
+    if (sortKey === "id") {
+      valA = PathUtil.getAppName(valA);
+      valB = PathUtil.getAppName(valB);
+    }
+    return valA > valB
       ? -1 * sortDirection
       : 1 * sortDirection;
   }
@@ -218,8 +226,10 @@ var AppListComponent = React.createClass({
       nodesSequence = nodesSequence
         .filter(app => {
           var pathParts = app.id.substr(1).split("/");
-          var appID = pathParts.pop();
           var curPath = "";
+
+          // Skip last item
+          pathParts.pop();
 
           // Append found groups in the list
           pathParts.forEach(part => {
@@ -240,8 +250,7 @@ var AppListComponent = React.createClass({
           });
 
           // Filter item
-          if (score(appID, filterText) > FUZZY_COMPARISON_SCORE)
-            return true;
+          return (score(app.id, filterText) > FUZZY_COMPARISON_SCORE);
         });
 
       // Apend the group nodes

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -9,6 +9,7 @@ import AppListItemLabelsComponent
   from "../components/AppListItemLabelsComponent";
 import AppListViewTypes from "../constants/AppListViewTypes";
 import AppStatus from "../constants/AppStatus";
+import FilterTypes from "../constants/FilterTypes";
 import AppStatusComponent from "../components/AppStatusComponent";
 import BreadcrumbComponent from "../components/BreadcrumbComponent";
 import Util from "../helpers/Util";
@@ -124,6 +125,10 @@ var AppListItemComponent = React.createClass({
       let param = {
         groupId: encodeURIComponent(model.id)
       };
+      if (query[FilterTypes.TEXT] !== undefined) {
+        delete query[FilterTypes.TEXT];
+      }
+      console.log(query);
       router.transitionTo("group", param, query);
     } else {
       router.transitionTo("app", {appId: encodeURIComponent(model.id)});

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -128,7 +128,6 @@ var AppListItemComponent = React.createClass({
       if (query[FilterTypes.TEXT] !== undefined) {
         delete query[FilterTypes.TEXT];
       }
-      console.log(query);
       router.transitionTo("group", param, query);
     } else {
       router.transitionTo("app", {appId: encodeURIComponent(model.id)});

--- a/src/test/units/AppListComponent.test.js
+++ b/src/test/units/AppListComponent.test.js
@@ -213,16 +213,20 @@ describe("AppListComponent", function () {
         .map(app => app.props().model.id);
 
       expect(appNames).to.deep.equal([
+        // Groups
+        "/fuzzy/apps",
+        "/apps",
+        // Applications
+        "/group-alpha/app-1",
+        "/group-alpha/app-2",
+        "/group-alpha/group-beta/app-3",
+        "/app-alpha",
         "/app-beta",
         "/app-exact",
-        "/app-alpha",
-        "/group-alpha/app-2",
-        "/group-alpha/app-1",
-        "/group-alpha/group-beta/app-3",
-        "/apps/sleep",
-        "/fuzzy/apps/sleepz",
         "/group-with-long-name/group-with-long-name-/group-with-long-name/" +
-          "group-with-long-name/group-with-long-name/app-omega"
+          "group-with-long-name/group-with-long-name/app-omega",
+        "/apps/sleep",
+        "/fuzzy/apps/sleepz"
       ]);
       this.component.instance().componentWillUnmount();
     });


### PR DESCRIPTION
Resolve mesosphere/marathon#3174:
- It looks that help icon overflows due to page break on firefox. Enforcing non-breaking. 
- Smaller status icon caused by the text `<span>` compressing the `<i>` when text too long. Decided to increase the column width.

Resolve mesosphere/marathon#3133 :
- Caused by division by zero, producing NaN width

Resolve mesosphere/marathon#3127 :
- Add: Performing fuzzy match also on group names
- Fix: Removing query parameters when clicking on a group
AppListItemComponent
- Fix: Moving lazy() dependencies outside the filterNodes() function