### PR TITLE
Show generic validation errors in the App create modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - \#3160 - Show server-side validation errors for invalid constraints
 - \#3164 - Show server-side validation errors for invalid object
 - \#3102 - Updating environment variables sometimes deletes entries
+- \#3242 - Treat "value" attribute in server-side validation errors as general
+  error
 
 ## 0.15.3 - 2016-02-03
 ### Fixed

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -173,7 +173,8 @@ const responseAttributePathToFieldIdMap = {
   "/labels": "labels",
   "/ports": "ports",
   "/uris": "uris",
-  "/user": "user"
+  "/user": "user",
+  "value": "general"
 };
 
 /**

--- a/src/test/scenarios/createApplication.test.js
+++ b/src/test/scenarios/createApplication.test.js
@@ -110,31 +110,6 @@ describe("Create Application", function () {
         });
       });
 
-      it("handles atttribute value error", function (done) {
-        nock(config.apiURL)
-          .post("/v2/apps")
-          .reply(422, {
-            details: [
-              {
-                attribute: "id",
-                error: "attribute has invalid value"
-              }
-            ]
-          });
-
-        AppsStore.once(AppsEvents.CREATE_APP_ERROR, function (error) {
-          expectAsync(function () {
-            expect(error.details[0].attribute).to.equal("id");
-            expect(error.details[0].error)
-              .to.equal("attribute has invalid value");
-          }, done);
-        });
-
-        AppsActions.createApp({
-          id: "app 1"
-        });
-      });
-
       it("handles unauthorized errors gracefully", function (done) {
         nock(config.apiURL)
           .post("/v2/apps")

--- a/src/test/scenarios/createApplication.test.js
+++ b/src/test/scenarios/createApplication.test.js
@@ -203,8 +203,9 @@ describe("Create Application", function () {
 
         AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
           expectAsync(function () {
-            expect(AppFormStore.responseErrors.appId)
-              .to.equal("error on id attribute");
+            expect(AppFormStore.responseErrors.general)
+              .to.equal("Groups and Applications may not have the same " +
+                "identifier: /sleep");
           }, done);
         });
 
@@ -212,13 +213,14 @@ describe("Create Application", function () {
           .post("/v2/apps")
           .reply(422, {
             "details": [{
-              "attribute": "id",
-              "error": "error on id attribute"
+              "attribute": "value",
+              "error": "Groups and Applications may not have the same " +
+                "identifier: /sleep"
             }]
           });
 
         AppsActions.createApp({
-          id: "bad id"
+          id: "sleep/my-app"
         });
       });
 


### PR DESCRIPTION
This fixes https://github.com/mesosphere/marathon/issues/3242 

The API seems to have started returning an `attribute` with value `"value"` for `422` errors that went unnoticed until now. This PR addresses this issue.

To reproduce: 
1) try to create an app whose `id` shares the path with an existing app, for example `sleep/new-app` given an existing `sleep` app.
2) the creation fails with no visible errors.

Result:

![screen shot 2016-02-15 at 14 30 52](https://cloud.githubusercontent.com/assets/1078545/13050002/e2c9082c-d3f0-11e5-9075-71e9d1e989a7.png)

