### PR TITLE
Feature 3155 - add local volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - \#3082 - Make URLs in form validation error messages clickable
 - \#3076 - Highlight sorted columns in the UI
 - \#2049 - Added JSON editor to application modal
+- \#3155 - Add support for Local Volumes in Create/Edit modal
 
 ### Changed
 - \#3078 - Always show download button for logs

--- a/src/js/components/AppConfigEditFormComponent.jsx
+++ b/src/js/components/AppConfigEditFormComponent.jsx
@@ -17,6 +17,8 @@ import OptionalEnvironmentComponent
 import OptionalLabelsComponent from "../components/OptionalLabelsComponent";
 import OptionalSettingsComponent
   from "../components/OptionalSettingsComponent";
+import OptionalVolumesComponent
+  from "../components/OptionalVolumesComponent";
 import FormGroupComponent from "../components/FormGroupComponent";
 
 var AppConfigEditFormComponent = React.createClass({
@@ -248,6 +250,16 @@ var AppConfigEditFormComponent = React.createClass({
               errorIndices={state.errorIndices}
               fields={state.fields}
               getErrorMessage={this.getErrorMessage}/>
+          </CollapsiblePanelComponent>
+        </div>
+        <div className="row full-bleed">
+          <CollapsiblePanelComponent
+            isOpen={this.fieldsHaveError({volumes: "volumes"})}
+            title="Volumes">
+            <OptionalVolumesComponent
+              errorIndices={state.errorIndices}
+              getErrorMessage={this.getErrorMessage}
+              fields={state.fields} />
           </CollapsiblePanelComponent>
         </div>
         <div className="row full-bleed">

--- a/src/js/components/AppConfigEditFormComponent.jsx
+++ b/src/js/components/AppConfigEditFormComponent.jsx
@@ -254,8 +254,8 @@ var AppConfigEditFormComponent = React.createClass({
         </div>
         <div className="row full-bleed">
           <CollapsiblePanelComponent
-            isOpen={this.fieldsHaveError({volumes: "volumes"})}
-            title="Volumes">
+              isOpen={this.fieldsHaveError({volumes: "volumes"})}
+              title="Volumes">
             <OptionalVolumesComponent
               errorIndices={state.errorIndices}
               getErrorMessage={this.getErrorMessage}

--- a/src/js/components/OptionalVolumesComponent.jsx
+++ b/src/js/components/OptionalVolumesComponent.jsx
@@ -11,9 +11,9 @@ var OptionalVolumesComponent = React.createClass({
   mixins: [DuplicableRowsMixin],
 
   duplicableRowsScheme: {
-    volumes: {
-      size: "",
-      path: ""
+    containerVolumesLocal: {
+      persistentSize: "",
+      containerPath: ""
     }
   },
 
@@ -21,22 +21,22 @@ var OptionalVolumesComponent = React.createClass({
     event.target.blur();
     event.preventDefault();
 
-    this.addRow("volumes", position);
+    this.addRow("containerVolumesLocal", position);
   },
 
   handleRemoveRow: function (position, event) {
     event.target.blur();
     event.preventDefault();
 
-    this.removeRow("volumes", position);
+    this.removeRow("containerVolumesLocal", position);
   },
 
   handleChange: function (position) {
-    this.updateRow("volumes", position);
+    this.updateRow("containerVolumesLocal", position);
   },
 
   getVolumeRow: function (row, i, disableRemoveButton = false) {
-    var error = this.getError("volumes", row.consecutiveKey);
+    var error = this.getError("containerVolumesLocal", row.consecutiveKey);
     // var handleChange = this.handleChangeRow.bind(null, fieldsetId, i);
 
     var rowClassSet = classNames({
@@ -49,19 +49,19 @@ var OptionalVolumesComponent = React.createClass({
                   onChange={this.handleChange.bind(null, i)}>
           <div className="col-sm-4">
             <FormGroupComponent
-                fieldId={`volumes.size.${i}`}
+                fieldId={`containerVolumesLocal.persistent.size.${i}`}
                 label="Size (MiB)"
-                value={row.size}>
-              <input ref={`size${i}`}
+                value={row.persistentSize}>
+              <input ref={`persistentSize${i}`}
                 type="number"/>
             </FormGroupComponent>
           </div>
           <div className="col-sm-8">
             <FormGroupComponent
-              fieldId={`volumes.path.${i}`}
+              fieldId={`containerVolumesLocal.containerPath.${i}`}
               label="Container Path"
-              value={row.path}>
-              <input ref={`path${i}`} />
+              value={row.containerPath}>
+              <input ref={`containerPath${i}`} />
             </FormGroupComponent>
             <DuplicableRowControls
               disableRemoveButton={disableRemoveButton}
@@ -75,7 +75,7 @@ var OptionalVolumesComponent = React.createClass({
   },
 
   getVolumesRows: function () {
-    var rows = this.state.rows.volumes;
+    var rows = this.state.rows.containerVolumesLocal;
     if (rows == null) {
       return (
         <button type="button">
@@ -83,7 +83,10 @@ var OptionalVolumesComponent = React.createClass({
         </button>
       );
     }
-    let disableRemoveButton = this.hasOnlyOneSingleEmptyRow("volumes");
+
+    let disableRemoveButton = this.hasOnlyOneSingleEmptyRow(
+      "containerVolumesLocal"
+    );
 
     return rows.map((row, i) => {
       return this.getVolumeRow(row, i, disableRemoveButton);
@@ -99,7 +102,7 @@ var OptionalVolumesComponent = React.createClass({
         <div className="duplicable-list">
           {this.getVolumesRows()}
         </div>
-        {this.getGeneralErrorBlock("volumes")}
+        {this.getGeneralErrorBlock("containerVolumesLocal")}
       </div>
     );
   }

--- a/src/js/components/OptionalVolumesComponent.jsx
+++ b/src/js/components/OptionalVolumesComponent.jsx
@@ -42,6 +42,7 @@ var OptionalVolumesComponent = React.createClass({
       "has-error": !!error,
       "duplicable-row": true
     });
+
     return (
       <div key={row.consecutiveKey} className={rowClassSet}>
         <fieldset className="row duplicable-row"
@@ -57,9 +58,9 @@ var OptionalVolumesComponent = React.createClass({
           </div>
           <div className="col-sm-8">
             <FormGroupComponent
-              fieldId={`containerVolumesLocal.containerPath.${i}`}
-              label="Container Path"
-              value={row.containerPath}>
+                fieldId={`containerVolumesLocal.containerPath.${i}`}
+                label="Container Path"
+                value={row.containerPath}>
               <input ref={`containerPath${i}`} />
             </FormGroupComponent>
             <DuplicableRowControls

--- a/src/js/components/OptionalVolumesComponent.jsx
+++ b/src/js/components/OptionalVolumesComponent.jsx
@@ -46,7 +46,7 @@ var OptionalVolumesComponent = React.createClass({
     return (
       <div key={row.consecutiveKey} className={rowClassSet}>
         <fieldset className="row duplicable-row"
-                  onChange={this.handleChange.bind(null, i)}>
+            onChange={this.handleChange.bind(null, i)}>
           <div className="col-sm-4">
             <FormGroupComponent
                 fieldId={`containerVolumesLocal.persistent.size.${i}`}

--- a/src/js/components/OptionalVolumesComponent.jsx
+++ b/src/js/components/OptionalVolumesComponent.jsx
@@ -1,0 +1,108 @@
+import classNames from "classnames";
+import React from "react/addons";
+
+import DuplicableRowControls from "../components/DuplicableRowControls";
+import DuplicableRowsMixin from "../mixins/DuplicableRowsMixin";
+import FormGroupComponent from "../components/FormGroupComponent";
+
+var OptionalVolumesComponent = React.createClass({
+  displayName: "OptionalVolumesComponent",
+
+  mixins: [DuplicableRowsMixin],
+
+  duplicableRowsScheme: {
+    volumes: {
+      size: "",
+      path: ""
+    }
+  },
+
+  handleAddRow: function (position, event) {
+    event.target.blur();
+    event.preventDefault();
+
+    this.addRow("volumes", position);
+  },
+
+  handleRemoveRow: function (position, event) {
+    event.target.blur();
+    event.preventDefault();
+
+    this.removeRow("volumes", position);
+  },
+
+  handleChange: function (position) {
+    this.updateRow("volumes", position);
+  },
+
+  getVolumeRow: function (row, i, disableRemoveButton = false) {
+    var error = this.getError("volumes", row.consecutiveKey);
+    // var handleChange = this.handleChangeRow.bind(null, fieldsetId, i);
+
+    var rowClassSet = classNames({
+      "has-error": !!error,
+      "duplicable-row": true
+    });
+    return (
+      <div key={row.consecutiveKey} className={rowClassSet}>
+        <fieldset className="row duplicable-row"
+                  onChange={this.handleChange.bind(null, i)}>
+          <div className="col-sm-4">
+            <FormGroupComponent
+                fieldId={`volumes.size.${i}`}
+                label="Size (MiB)"
+                value={row.size}>
+              <input ref={`size${i}`}
+                type="number"/>
+            </FormGroupComponent>
+          </div>
+          <div className="col-sm-8">
+            <FormGroupComponent
+              fieldId={`volumes.path.${i}`}
+              label="Container Path"
+              value={row.path}>
+              <input ref={`path${i}`} />
+            </FormGroupComponent>
+            <DuplicableRowControls
+              disableRemoveButton={disableRemoveButton}
+              handleAddRow={this.handleAddRow.bind(null, i + 1)}
+              handleRemoveRow={this.handleRemoveRow.bind(null, i)} />
+          </div>
+        </fieldset>
+        {error}
+      </div>
+    );
+  },
+
+  getVolumesRows: function () {
+    var rows = this.state.rows.volumes;
+    if (rows == null) {
+      return (
+        <button type="button">
+          Add a persistent local volume
+        </button>
+      );
+    }
+    let disableRemoveButton = this.hasOnlyOneSingleEmptyRow("volumes");
+
+    return rows.map((row, i) => {
+      return this.getVolumeRow(row, i, disableRemoveButton);
+    });
+  },
+
+  render: function () {
+    return (
+      <div>
+        <h4>
+          Persistent Local Volumes
+        </h4>
+        <div className="duplicable-list">
+          {this.getVolumesRows()}
+        </div>
+        {this.getGeneralErrorBlock("volumes")}
+      </div>
+    );
+  }
+});
+
+export default OptionalVolumesComponent;

--- a/src/js/components/OptionalVolumesComponent.jsx
+++ b/src/js/components/OptionalVolumesComponent.jsx
@@ -37,7 +37,6 @@ var OptionalVolumesComponent = React.createClass({
 
   getVolumeRow: function (row, i, disableRemoveButton = false) {
     var error = this.getError("containerVolumesLocal", row.consecutiveKey);
-    // var handleChange = this.handleChangeRow.bind(null, fieldsetId, i);
 
     var rowClassSet = classNames({
       "has-error": !!error,

--- a/src/js/constants/AppFormErrorMessages.js
+++ b/src/js/constants/AppFormErrorMessages.js
@@ -24,7 +24,8 @@ const applicationFieldValidationErrors = Util.deepFreeze({
   ],
   containerVolumesLocal: [
     "Size must be a non-negative number",
-    "Container Path must be a valid path"
+    "Container Path must be a valid path",
+    "Container Path and Size have to be set"
   ],
   cpus: ["CPUs must be a number greater or equal to 0.01"],
   disk: ["Disk Space must be a non-negative number"],

--- a/src/js/constants/AppFormErrorMessages.js
+++ b/src/js/constants/AppFormErrorMessages.js
@@ -19,7 +19,8 @@ const applicationFieldValidationErrors = Util.deepFreeze({
   containerVolumes: [
     "Container Path must be a valid path",
     "Host Path must be a valid path",
-    "Mode must not be empty"
+    "Mode must not be empty",
+    "Container Path and Host Path have to be set."
   ],
   containerVolumesLocal: [
     "Size must be a non-negative number",

--- a/src/js/constants/AppFormErrorMessages.js
+++ b/src/js/constants/AppFormErrorMessages.js
@@ -22,12 +22,12 @@ const applicationFieldValidationErrors = Util.deepFreeze({
     "Mode must not be empty"
   ],
   containerVolumesLocal: [
-    "Size must be a non-negative Number",
-    "Contianer Path must be a valid path"
+    "Size must be a non-negative number",
+    "Container Path must be a valid path"
   ],
   cpus: ["CPUs must be a number greater or equal to 0.01"],
   disk: ["Disk Space must be a non-negative number"],
-  dockerImage: ["Image cannot  contain whitespaces"],
+  dockerImage: ["Image cannot contain whitespaces"],
   dockerParameters: ["Key cannot be blank"],
   dockerPortMappings: [
     "Container Port must be a valid port",
@@ -48,7 +48,7 @@ const applicationFieldValidationErrors = Util.deepFreeze({
     "Timeout must be a non-negative number",
     "Maximal Consecutive Failures must be a non-negative number"
   ],
-  instances: ["Instances must be a non-negative Number"],
+  instances: ["Instances must be a non-negative number"],
   labels: ["Key cannot be blank"],
   mem: ["Memory must be a number greater or equal to 32"],
   ports: ["Ports must be a comma-separated list of numbers"]

--- a/src/js/constants/AppFormErrorMessages.js
+++ b/src/js/constants/AppFormErrorMessages.js
@@ -21,6 +21,10 @@ const applicationFieldValidationErrors = Util.deepFreeze({
     "Host Path must be a valid path",
     "Mode must not be empty"
   ],
+  containerVolumesLocal: [
+    "Size must be a non-negative Number",
+    "Contianer Path must be a valid path"
+  ],
   cpus: ["CPUs must be a number greater or equal to 0.01"],
   disk: ["Disk Space must be a non-negative number"],
   dockerImage: ["Image cannot  contain whitespaces"],

--- a/src/js/mixins/DuplicableRowsMixin.jsx
+++ b/src/js/mixins/DuplicableRowsMixin.jsx
@@ -5,6 +5,10 @@ import FormActions from "../actions/FormActions";
 
 import Util from "../helpers/Util";
 
+function getNewConsecutiveKey() {
+  return parseInt((Util.getUniqueId() + "").slice(-9));
+}
+
 var DuplicableRowsMixin = {
   propTypes: {
     errorIndices: React.PropTypes.object.isRequired,
@@ -40,7 +44,7 @@ var DuplicableRowsMixin = {
     Object.keys(duplicableRowsScheme).forEach(function (fieldId) {
       if (state.rows[fieldId] == null || state.rows[fieldId].length === 0) {
         let rowScheme = Util.extendObject(duplicableRowsScheme[fieldId], {
-          consecutiveKey: parseInt((Util.getUniqueId() + "").slice(-9))
+          consecutiveKey: getNewConsecutiveKey()
         });
         FormActions.insert(fieldId, rowScheme);
       }
@@ -66,7 +70,7 @@ var DuplicableRowsMixin = {
       return Util.extendObject(row, {
         consecutiveKey: row.consecutiveKey != null
           ? row.consecutiveKey
-          : Util.getUniqueId()
+          : getNewConsecutiveKey()
       });
     });
   },
@@ -92,7 +96,7 @@ var DuplicableRowsMixin = {
   addRow: function (fieldId, position) {
     FormActions.insert(fieldId,
       Util.extendObject(this.duplicableRowsScheme[fieldId], {
-        consecutiveKey: Util.getUniqueId()
+        consecutiveKey: getNewConsecutiveKey()
       }),
       position
     );

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -31,7 +31,8 @@ const duplicableRowFields = [
   "dockerParameters",
   "env",
   "healthChecks",
-  "labels"
+  "labels",
+  "volumes"
 ];
 
 /**
@@ -80,7 +81,11 @@ const validationRules = {
   "instances": [AppFormValidators.instances],
   "labels": [AppFormValidators.labels],
   "mem": [AppFormValidators.mem],
-  "ports": [AppFormValidators.ports]
+  "ports": [AppFormValidators.ports],
+  "volumes": [
+    AppFormValidators.volumesSize,
+    AppFormValidators.volumesPath
+  ]
 };
 
 /**
@@ -110,7 +115,8 @@ const resolveFieldIdToAppKeyMap = {
   mem: "mem",
   ports: "ports",
   uris: "uris",
-  user: "user"
+  user: "user",
+  volumes: "volumes"
 };
 
 /**
@@ -191,7 +197,8 @@ const resolveAppKeyToFieldIdMap = {
   "container.docker.parameters": "dockerParameters",
   "container.docker.privileged": "dockerPrivileged",
   "container.volumes": "containerVolumes",
-  "healthChecks": "healthChecks"
+  "healthChecks": "healthChecks",
+  "volumes": "volumes"
 };
 
 // Validate all fields in form store and update validationErrorIndices.
@@ -270,7 +277,6 @@ function rebuildModelFromFields(app, fields, fieldId) {
       Util.objectPathSet(app, key, transform(fields[fieldId]));
     }
   }
-
   Object.keys(app).forEach((appKey) => {
     var postProcessor = AppFormModelPostProcess[appKey];
     if (postProcessor != null) {

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -58,7 +58,8 @@ const validationRules = {
   ],
   "containerVolumesLocal": [
     AppFormValidators.containerVolumesLocalSize,
-    AppFormValidators.containerVolumesLocalPath
+    AppFormValidators.containerVolumesLocalPath,
+    AppFormValidators.containerVolumesLocalIsNotEmpty
   ],
   "cpus": [AppFormValidators.cpus],
   "disk": [AppFormValidators.disk],

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -53,7 +53,8 @@ const validationRules = {
   "containerVolumes": [
     AppFormValidators.containerVolumesContainerPathIsValid,
     AppFormValidators.containerVolumesHostPathIsValid,
-    AppFormValidators.containerVolumesModeNotEmpty
+    AppFormValidators.containerVolumesModeNotEmpty,
+    AppFormValidators.containerVolumesIsNotEmpty
   ],
   "containerVolumesLocal": [
     AppFormValidators.containerVolumesLocalSize,

--- a/src/js/stores/transforms/AppFormFieldToModelTransforms.js
+++ b/src/js/stores/transforms/AppFormFieldToModelTransforms.js
@@ -144,7 +144,13 @@ const AppFormFieldToModelTransforms = {
   uris: (uris) => lazy(uris.split(","))
     .map((uri) => uri.trim())
     .filter((uri) => uri != null && uri !== "")
-    .value()
+    .value(),
+  volumes: (volumes) => {
+    return volumes.map(volume => {
+      volume.mode = "RW";
+      return volume;
+    });
+  }
 };
 
 export default Object.freeze(AppFormFieldToModelTransforms);

--- a/src/js/stores/transforms/AppFormFieldToModelTransforms.js
+++ b/src/js/stores/transforms/AppFormFieldToModelTransforms.js
@@ -33,7 +33,8 @@ const AppFormFieldToModelTransforms = {
   constraints: (constraints) => constraints
     .split(",")
     .map((constraint) => constraint.split(":").map((value) => value.trim())),
-  containerVolumes: (rows) => lazy(rows)
+  containerVolumes: (rows) => {
+    return lazy(rows)
     .map((row) => ensureObjectScheme(row, dockerRowSchemes.containerVolumes))
     .compact()
     .filter((row) => {
@@ -42,7 +43,25 @@ const AppFormFieldToModelTransforms = {
           !Util.isStringAndEmpty(row[key].toString().trim()));
       });
     })
-    .value(),
+    .value();
+  },
+  containerVolumesLocal: rows => {
+    rows = rows.filter(row => {
+      return ["containerPath", "persistentSize"].every(key => {
+        return row[key] != null && row[key] !== "";
+      });
+    })
+      .map(row => {
+        return {
+          containerPath: row.containerPath,
+          persistent: {
+            size: row.persistentSize * 1
+          },
+          mode: "RW"
+        };
+      });
+    return rows;
+  },
   dockerForcePullImage: (isChecked) => !!isChecked,
   dockerParameters: (rows) => lazy(rows)
     .map((row) => ensureObjectScheme(row, dockerRowSchemes.dockerParameters))

--- a/src/js/stores/transforms/AppFormFieldToModelTransforms.js
+++ b/src/js/stores/transforms/AppFormFieldToModelTransforms.js
@@ -33,17 +33,17 @@ const AppFormFieldToModelTransforms = {
   constraints: (constraints) => constraints
     .split(",")
     .map((constraint) => constraint.split(":").map((value) => value.trim())),
-  containerVolumes: (rows) => {
+  containerVolumes: rows => {
     return lazy(rows)
-    .map((row) => ensureObjectScheme(row, dockerRowSchemes.containerVolumes))
-    .compact()
-    .filter((row) => {
-      return ["containerPath", "hostPath", "mode"].every((key) => {
-        return (row[key] != null &&
-          !Util.isStringAndEmpty(row[key].toString().trim()));
-      });
-    })
-    .value();
+      .map((row) => ensureObjectScheme(row, dockerRowSchemes.containerVolumes))
+      .compact()
+      .filter((row) => {
+        return ["containerPath", "hostPath", "mode"].every((key) => {
+          return (row[key] != null &&
+            !Util.isStringAndEmpty(row[key].toString().trim()));
+        });
+      })
+      .value();
   },
   containerVolumesLocal: rows => {
     rows = rows.filter(row => {
@@ -55,7 +55,7 @@ const AppFormFieldToModelTransforms = {
         return {
           containerPath: row.containerPath,
           persistent: {
-            size: row.persistentSize * 1
+            size: parseInt(row.persistentSize, 10)
           },
           mode: "RW"
         };

--- a/src/js/stores/transforms/AppFormModelPostProcess.js
+++ b/src/js/stores/transforms/AppFormModelPostProcess.js
@@ -33,6 +33,10 @@ const AppFormModelPostProcess = {
       return;
     }
 
+    if (container.type == null) {
+      container.type = "MESOS";
+    }
+
     let isEmpty = (Util.isArray(container.volumes) &&
         container.volumes.length === 0 ||
         container.volumes == null) &&

--- a/src/js/stores/transforms/AppFormModelPostProcess.js
+++ b/src/js/stores/transforms/AppFormModelPostProcess.js
@@ -28,7 +28,6 @@ const AppFormModelPostProcess = {
   },
   container: (app) => {
     var container = app.container;
-
     if (container == null) {
       return;
     }

--- a/src/js/stores/transforms/AppFormModelPostProcess.js
+++ b/src/js/stores/transforms/AppFormModelPostProcess.js
@@ -96,17 +96,20 @@ const AppFormModelPostProcess = {
       volume => volume.persistent == null
     );
 
-    app.container.volumes = app.container.volumes.concat(app.volumes.map(
-      volume => {
-        return {
-          containerPath: volume.path,
-          persistent: {
-            size: volume.size
-          },
-          mode: volume.mode
-        };
-      }
-    ));
+    app.container.volumes = app.container.volumes.concat(
+      app.volumes.map(
+        volume => {
+          return {
+            containerPath: volume.path,
+            persistent: {
+              size: volume.size
+            },
+            mode: volume.mode
+          };
+        }
+      )
+    );
+
     delete app.volumes;
   }
 };

--- a/src/js/stores/transforms/AppFormModelPostProcess.js
+++ b/src/js/stores/transforms/AppFormModelPostProcess.js
@@ -80,6 +80,33 @@ const AppFormModelPostProcess = {
     if (isEmpty) {
       app.healthChecks = [];
     }
+  },
+  volumes: app => {
+    if (app.container == null) {
+      app.container = {
+        type: "MESOS"
+      };
+    }
+    if (app.container.volumes == null) {
+      app.container.volumes = [];
+    }
+
+    app.container.volumes = app.container.volumes.filter(
+      volume => volume.persistent == null
+    );
+
+    app.container.volumes = app.container.volumes.concat(app.volumes.map(
+      volume => {
+        return {
+          containerPath: volume.path,
+          persistent: {
+            size: volume.size
+          },
+          mode: volume.mode
+        };
+      }
+    ));
+    delete app.volumes;
   }
 };
 

--- a/src/js/stores/transforms/AppFormModelPostProcess.js
+++ b/src/js/stores/transforms/AppFormModelPostProcess.js
@@ -32,9 +32,7 @@ const AppFormModelPostProcess = {
       return;
     }
 
-    if (container.type == null) {
-      container.type = "MESOS";
-    }
+    container.type = container.docker != null ? "DOCKER" : "MESOS";
 
     let isEmpty = (Util.isArray(container.volumes) &&
         container.volumes.length === 0 ||

--- a/src/js/stores/transforms/AppFormModelToFieldTransforms.js
+++ b/src/js/stores/transforms/AppFormModelToFieldTransforms.js
@@ -77,7 +77,14 @@ const AppFormModelToFieldTransforms = {
   ports: (ports) => ports
     .join(", "),
   uris: (uris) => uris
-    .join(", ")
+    .join(", "),
+  volumes: (volumes) => {
+    return volumes
+      .map((row, i) => {
+        row.consecutiveKey = i;
+        return row;
+      });
+  }
 };
 
 export default Object.freeze(AppFormModelToFieldTransforms);

--- a/src/js/stores/transforms/AppFormModelToFieldTransforms.js
+++ b/src/js/stores/transforms/AppFormModelToFieldTransforms.js
@@ -29,8 +29,19 @@ const AppFormModelToFieldTransforms = {
   },
   containerVolumes: (volumes) => {
     return volumes
+      .filter(row => row.hostPath != null)
       .map((row, i) => {
         row.consecutiveKey = i;
+        return row;
+      });
+  },
+  containerVolumesLocal: (volumes) => {
+    return volumes
+      .filter(row => row.persistent != null)
+      .map((row, i) => {
+        row.persistentSize = row.persistent.size;
+        row.consecutiveKey = i;
+        delete row.persistent;
         return row;
       });
   },

--- a/src/js/stores/validators/AppFormValidators.js
+++ b/src/js/stores/validators/AppFormValidators.js
@@ -160,12 +160,13 @@ const AppFormValidators = {
     ports.split(",")
       .every((port) => port.toString().trim().match(/^[0-9]+$/)),
   containerVolumesLocalSize: (obj) =>
+    Util.isStringAndEmpty(obj.persistentSize) ||
+    !!obj.persistentSize.toString().match(/^[0-9\.]+$/),
+  containerVolumesLocalPath: (obj) => isValidPath(obj.containerPath) &&
+    !obj.containerPath.match(/\//),
+  containerVolumesLocalIsNotEmpty: (obj) =>
     (!Util.isStringAndEmpty(obj.persistentSize) &&
-      !!obj.persistentSize.toString().match(/^[0-9\.]+$/)) ||
-      (Util.isStringAndEmpty(obj.persistentSize) &&
-      Util.isStringAndEmpty(obj.containerPath)),
-  containerVolumesLocalPath: (obj) => (isValidPath(obj.containerPath) &&
-      !obj.containerPath.match(/\//)) ||
+    !Util.isStringAndEmpty(obj.containerPath)) ||
     (Util.isStringAndEmpty(obj.persistentSize) &&
     Util.isStringAndEmpty(obj.containerPath))
 };

--- a/src/js/stores/validators/AppFormValidators.js
+++ b/src/js/stores/validators/AppFormValidators.js
@@ -48,6 +48,11 @@ const AppFormValidators = {
 
   containerVolumesModeNotEmpty: (obj) => !Util.isStringAndEmpty(obj.mode),
 
+  containerVolumesIsNotEmpty: (obj) =>
+    (!Util.isStringAndEmpty(obj.containerPath) &&
+    !Util.isStringAndEmpty(obj.hostPath)) ||
+    obj.mode == null,
+
   constraints: (constraints) => Util.isStringAndEmpty(constraints) ||
     constraints
       .split(",")

--- a/src/js/stores/validators/AppFormValidators.js
+++ b/src/js/stores/validators/AppFormValidators.js
@@ -155,10 +155,14 @@ const AppFormValidators = {
     ports.split(",")
       .every((port) => port.toString().trim().match(/^[0-9]+$/)),
   containerVolumesLocalSize: (obj) =>
-    !Util.isStringAndEmpty(obj.persistentSize) &&
-      !!obj.persistentSize.toString().match(/^[0-9\.]+$/),
+    (!Util.isStringAndEmpty(obj.persistentSize) &&
+      !!obj.persistentSize.toString().match(/^[0-9\.]+$/)) ||
+      (Util.isStringAndEmpty(obj.persistentSize) &&
+      Util.isStringAndEmpty(obj.containerPath)),
   containerVolumesLocalPath: (obj) => {
-    return isValidPath(obj.containerPath);
+    return isValidPath(obj.containerPath) ||
+    (Util.isStringAndEmpty(obj.persistentSize) &&
+    Util.isStringAndEmpty(obj.containerPath));
   }
 };
 

--- a/src/js/stores/validators/AppFormValidators.js
+++ b/src/js/stores/validators/AppFormValidators.js
@@ -164,7 +164,8 @@ const AppFormValidators = {
       !!obj.persistentSize.toString().match(/^[0-9\.]+$/)) ||
       (Util.isStringAndEmpty(obj.persistentSize) &&
       Util.isStringAndEmpty(obj.containerPath)),
-  containerVolumesLocalPath: (obj) => isValidPath(obj.containerPath) ||
+  containerVolumesLocalPath: (obj) => (isValidPath(obj.containerPath) &&
+      !obj.containerPath.match(/\//)) ||
     (Util.isStringAndEmpty(obj.persistentSize) &&
     Util.isStringAndEmpty(obj.containerPath))
 };

--- a/src/js/stores/validators/AppFormValidators.js
+++ b/src/js/stores/validators/AppFormValidators.js
@@ -159,11 +159,9 @@ const AppFormValidators = {
       !!obj.persistentSize.toString().match(/^[0-9\.]+$/)) ||
       (Util.isStringAndEmpty(obj.persistentSize) &&
       Util.isStringAndEmpty(obj.containerPath)),
-  containerVolumesLocalPath: (obj) => {
-    return isValidPath(obj.containerPath) ||
+  containerVolumesLocalPath: (obj) => isValidPath(obj.containerPath) ||
     (Util.isStringAndEmpty(obj.persistentSize) &&
-    Util.isStringAndEmpty(obj.containerPath));
-  }
+    Util.isStringAndEmpty(obj.containerPath))
 };
 
 export default Object.freeze(AppFormValidators);

--- a/src/js/stores/validators/AppFormValidators.js
+++ b/src/js/stores/validators/AppFormValidators.js
@@ -154,9 +154,12 @@ const AppFormValidators = {
   ports: (ports) => Util.isStringAndEmpty(ports) ||
     ports.split(",")
       .every((port) => port.toString().trim().match(/^[0-9]+$/)),
-  volumesSize: (obj) => !Util.isStringAndEmpty(obj.size) &&
-    !!obj.size.toString().match(/^[0-9\.]+$/),
-  volumesPath: (obj) => isValidPath(obj.path)
+  containerVolumesLocalSize: (obj) =>
+    !Util.isStringAndEmpty(obj.persistentSize) &&
+      !!obj.persistentSize.toString().match(/^[0-9\.]+$/),
+  containerVolumesLocalPath: (obj) => {
+    return isValidPath(obj.containerPath);
+  }
 };
 
 export default Object.freeze(AppFormValidators);

--- a/src/js/stores/validators/AppFormValidators.js
+++ b/src/js/stores/validators/AppFormValidators.js
@@ -153,7 +153,10 @@ const AppFormValidators = {
 
   ports: (ports) => Util.isStringAndEmpty(ports) ||
     ports.split(",")
-      .every((port) => port.toString().trim().match(/^[0-9]+$/))
+      .every((port) => port.toString().trim().match(/^[0-9]+$/)),
+  volumesSize: (obj) => !Util.isStringAndEmpty(obj.size) &&
+    !!obj.size.toString().match(/^[0-9\.]+$/),
+  volumesPath: (obj) => isValidPath(obj.path)
 };
 
 export default Object.freeze(AppFormValidators);

--- a/src/test/units/AppFormValidators.test.js
+++ b/src/test/units/AppFormValidators.test.js
@@ -682,13 +682,6 @@ describe("App Form Validators", function () {
     });
     describe("Volumes", function () {
       describe("size", function () {
-        it("should not be empty", function () {
-          var volume = {
-            persistentSize: ""
-          };
-          expect(this.validatior.containerVolumesLocalSize(volume)).to.be.false;
-        });
-
         it("should not be a not number value", function () {
           var volume = {
             persistentSize: "abc"
@@ -701,6 +694,13 @@ describe("App Form Validators", function () {
             persistentSize: "1024"
           };
           expect(this.validatior.containerVolumesLocalSize(volume)).to.be.true;
+        });
+
+        it("should not be a negative value", function () {
+          var volume = {
+            persistentSize: "-1024"
+          };
+          expect(this.validatior.containerVolumesLocalSize(volume)).to.be.false;
         });
       });
       describe("path", function () {
@@ -737,6 +737,37 @@ describe("App Form Validators", function () {
             containerPath: "/abc"
           };
           expect(this.validatior.containerVolumesLocalPath(volume)).to.be.false;
+        });
+      });
+      describe("all fields", function () {
+        it("should not have an empty persistentSize", function () {
+          var volume = {
+            containerPath: "abc",
+            persistentSize: ""
+          };
+
+          expect(this.validatior.containerVolumesLocalIsNotEmpty(volume))
+            .to.be.false;
+        });
+
+        it("should not have an empty containerPath", function () {
+          var volume = {
+            containerPath: "",
+            persistentSize: "12"
+          };
+
+          expect(this.validatior.containerVolumesLocalIsNotEmpty(volume))
+            .to.be.false;
+        });
+
+        it("should be valid if no empty value is provided", function () {
+          var volume = {
+            containerPath: "asdasd",
+            persistentSize: "12"
+          };
+
+          expect(this.validatior.containerVolumesLocalIsNotEmpty(volume))
+            .to.be.true;
         });
       });
     });

--- a/src/test/units/AppFormValidators.test.js
+++ b/src/test/units/AppFormValidators.test.js
@@ -633,6 +633,59 @@ describe("App Form Validators", function () {
         expect(this.validatior.ports("123, 495 666")).to.be.false;
       });
     });
+    describe("Volumes", function () {
+      describe("size", function () {
+        it("should not be empty", function () {
+          var volume = {
+            size: ""
+          };
+          expect(this.validatior.volumesSize(volume)).to.be.false;
+        });
+
+        it("should not be a not number value", function () {
+          var volume = {
+            size: "abc"
+          };
+          expect(this.validatior.volumesSize(volume)).to.be.false;
+        });
+
+        it("should be a number value", function () {
+          var volume = {
+            size: "1024"
+          };
+          expect(this.validatior.volumesSize(volume)).to.be.true;
+        });
+      });
+      describe("path", function () {
+        it("shouyld allow an empty value", function () {
+          var volume = {
+            path: ""
+          };
+          expect(this.validatior.volumesPath(volume)).to.be.true;
+        });
+
+        it("should not be a not contain a space", function () {
+          var volume = {
+            path: "ab c"
+          };
+          expect(this.validatior.volumesPath(volume)).to.be.false;
+        });
+
+        it("should be a string value", function () {
+          var volume = {
+            path: "abc"
+          };
+          expect(this.validatior.volumesPath(volume)).to.be.true;
+        });
+
+        it("should be can contain a slash string value", function () {
+          var volume = {
+            path: "ab/c"
+          };
+          expect(this.validatior.volumesPath(volume)).to.be.true;
+        });
+      });
+    });
 
   });
 

--- a/src/test/units/AppFormValidators.test.js
+++ b/src/test/units/AppFormValidators.test.js
@@ -725,18 +725,18 @@ describe("App Form Validators", function () {
           expect(this.validatior.containerVolumesLocalPath(volume)).to.be.true;
         });
 
-        it("should contain a slash string value", function () {
+        it("should not contain a slash string value", function () {
           var volume = {
             containerPath: "ab/c"
           };
-          expect(this.validatior.containerVolumesLocalPath(volume)).to.be.true;
+          expect(this.validatior.containerVolumesLocalPath(volume)).to.be.false;
         });
 
-        it("should begin with a slash string value", function () {
+        it("should not begin with a slash string value", function () {
           var volume = {
             containerPath: "/abc"
           };
-          expect(this.validatior.containerVolumesLocalPath(volume)).to.be.true;
+          expect(this.validatior.containerVolumesLocalPath(volume)).to.be.false;
         });
       });
     });

--- a/src/test/units/AppFormValidators.test.js
+++ b/src/test/units/AppFormValidators.test.js
@@ -296,6 +296,53 @@ describe("App Form Validators", function () {
           });
         });
 
+        describe("container is not empty", function () {
+
+          it("should be valid if empty", function () {
+            let isValid = this.validatior.containerVolumesIsNotEmpty;
+            var givenEmptyObject = {
+              containerPath: "",
+              hostPath: "",
+              mode: null
+            };
+            var expectedState = true;
+            expect(isValid(givenEmptyObject)).to.be.equal(expectedState);
+          });
+
+          it("should be valid if not empty", function () {
+            let isValid = this.validatior.containerVolumesIsNotEmpty;
+            var givenEmptyObject = {
+              containerPath: "/container-0",
+              hostPath: "/host-0",
+              mode: "RO"
+            };
+            var expectedState = true;
+            expect(isValid(givenEmptyObject)).to.be.equal(expectedState);
+          });
+
+          it("should not be valid if hostPath is empty", function () {
+            let isValid = this.validatior.containerVolumesIsNotEmpty;
+            var givenEmptyObject = {
+              containerPath: "/container-0",
+              hostPath: "",
+              mode: "RO"
+            };
+            var expectedState = false;
+            expect(isValid(givenEmptyObject)).to.be.equal(expectedState);
+          });
+
+          it("should not be valid if containerPath is empty", function () {
+            let isValid = this.validatior.containerVolumesIsNotEmpty;
+            var givenEmptyObject = {
+              containerPath: "",
+              hostPath: "/host-0",
+              mode: "RO"
+            };
+            var expectedState = false;
+            expect(isValid(givenEmptyObject)).to.be.equal(expectedState);
+          });
+        });
+
       });
 
     });

--- a/src/test/units/AppFormValidators.test.js
+++ b/src/test/units/AppFormValidators.test.js
@@ -9,7 +9,7 @@ describe("App Form Validators", function () {
 
     before(function () {
       this.validatior = AppFormValidators;
-    })
+    });
 
     describe("app id", function () {
       it("is not an empty string", function () {
@@ -637,52 +637,59 @@ describe("App Form Validators", function () {
       describe("size", function () {
         it("should not be empty", function () {
           var volume = {
-            size: ""
+            persistentSize: ""
           };
-          expect(this.validatior.volumesSize(volume)).to.be.false;
+          expect(this.validatior.containerVolumesLocalSize(volume)).to.be.false;
         });
 
         it("should not be a not number value", function () {
           var volume = {
-            size: "abc"
+            persistentSize: "abc"
           };
-          expect(this.validatior.volumesSize(volume)).to.be.false;
+          expect(this.validatior.containerVolumesLocalSize(volume)).to.be.false;
         });
 
         it("should be a number value", function () {
           var volume = {
-            size: "1024"
+            persistentSize: "1024"
           };
-          expect(this.validatior.volumesSize(volume)).to.be.true;
+          expect(this.validatior.containerVolumesLocalSize(volume)).to.be.true;
         });
       });
       describe("path", function () {
-        it("shouyld allow an empty value", function () {
+        it("should allow an empty value", function () {
           var volume = {
-            path: ""
+            containerPath: ""
           };
-          expect(this.validatior.volumesPath(volume)).to.be.true;
+          expect(this.validatior.containerVolumesLocalPath(volume)).to.be.true;
         });
 
         it("should not be a not contain a space", function () {
           var volume = {
-            path: "ab c"
+            containerPath: "ab c"
           };
-          expect(this.validatior.volumesPath(volume)).to.be.false;
+          expect(this.validatior.containerVolumesLocalPath(volume)).to.be.false;
         });
 
         it("should be a string value", function () {
           var volume = {
-            path: "abc"
+            containerPath: "abc"
           };
-          expect(this.validatior.volumesPath(volume)).to.be.true;
+          expect(this.validatior.containerVolumesLocalPath(volume)).to.be.true;
         });
 
-        it("should be can contain a slash string value", function () {
+        it("should contain a slash string value", function () {
           var volume = {
-            path: "ab/c"
+            containerPath: "ab/c"
           };
-          expect(this.validatior.volumesPath(volume)).to.be.true;
+          expect(this.validatior.containerVolumesLocalPath(volume)).to.be.true;
+        });
+
+        it("should begin with a slash string value", function () {
+          var volume = {
+            containerPath: "/abc"
+          };
+          expect(this.validatior.containerVolumesLocalPath(volume)).to.be.true;
         });
       });
     });

--- a/src/test/units/OptionalVolumesComponent.test.js
+++ b/src/test/units/OptionalVolumesComponent.test.js
@@ -1,0 +1,66 @@
+import {expect} from "chai";
+import {render, shallow} from "enzyme";
+
+import React from "react/addons";
+import OptionalVolumesComponent from "../../js/components/OptionalVolumesComponent.jsx";
+
+describe("Optional Volumes Component", function () {
+  describe("(no volume)", () => {
+    var component = shallow(
+      <OptionalVolumesComponent errorIndices={{}}
+        fields={{"volumes": null}}
+        getErrorMessage={()=>{}}/>
+    );
+
+    it("should display a button", () => {
+      expect(component.find("button")).to.have.length(1);
+    });
+
+    it("should have a button with type button", () => {
+      expect(component.find("button").first().props().type).to.equal("button");
+    });
+
+    it("should have a button with the right text", () => {
+      expect(component.find("button").first().props().children)
+        .to.equal("Add a persistent local volume");
+    });
+
+    it("should have the right title", () => {
+      expect(component.find("h4").first().props().children)
+        .to.equal("Persistent Local Volumes");
+    })
+  });
+  describe("(one volume)", () => {
+    var component = render(
+      <OptionalVolumesComponent errorIndices={{}}
+        fields={{"volumes": [{
+          consecutiveKey: "11454950241300",
+          mode: null,
+          path: "",
+          size: "1024"
+        }]}}
+        getErrorMessage={()=>{}}/>
+    );
+
+    it("should have the right size id", () => {
+      expect(component.find("input").get(0).attribs.id)
+        .to.equal("volumes.size.0");
+    });
+
+    it("should have the right size value", () => {
+      expect(component.find("input").get(0).attribs.value)
+        .to.equal("1024");
+    });
+
+    it("should have the right path id", () => {
+      expect(component.find("input").get(1).attribs.id)
+        .to.equal("volumes.path.0");
+    });
+
+    it("should have the right path value", () => {
+      expect(component.find("input").get(1).attribs.value)
+        .to.equal("");
+    });
+  });
+
+});

--- a/src/test/units/OptionalVolumesComponent.test.js
+++ b/src/test/units/OptionalVolumesComponent.test.js
@@ -2,7 +2,8 @@ import {expect} from "chai";
 import {render, shallow} from "enzyme";
 
 import React from "react/addons";
-import OptionalVolumesComponent from "../../js/components/OptionalVolumesComponent.jsx";
+import OptionalVolumesComponent
+  from "../../js/components/OptionalVolumesComponent.jsx";
 
 describe("Optional Volumes Component", function () {
   describe("(no volume)", () => {
@@ -33,18 +34,17 @@ describe("Optional Volumes Component", function () {
   describe("(one volume)", () => {
     var component = render(
       <OptionalVolumesComponent errorIndices={{}}
-        fields={{"volumes": [{
-          consecutiveKey: "11454950241300",
-          mode: null,
-          path: "",
-          size: "1024"
+        fields={{"containerVolumesLocal": [{
+          consecutiveKey: "0",
+          containerPath: "",
+          persistentSize: "1024"
         }]}}
         getErrorMessage={()=>{}}/>
     );
 
     it("should have the right size id", () => {
       expect(component.find("input").get(0).attribs.id)
-        .to.equal("volumes.size.0");
+        .to.equal("containerVolumesLocal.persistent.size.0");
     });
 
     it("should have the right size value", () => {
@@ -54,7 +54,7 @@ describe("Optional Volumes Component", function () {
 
     it("should have the right path id", () => {
       expect(component.find("input").get(1).attribs.id)
-        .to.equal("volumes.path.0");
+        .to.equal("containerVolumesLocal.containerPath.0");
     });
 
     it("should have the right path value", () => {


### PR DESCRIPTION
This introduces the volumes section to the create / edit application modal and is part of mesosphere/marathon#3155. The section uses the duplicable rows mixin and uses the old behaviour for duplicable rows. The new behaviour will be introduced with another PR.

## Changes
This changes the model to field transforms in the `AppsFormStore` since we need to map `container.volumes` to multiple fields like `containerVolumes`  and `containerVolumesLocal` and before only a 1:1 conversion was needed.