### PR TITLE
Make date format consistent

### DIFF
--- a/src/js/components/AppDebugInfoComponent.jsx
+++ b/src/js/components/AppDebugInfoComponent.jsx
@@ -80,11 +80,13 @@ var AppDebugInfoComponent = React.createClass({
         {invalidateValue(lastTaskFailure.host)}
         <dt>Timestamp</dt>
         <dd>
-          <span>{timestamp}</span> ({timeStampText})
+          <span>{new Date(timestamp).toLocaleString()}</span> ({timeStampText})
         </dd>
         <dt>Version</dt>
         <dd>
-          <span>{version}</span> ({new Moment(version).fromNow()})
+          <span>
+            {new Date(version).toLocaleString()}
+          </span> ({new Moment(version).fromNow()})
         </dd>
         <dt>Mesos Details</dt>
         <dd><TaskMesosUrlComponent task={lastTaskFailure}/></dd>
@@ -113,7 +115,11 @@ var AppDebugInfoComponent = React.createClass({
     );
 
     if (lastScalingAt !== lastConfigChangeAt) {
-      let lastScalingTimestamp = <span>{lastScalingAt}</span>;
+      let lastScalingTimestamp = (
+        <span>
+          {new Date(lastScalingAt).toLocaleString()}
+        </span>
+      );
       lastScaling = (
         <dd>
           {lastScalingTimestamp} ({new Moment(lastScalingAt).fromNow()})
@@ -121,7 +127,11 @@ var AppDebugInfoComponent = React.createClass({
       );
     }
 
-    var lastConfigTimestamp = <span>{lastConfigChangeAt}</span>;
+    var lastConfigTimestamp = (
+      <span>
+        {new Date(lastConfigChangeAt).toLocaleString()}
+      </span>
+    );
     var lastConfig = (
       <dd>
         {lastConfigTimestamp} ({new Moment(lastConfigChangeAt).fromNow()})

--- a/src/js/components/AppVersionComponent.jsx
+++ b/src/js/components/AppVersionComponent.jsx
@@ -274,7 +274,7 @@ var AppVersionComponent = React.createClass({
           <dt>User</dt>
           {invalidateValue(appVersion.user)}
           <dt>Version</dt>
-          {invalidateValue(appVersion.version)}
+          {invalidateValue(new Date(appVersion.version).toLocaleString())}
         </dl>
       </div>
     );

--- a/src/test/units/AppDebugInfoComponent.test.js
+++ b/src/test/units/AppDebugInfoComponent.test.js
@@ -82,8 +82,8 @@ describe("App debug info component", function () {
           expect(state).to.equal("TASK_LOST");
           expect(message).to.equal("Slave slave1.dcos.io removed");
           expect(host).to.equal("slave1.dcos.io");
-          expect(timestamp).to.equal("2015-08-05T09:08:56.349Z");
-          expect(version).to.equal("2015-07-06T12:37:28.774Z");
+          expect(timestamp).to.equal(new Date("2015-08-05T09:08:56.349Z").toLocaleString());
+          expect(version).to.equal(new Date("2015-07-06T12:37:28.774Z").toLocaleString());
         }, done);
       });
 
@@ -200,7 +200,7 @@ describe("App debug info component", function () {
         .at(1)
         .find("span")
         .text();
-      expect(message).to.equal("2015-08-11T13:57:11.238Z");
+      expect(message).to.equal(new Date("2015-08-11T13:57:11.238Z").toLocaleString());
     });
 
   });

--- a/src/test/units/AppVersionComponent.test.js
+++ b/src/test/units/AppVersionComponent.test.js
@@ -170,7 +170,7 @@ describe("AppVersionComponent", function () {
 
   it("has correct version", function () {
     expect(this.rows.at(43).props().children[0])
-      .to.equal("2015-06-29T12:57:02.269Z");
+      .to.equal(new Date("2015-06-29T12:57:02.269Z").toLocaleString());
   });
 
 });


### PR DESCRIPTION
Right now dates are presented in two formats `2015-06-29T12:57:02.269Z` or ` 2/10/2016, 1:09:17 AM`. I've got request form @adamdubiel that current format is misleading, there are two dates which on first sight looks different but in fact only difference is formatting. I think date format should be consistent in whole UI. 