### PR TITLE
Correct indentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,15 @@ https://mesosphere.github.io/marathon/docs/marathon-ui.html.
 
 6. Run development environment
 
-        npm run serve
-
+  ```
+  npm run serve
+  ```
+  
   or
-
-        npm run livereload
+  
+  ```
+  npm run livereload
+  ```
 
   for a `browsersync` live-reload server.
 


### PR DESCRIPTION
The identation in the rendered Markdown of ```npm run livereaload``` was one to much, compared to ```npm run serve```.
Don't know why, but this approach fixes it.