### PR TITLE
Refactor 3192 - Adapt default Mem/CPU settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - \#3078 - Always show download button for logs
 - \#3077 - Future timestamps
 - \#3124 - Improve usability of labels filter dropdown
+- \#3192 - Adapt default Mem/CPU settings
 
 ### Fixed
 - \#3133 - Interrupted scaling operations can leave the health bar in an

--- a/src/js/constants/AppFormErrorMessages.js
+++ b/src/js/constants/AppFormErrorMessages.js
@@ -21,7 +21,7 @@ const applicationFieldValidationErrors = Util.deepFreeze({
     "Host Path must be a valid path",
     "Mode must not be empty"
   ],
-  cpus: ["CPUs must be a non-negative number"],
+  cpus: ["CPUs must be a number greater or equal to 0.01"],
   disk: ["Disk Space must be a non-negative number"],
   dockerImage: ["Image cannot  contain whitespaces"],
   dockerParameters: ["Key cannot be blank"],
@@ -46,7 +46,7 @@ const applicationFieldValidationErrors = Util.deepFreeze({
   ],
   instances: ["Instances must be a non-negative Number"],
   labels: ["Key cannot be blank"],
-  mem: ["Memory must be a non-negative Number"],
+  mem: ["Memory must be a number greater or equal to 32"],
   ports: ["Ports must be a comma-separated list of numbers"]
 });
 

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -19,8 +19,8 @@ const storeData = {
 };
 
 const defaultFieldValues = Object.freeze({
-  cpus: 0.1,
-  mem: 16,
+  cpus: 1,
+  mem: 128,
   disk: 0,
   instances: 1
 });

--- a/src/js/stores/validators/AppFormValidators.js
+++ b/src/js/stores/validators/AppFormValidators.js
@@ -60,7 +60,7 @@ const AppFormValidators = {
       }),
 
   cpus: (value) => !Util.isStringAndEmpty(value) &&
-    !!value.toString().match(/^[0-9\.]+$/),
+    !!value.toString().match(/^[0-9\.]+$/) && value >= 0.01,
 
   disk: (value) => !Util.isStringAndEmpty(value) &&
     !!value.toString().match(/^[0-9\.]+$/),
@@ -149,7 +149,7 @@ const AppFormValidators = {
     !Util.isStringAndEmpty(obj.value)),
 
   mem: (value) => !Util.isStringAndEmpty(value) &&
-    !!value.toString().match(/^[0-9\.]+$/),
+    !!value.toString().match(/^[0-9\.]+$/) && value >= 32,
 
   ports: (ports) => Util.isStringAndEmpty(ports) ||
     ports.split(",")

--- a/src/js/stores/validators/AppFormValidators.js
+++ b/src/js/stores/validators/AppFormValidators.js
@@ -60,7 +60,7 @@ const AppFormValidators = {
       }),
 
   cpus: (value) => !Util.isStringAndEmpty(value) &&
-    !!value.toString().match(/^[0-9\.]+$/) && value >= 0.01,
+    !!value.toString().match(/^[0-9\.]+$/) && parseFloat(value) >= 0.01,
 
   disk: (value) => !Util.isStringAndEmpty(value) &&
     !!value.toString().match(/^[0-9\.]+$/),
@@ -149,7 +149,7 @@ const AppFormValidators = {
     !Util.isStringAndEmpty(obj.value)),
 
   mem: (value) => !Util.isStringAndEmpty(value) &&
-    !!value.toString().match(/^[0-9\.]+$/) && value >= 32,
+    !!value.toString().match(/^[0-9\.]+$/) && parseInt(value) >= 32,
 
   ports: (ports) => Util.isStringAndEmpty(ports) ||
     ports.split(",")

--- a/src/test/units/AppFormValidators.test.js
+++ b/src/test/units/AppFormValidators.test.js
@@ -82,11 +82,13 @@ describe("App Form Validators", function () {
         expect(this.validatior.cpus("")).to.be.false;
       });
 
-      it("looks like a number", function () {
+      it("looks like a number greater or equal to 0.01", function () {
         expect(this.validatior.cpus("not a number 666")).to.be.false;
-        expect(this.validatior.cpus(0.1)).to.be.true;
+        expect(this.validatior.cpus(0.001)).to.be.false;
+        expect(this.validatior.cpus("0.0001")).to.be.false;
+        expect(this.validatior.cpus(0.01)).to.be.true;
+        expect(this.validatior.cpus("0.01")).to.be.true;
         expect(this.validatior.cpus(5)).to.be.true;
-        expect(this.validatior.cpus("0.0001")).to.be.true;
         expect(this.validatior.cpus("2")).to.be.true;
       });
     });
@@ -596,13 +598,17 @@ describe("App Form Validators", function () {
         expect(this.validatior.mem("")).to.be.false;
       });
 
-      it("looks like a number", function () {
+      it("looks like a number greater or equal to 32", function () {
         expect(this.validatior.mem("")).to.be.false;
         expect(this.validatior.mem("not a number 666")).to.be.false;
-        expect(this.validatior.mem(0.1)).to.be.true;
-        expect(this.validatior.mem(5)).to.be.true;
-        expect(this.validatior.mem("0.0001")).to.be.true;
-        expect(this.validatior.mem("2")).to.be.true;
+        expect(this.validatior.mem(0.1)).to.be.false;
+        expect(this.validatior.mem(5)).to.be.false;
+        expect(this.validatior.mem("0.0001")).to.be.false;
+        expect(this.validatior.mem("31")).to.be.false;
+        expect(this.validatior.mem("32")).to.be.true;
+        expect(this.validatior.mem("32.7")).to.be.true;
+        expect(this.validatior.mem(32)).to.be.true;
+        expect(this.validatior.mem(500)).to.be.true;
       });
     });
 


### PR DESCRIPTION
Update app default cpu and mem values to match the Marathon Service defaults and validate app cpu and mem against Mesos min values.

Closes mesosphere/marathon#3192