### PR TITLE
Fix contextual bar size

### DIFF
--- a/src/css/components/breadcrumb.less
+++ b/src/css/components/breadcrumb.less
@@ -8,12 +8,12 @@
   display: flex;
   flex: 1;
   font-size: @base-font-size;
+  line-height: @base-spacing-unit*2;
   list-style: none;
   margin: 0;
   padding: @base-spacing-unit*2;
 
   li {
-    line-height: @base-spacing-unit*2;
     display: flex;
 
     + li::before {

--- a/src/css/components/pane.less
+++ b/src/css/components/pane.less
@@ -41,10 +41,7 @@
           padding: 0;
           align-items: center;
           overflow-x: hidden;
-
-          li {
-            line-height: @font-size-h2+@base-spacing-unit;
-          }
+          line-height: @font-size-h2+@base-spacing-unit;
 
           .clear {
             margin-left: @horizontal-spacing-unit;


### PR DESCRIPTION
![fix-contextual-bar-size](https://cloud.githubusercontent.com/assets/647035/13055806/be8b3752-d411-11e5-8d88-7c58fddd95c9.gif)
Adjust the breadcrumb line-height setting to fix the contextual bar size, which is otherwise different due to non-matching selectors :smile_cat: 

Closes mesosphere/marathon#3134