### PR TITLE
Fixes issues 3174 & 3133

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - \#3124 - Improve usability of labels filter dropdown
 
 ### Fixed
+- \#3174 - Header and suspend icon have size problem
+- \#3133 - Interrupted scaling operations can leave the health bar in an
+  incorrect state
 - \#3093 - Don't display "Create an Application" together with "Loading error"
 - \#2907 - Add tooltip with help links to Status and Health columns in App list
 - \#3160 - Show server-side validation errors for invalid constraints

--- a/src/css/components/app-list.less
+++ b/src/css/components/app-list.less
@@ -24,7 +24,7 @@
     }
 
     &.status-col {
-      width: @base-spacing-unit*13;
+      width: @base-spacing-unit*14;
     }
 
     &.instances-col {

--- a/src/css/components/help-menu.less
+++ b/src/css/components/help-menu.less
@@ -10,6 +10,7 @@
   background-position: center left;
   line-height: 1;
   opacity: .4;
+  white-space: nowrap;
 
   .caret {
     margin-left: @horizontal-spacing-unit;

--- a/src/js/components/AppHealthBarComponent.jsx
+++ b/src/js/components/AppHealthBarComponent.jsx
@@ -31,7 +31,9 @@ var AppHealthBarComponent = React.createClass({
 
     let allZeroWidthBefore = true;
     return health.map(function (d, i) {
-      var width = (dataSum == 0) ? 0 : roundWorkaround(d.quantity * 100 / dataSum);
+      var width = (dataSum === 0)
+        ? 0  // Make sure we don't divide by zero
+        : roundWorkaround(d.quantity * 100 / dataSum);
       var classSet = {
         // set health-bar-inner class for bars in the stack which have a
         // non-zero-width left neightbar

--- a/src/js/components/AppHealthBarComponent.jsx
+++ b/src/js/components/AppHealthBarComponent.jsx
@@ -31,7 +31,7 @@ var AppHealthBarComponent = React.createClass({
 
     let allZeroWidthBefore = true;
     return health.map(function (d, i) {
-      var width = roundWorkaround(d.quantity * 100 / dataSum);
+      var width = (dataSum == 0) ? 0 : roundWorkaround(d.quantity * 100 / dataSum);
       var classSet = {
         // set health-bar-inner class for bars in the stack which have a
         // non-zero-width left neightbar


### PR DESCRIPTION
Resolve mesosphere/marathon#3174:
- It looks that help icon overflows due to page break on firefox. Enforcing non-breaking. 
- Smaller status icon caused by the text `<span>` compressing the `<i>` when text too long. Decided to increase the column width.

Resolve mesosphere/marathon#3133 :
- Caused by division by zero, producing NaN width