### PR TITLE
Remove unnecessary CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 - \#3124 - Improve usability of labels filter dropdown
 
 ### Fixed
-- \#3174 - Header and suspend icon have size problem
 - \#3133 - Interrupted scaling operations can leave the health bar in an
   incorrect state
 - \#3093 - Don't display "Create an Application" together with "Loading error"


### PR DESCRIPTION
As the fix added in https://github.com/mesosphere/marathon-ui/pull/625 was actually introduced in recent master changes, I don't see the need for a changelog entry. Feel free to close this if I'm wrong.