### PR TITLE
Fix duplicable lines validation

### DIFF
--- a/src/js/helpers/Util.js
+++ b/src/js/helpers/Util.js
@@ -105,8 +105,8 @@ var Util = {
     } else if (this.isArray(obj)) {
       copy = obj.slice(); // shallow copy
 
-      copy.forEach((value, index) => {
-        copy[index] = this.deepCopy(value);
+      Object.keys(copy).forEach((key) => {
+        copy[key] = this.deepCopy(copy[key]);
       });
     } else {
       copy = obj;

--- a/src/js/mixins/DuplicableRowsMixin.jsx
+++ b/src/js/mixins/DuplicableRowsMixin.jsx
@@ -40,7 +40,7 @@ var DuplicableRowsMixin = {
     Object.keys(duplicableRowsScheme).forEach(function (fieldId) {
       if (state.rows[fieldId] == null || state.rows[fieldId].length === 0) {
         let rowScheme = Util.extendObject(duplicableRowsScheme[fieldId], {
-          consecutiveKey: Util.getUniqueId()
+          consecutiveKey: parseInt((Util.getUniqueId() + "").slice(-9))
         });
         FormActions.insert(fieldId, rowScheme);
       }

--- a/src/test/units/util.test.js
+++ b/src/test/units/util.test.js
@@ -531,5 +531,62 @@ describe("Util", function () {
       var copiedObject = Util.deepCopy(originalObject);
       expect(copiedObject).to.not.eql(originalObject);
     });
+
+    it("does clone an array with normal indices", () => {
+      var originalObject = {
+        array: []
+      };
+      originalObject.array[0] = "test";
+
+      var expectedObject = {
+        array: []
+      };
+      expectedObject.array[0] = "test";
+
+      expect(Util.deepCopy(originalObject)).to.deep.equal(expectedObject);
+    });
+
+    it("does clone an array with unusual small indices", () => {
+      var originalObject = {
+        array: []
+      };
+      originalObject.array[2] = "test";
+
+      var expectedObject = {
+        array: []
+      };
+      expectedObject.array[2] = "test";
+
+      expect(Util.deepCopy(originalObject)).to.deep.equal(expectedObject);
+    });
+
+    it("does clone an array with with in max range indices", () => {
+      var originalObject = {
+        array: []
+      };
+      originalObject.array[1145529089] = "test";
+
+      var expectedObject = {
+        array: []
+      };
+      expectedObject.array[1145529089] = "test";
+
+      expect(Util.deepCopy(originalObject)).to.deep.equal(expectedObject);
+    });
+
+    // IF this test fails change remove the not if that works we are good.
+    it("does clone an array with unusual indices", () => {
+      var originalObject = {
+        array: []
+      };
+      originalObject.array[11455290885778] = "test";
+
+      var expectedObject = {
+        array: []
+      };
+      expectedObject.array[11455290885778] = "test";
+
+      expect(Util.deepCopy(originalObject)).to.not.deep.equal(expectedObject);
+    });
   });
 });


### PR DESCRIPTION
Fix the validation of duplicable lines.

Problem with that was that if an array had a very high key it is excluded from for each basically every number above  2^32-1 which is `4,294,967,295` this is lower then the usual consecutive keys. And the get excluded with the deepCopy.