### PR TITLE
Change - 3239: Move docker volumes settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - \#3077 - Future timestamps
 - \#3124 - Improve usability of labels filter dropdown
 - \#3192 - Adapt default Mem/CPU settings
+- \#3239 - Move docker volumes to volumes section
 
 ### Fixed
 - \#3133 - Interrupted scaling operations can leave the health bar in an

--- a/src/js/components/ContainerSettingsComponent.jsx
+++ b/src/js/components/ContainerSettingsComponent.jsx
@@ -273,7 +273,7 @@ var ContainerSettingsComponent = React.createClass({
         <div className="duplicable-list">{this.getPortMappingRows()}</div>
         <h4>Parameters</h4>
         <div className="duplicable-list">{this.getParametersRows()}</div>
-        <div>You can set you Docker volume settings below.</div>
+        <div>You can set your Docker volume settings below.</div>
       </div>
     );
   }

--- a/src/js/components/ContainerSettingsComponent.jsx
+++ b/src/js/components/ContainerSettingsComponent.jsx
@@ -24,7 +24,6 @@ var ContainerSettingsComponent = React.createClass({
 
   statics: {
     fieldIds: Object.freeze({
-      containerVolumes: "containerVolumes",
       dockerForcePullImage: "dockerForcePullImage",
       dockerImage: "dockerImage",
       dockerNetwork: "dockerNetwork",
@@ -213,84 +212,6 @@ var ContainerSettingsComponent = React.createClass({
     });
   },
 
-  getVolumesRow: function (row, i, disableRemoveButton = false) {
-    var fieldsetId = ContainerSettingsComponent.fieldIds.containerVolumes;
-    var error = this.getError(fieldsetId, row.consecutiveKey);
-    var getErrorMessage = this.props.getErrorMessage;
-    var handleChange = this.handleChangeRow.bind(null, fieldsetId, i);
-    var handleAddRow = this.handleAddRow.bind(null, fieldsetId, i + 1);
-    var handleRemoveRow =
-      this.handleRemoveRow.bind(null, fieldsetId, i);
-
-    var rowClassSet = classNames({
-      "has-error": !!error,
-      "duplicable-row": true
-    });
-
-    return (
-      <div key={row.consecutiveKey} className={rowClassSet}>
-        <fieldset className="row duplicable-row"
-          onChange={handleChange}>
-          <div className="col-sm-4">
-            <FormGroupComponent
-                errorMessage={
-                  getErrorMessage(`${fieldsetId}.${i}.containerPath`)
-                }
-                fieldId={`${fieldsetId}.${i}.containerPath`}
-                label="Container Path"
-                value={row.containerPath}>
-              <input ref={`containerPath${i}`} />
-            </FormGroupComponent>
-          </div>
-          <div className="col-sm-4">
-            <FormGroupComponent
-                errorMessage={getErrorMessage(`${fieldsetId}.${i}.hostPath`)}
-                fieldId={`${fieldsetId}.${i}.hostPath`}
-                label="Host Path"
-                value={row.hostPath}>
-              <input ref={`hostPath${i}`} />
-            </FormGroupComponent>
-          </div>
-          <div className="col-sm-4">
-            <FormGroupComponent
-                errorMessage={getErrorMessage(`${fieldsetId}.${i}.mode`)}
-                fieldId={`${fieldsetId}.${i}.mode`}
-                label="Mode"
-                value={row.mode}>
-              <select defaultValue="" ref={`mode${i}`}>
-                <option value="">Select</option>
-                <option value={ContainerConstants.VOLUMES.MODE.RO}>
-                  Read Only
-                </option>
-                <option value={ContainerConstants.VOLUMES.MODE.RW}>
-                  Read and Write
-                </option>
-              </select>
-            </FormGroupComponent>
-            <DuplicableRowControls disableRemoveButton={disableRemoveButton}
-              handleAddRow={handleAddRow}
-              handleRemoveRow={handleRemoveRow} />
-          </div>
-        </fieldset>
-        {error}
-      </div>
-    );
-  },
-
-  getVolumesRows: function () {
-    var rows = this.state.rows.containerVolumes;
-
-    if (rows == null) {
-      return null;
-    }
-
-    let disableRemoveButton = this.hasOnlyOneSingleEmptyRow("containerVolumes");
-
-    return rows.map((row, i) => {
-      return this.getVolumesRow(row, i, disableRemoveButton);
-    });
-  },
-
   render: function () {
     var props = this.props;
     var fieldIds = ContainerSettingsComponent.fieldIds;
@@ -352,8 +273,7 @@ var ContainerSettingsComponent = React.createClass({
         <div className="duplicable-list">{this.getPortMappingRows()}</div>
         <h4>Parameters</h4>
         <div className="duplicable-list">{this.getParametersRows()}</div>
-        <h4>Volumes</h4>
-        <div className="duplicable-list">{this.getVolumesRows()}</div>
+        <div>You can set you Docker volume settings below.</div>
       </div>
     );
   }

--- a/src/js/components/ContainerVolumesComponent.jsx
+++ b/src/js/components/ContainerVolumesComponent.jsx
@@ -7,8 +7,8 @@ import FormGroupComponent from "../components/FormGroupComponent";
 
 import ContainerConstants from "../constants/ContainerConstants";
 
-var OptionalContainerVolumesComponent = React.createClass({
-  displayName: "OptionalContainerVolumesComponent",
+var ContainerVolumesComponent = React.createClass({
+  displayName: "ContainerVolumesComponent",
 
   propTypes: {
     fields: React.PropTypes.object.isRequired
@@ -140,4 +140,4 @@ var OptionalContainerVolumesComponent = React.createClass({
   }
 });
 
-export default OptionalContainerVolumesComponent;
+export default ContainerVolumesComponent;

--- a/src/js/components/ContainerVolumesComponent.jsx
+++ b/src/js/components/ContainerVolumesComponent.jsx
@@ -57,7 +57,7 @@ var ContainerVolumesComponent = React.createClass({
     return (
       <div key={row.consecutiveKey} className={rowClassSet}>
         <fieldset className="row duplicable-row"
-          onChange={this.handleChangeContainerVolumes.bind(null, i)}>
+            onChange={this.handleChangeContainerVolumes.bind(null, i)}>
           <div className="col-sm-4">
             <FormGroupComponent
                 fieldId={`containerVolumes.${i}.containerPath`}

--- a/src/js/components/LocalVolumesComponent.jsx
+++ b/src/js/components/LocalVolumesComponent.jsx
@@ -17,7 +17,7 @@ var LocalVolumesComponent = React.createClass({
   mixins: [DuplicableRowsMixin],
 
   duplicableRowsScheme: {
-    containerVolumesLocal: {
+    localVolumes: {
       persistentSize: "",
       containerPath: ""
     }
@@ -27,22 +27,22 @@ var LocalVolumesComponent = React.createClass({
     event.target.blur();
     event.preventDefault();
 
-    this.addRow("containerVolumesLocal", position);
+    this.addRow("localVolumes", position);
   },
 
   handleRemoveRow: function (position, event) {
     event.target.blur();
     event.preventDefault();
 
-    this.removeRow("containerVolumesLocal", position);
+    this.removeRow("localVolumes", position);
   },
 
   handleChange: function (position) {
-    this.updateRow("containerVolumesLocal", position);
+    this.updateRow("localVolumes", position);
   },
 
   getVolumeRow: function (row, i, disableRemoveButton = false) {
-    var error = this.getError("containerVolumesLocal", row.consecutiveKey);
+    var error = this.getError("localVolumes", row.consecutiveKey);
 
     var rowClassSet = classNames({
       "has-error": !!error,
@@ -55,7 +55,7 @@ var LocalVolumesComponent = React.createClass({
             onChange={this.handleChange.bind(null, i)}>
           <div className="col-sm-4">
             <FormGroupComponent
-                fieldId={`containerVolumesLocal.persistent.size.${i}`}
+                fieldId={`localVolumes.persistent.size.${i}`}
                 label="Size (MiB)"
                 value={row.persistentSize}>
               <input ref={`persistentSize${i}`}
@@ -64,7 +64,7 @@ var LocalVolumesComponent = React.createClass({
           </div>
           <div className="col-sm-8">
             <FormGroupComponent
-                fieldId={`containerVolumesLocal.containerPath.${i}`}
+                fieldId={`localVolumes.containerPath.${i}`}
                 label="Container Path"
                 value={row.containerPath}>
               <input ref={`containerPath${i}`} />
@@ -81,7 +81,7 @@ var LocalVolumesComponent = React.createClass({
   },
 
   getVolumesRows: function () {
-    var rows = this.state.rows.containerVolumesLocal;
+    var rows = this.state.rows.localVolumes;
     if (rows == null) {
       return (
         <button type="button">
@@ -91,7 +91,7 @@ var LocalVolumesComponent = React.createClass({
     }
 
     let disableRemoveButton = this.hasOnlyOneSingleEmptyRow(
-      "containerVolumesLocal"
+      "localVolumes"
     );
 
     return rows.map((row, i) => {
@@ -108,7 +108,7 @@ var LocalVolumesComponent = React.createClass({
         <div className="duplicable-list">
           {this.getVolumesRows()}
         </div>
-        {this.getGeneralErrorBlock("containerVolumesLocal")}
+        {this.getGeneralErrorBlock("localVolumes")}
       </div>
     );
   }

--- a/src/js/components/LocalVolumesComponent.jsx
+++ b/src/js/components/LocalVolumesComponent.jsx
@@ -1,0 +1,117 @@
+import classNames from "classnames";
+import React from "react/addons";
+
+import DuplicableRowControls from "../components/DuplicableRowControls";
+import DuplicableRowsMixin from "../mixins/DuplicableRowsMixin";
+import FormGroupComponent from "../components/FormGroupComponent";
+
+var LocalVolumesComponent = React.createClass({
+  displayName: "LocalVolumesComponent",
+
+  propTypes: {
+    errorIndices: React.PropTypes.object.isRequired,
+    fields: React.PropTypes.object.isRequired,
+    getErrorMessage: React.PropTypes.func.isRequired
+  },
+
+  mixins: [DuplicableRowsMixin],
+
+  duplicableRowsScheme: {
+    containerVolumesLocal: {
+      persistentSize: "",
+      containerPath: ""
+    }
+  },
+
+  handleAddRow: function (position, event) {
+    event.target.blur();
+    event.preventDefault();
+
+    this.addRow("containerVolumesLocal", position);
+  },
+
+  handleRemoveRow: function (position, event) {
+    event.target.blur();
+    event.preventDefault();
+
+    this.removeRow("containerVolumesLocal", position);
+  },
+
+  handleChange: function (position) {
+    this.updateRow("containerVolumesLocal", position);
+  },
+
+  getVolumeRow: function (row, i, disableRemoveButton = false) {
+    var error = this.getError("containerVolumesLocal", row.consecutiveKey);
+
+    var rowClassSet = classNames({
+      "has-error": !!error,
+      "duplicable-row": true
+    });
+
+    return (
+      <div key={row.consecutiveKey} className={rowClassSet}>
+        <fieldset className="row duplicable-row"
+            onChange={this.handleChange.bind(null, i)}>
+          <div className="col-sm-4">
+            <FormGroupComponent
+                fieldId={`containerVolumesLocal.persistent.size.${i}`}
+                label="Size (MiB)"
+                value={row.persistentSize}>
+              <input ref={`persistentSize${i}`}
+                type="number"/>
+            </FormGroupComponent>
+          </div>
+          <div className="col-sm-8">
+            <FormGroupComponent
+                fieldId={`containerVolumesLocal.containerPath.${i}`}
+                label="Container Path"
+                value={row.containerPath}>
+              <input ref={`containerPath${i}`} />
+            </FormGroupComponent>
+            <DuplicableRowControls
+              disableRemoveButton={disableRemoveButton}
+              handleAddRow={this.handleAddRow.bind(null, i + 1)}
+              handleRemoveRow={this.handleRemoveRow.bind(null, i)} />
+          </div>
+        </fieldset>
+        {error}
+      </div>
+    );
+  },
+
+  getVolumesRows: function () {
+    var rows = this.state.rows.containerVolumesLocal;
+    if (rows == null) {
+      return (
+        <button type="button">
+          Add a persistent local volume
+        </button>
+      );
+    }
+
+    let disableRemoveButton = this.hasOnlyOneSingleEmptyRow(
+      "containerVolumesLocal"
+    );
+
+    return rows.map((row, i) => {
+      return this.getVolumeRow(row, i, disableRemoveButton);
+    });
+  },
+
+  render: function () {
+    return (
+      <div>
+        <h4>
+          Persistent Local Volumes
+        </h4>
+        <div className="duplicable-list">
+          {this.getVolumesRows()}
+        </div>
+        {this.getGeneralErrorBlock("containerVolumesLocal")}
+      </div>
+    );
+  }
+});
+
+export default LocalVolumesComponent;

--- a/src/js/components/OptionalContainerVolumesComponent.jsx
+++ b/src/js/components/OptionalContainerVolumesComponent.jsx
@@ -1,0 +1,143 @@
+import classNames from "classnames";
+import React from "react/addons";
+
+import DuplicableRowControls from "../components/DuplicableRowControls";
+import DuplicableRowsMixin from "../mixins/DuplicableRowsMixin";
+import FormGroupComponent from "../components/FormGroupComponent";
+
+import ContainerConstants from "../constants/ContainerConstants";
+
+var OptionalVolumesComponent = React.createClass({
+  displayName: "OptionalContainerVolumesComponent",
+
+  propTypes: {
+    fields: React.PropTypes.object.isRequired
+  },
+
+  mixins: [DuplicableRowsMixin],
+
+  duplicableRowsScheme: {
+    containerVolumes: {
+      hostPath: "",
+      containerPath: "",
+      mode: null
+    }
+  },
+
+  handleAddRow: function (position, event) {
+    event.target.blur();
+    event.preventDefault();
+
+    this.addRow("containerVolumes", position);
+  },
+
+  handleRemoveRow: function (position, event) {
+    event.target.blur();
+    event.preventDefault();
+
+    this.removeRow("containerVolumes", position);
+  },
+
+  handleChangeVolumesLocal: function (position) {
+    this.updateRow("containerVolumes", position);
+  },
+
+  handleChangeContainerVolumes: function (position) {
+    this.updateRow("containerVolumes", position);
+  },
+
+  getDockerVolumeRow: function (row, i, disableRemoveButton = false) {
+    var error = this.getError("containerVolumes", row.consecutiveKey);
+
+    var rowClassSet = classNames({
+      "has-error": !!error,
+      "duplicable-row": true
+    });
+
+    return (
+      <div key={row.consecutiveKey} className={rowClassSet}>
+        <fieldset className="row duplicable-row"
+          onChange={this.handleChangeContainerVolumes.bind(null, i)}>
+          <div className="col-sm-4">
+            <FormGroupComponent
+                fieldId={`containerVolumes.${i}.containerPath`}
+                label="Container Path"
+                value={row.containerPath}>
+              <input ref={`containerPath${i}`} />
+            </FormGroupComponent>
+          </div>
+          <div className="col-sm-4">
+            <FormGroupComponent
+                fieldId={`containerVolumes.${i}.hostPath`}
+                label="Host Path"
+                value={row.hostPath}>
+              <input ref={`hostPath${i}`} />
+            </FormGroupComponent>
+          </div>
+          <div className="col-sm-4">
+            <FormGroupComponent
+                fieldId={`containerVolumes.${i}.mode`}
+                label="Mode"
+                value={row.mode}>
+              <select defaultValue="" ref={`mode${i}`}>
+                <option value="">Select</option>
+                <option value={ContainerConstants.VOLUMES.MODE.RO}>
+                  Read Only
+                </option>
+                <option value={ContainerConstants.VOLUMES.MODE.RW}>
+                  Read and Write
+                </option>
+              </select>
+            </FormGroupComponent>
+            <DuplicableRowControls disableRemoveButton={disableRemoveButton}
+              handleAddRow={this.handleAddRow.bind(null, i + 1)}
+              handleRemoveRow={this.handleRemoveRow.bind(null, i)} />
+          </div>
+        </fieldset>
+        {error}
+      </div>
+    );
+  },
+
+  getDockerVolumesRows: function () {
+    var rows = this.state.rows.containerVolumes;
+
+    if (rows == null) {
+      return (
+        <button type="button" className="btn btn-default">
+          Add Docker Volume
+        </button>
+      );
+    }
+
+    let disableRemoveButton = this.hasOnlyOneSingleEmptyRow(
+      "containerVolumes"
+    );
+
+    return rows.map((row, i) => {
+      return this.getDockerVolumeRow(row, i, disableRemoveButton);
+    });
+  },
+
+  render: function () {
+    var dockerImage = this.props.fields.dockerImage;
+
+    if (dockerImage == null || dockerImage === "") {
+      return null;
+    }
+
+    return (
+      <div>
+        <h4>
+          Docker container Volumes
+        </h4>
+        <div className="duplicable-list">
+          {this.getDockerVolumesRows()}
+        </div>
+        {this.getGeneralErrorBlock("containerVolumes")}
+      </div>
+    );
+  }
+});
+
+export default OptionalVolumesComponent;

--- a/src/js/components/OptionalContainerVolumesComponent.jsx
+++ b/src/js/components/OptionalContainerVolumesComponent.jsx
@@ -7,7 +7,7 @@ import FormGroupComponent from "../components/FormGroupComponent";
 
 import ContainerConstants from "../constants/ContainerConstants";
 
-var OptionalVolumesComponent = React.createClass({
+var OptionalContainerVolumesComponent = React.createClass({
   displayName: "OptionalContainerVolumesComponent",
 
   propTypes: {
@@ -129,7 +129,7 @@ var OptionalVolumesComponent = React.createClass({
     return (
       <div>
         <h4>
-          Docker container Volumes
+          Docker Container Volumes
         </h4>
         <div className="duplicable-list">
           {this.getDockerVolumesRows()}
@@ -140,4 +140,4 @@ var OptionalVolumesComponent = React.createClass({
   }
 });
 
-export default OptionalVolumesComponent;
+export default OptionalContainerVolumesComponent;

--- a/src/js/components/OptionalVolumesComponent.jsx
+++ b/src/js/components/OptionalVolumesComponent.jsx
@@ -1,11 +1,9 @@
-import classNames from "classnames";
 import React from "react/addons";
 
-import DuplicableRowControls from "../components/DuplicableRowControls";
-import DuplicableRowsMixin from "../mixins/DuplicableRowsMixin";
-import FormGroupComponent from "../components/FormGroupComponent";
 import ContainerVolumesComponent
   from "../components/ContainerVolumesComponent";
+import LocalVolumesComponent
+  from "../components/LocalVolumesComponent";
 
 var OptionalVolumesComponent = React.createClass({
   displayName: "OptionalVolumesComponent",
@@ -16,101 +14,13 @@ var OptionalVolumesComponent = React.createClass({
     getErrorMessage: React.PropTypes.func.isRequired
   },
 
-  mixins: [DuplicableRowsMixin],
-
-  duplicableRowsScheme: {
-    containerVolumesLocal: {
-      persistentSize: "",
-      containerPath: ""
-    }
-  },
-
-  handleAddRow: function (position, event) {
-    event.target.blur();
-    event.preventDefault();
-
-    this.addRow("containerVolumesLocal", position);
-  },
-
-  handleRemoveRow: function (position, event) {
-    event.target.blur();
-    event.preventDefault();
-
-    this.removeRow("containerVolumesLocal", position);
-  },
-
-  handleChange: function (position) {
-    this.updateRow("containerVolumesLocal", position);
-  },
-
-  getVolumeRow: function (row, i, disableRemoveButton = false) {
-    var error = this.getError("containerVolumesLocal", row.consecutiveKey);
-
-    var rowClassSet = classNames({
-      "has-error": !!error,
-      "duplicable-row": true
-    });
-
-    return (
-      <div key={row.consecutiveKey} className={rowClassSet}>
-        <fieldset className="row duplicable-row"
-            onChange={this.handleChange.bind(null, i)}>
-          <div className="col-sm-4">
-            <FormGroupComponent
-                fieldId={`containerVolumesLocal.persistent.size.${i}`}
-                label="Size (MiB)"
-                value={row.persistentSize}>
-              <input ref={`persistentSize${i}`}
-                type="number"/>
-            </FormGroupComponent>
-          </div>
-          <div className="col-sm-8">
-            <FormGroupComponent
-                fieldId={`containerVolumesLocal.containerPath.${i}`}
-                label="Container Path"
-                value={row.containerPath}>
-              <input ref={`containerPath${i}`} />
-            </FormGroupComponent>
-            <DuplicableRowControls
-              disableRemoveButton={disableRemoveButton}
-              handleAddRow={this.handleAddRow.bind(null, i + 1)}
-              handleRemoveRow={this.handleRemoveRow.bind(null, i)} />
-          </div>
-        </fieldset>
-        {error}
-      </div>
-    );
-  },
-
-  getVolumesRows: function () {
-    var rows = this.state.rows.containerVolumesLocal;
-    if (rows == null) {
-      return (
-        <button type="button">
-          Add a persistent local volume
-        </button>
-      );
-    }
-
-    let disableRemoveButton = this.hasOnlyOneSingleEmptyRow(
-      "containerVolumesLocal"
-    );
-
-    return rows.map((row, i) => {
-      return this.getVolumeRow(row, i, disableRemoveButton);
-    });
-  },
-
   render: function () {
     return (
       <div>
-        <h4>
-          Persistent Local Volumes
-        </h4>
-        <div className="duplicable-list">
-          {this.getVolumesRows()}
-        </div>
-        {this.getGeneralErrorBlock("containerVolumesLocal")}
+        <LocalVolumesComponent
+          errorIndices={this.props.errorIndices}
+          getErrorMessage={this.props.getErrorMessage}
+          fields={this.props.fields} />
         <ContainerVolumesComponent
           errorIndices={this.props.errorIndices}
           getErrorMessage={this.props.getErrorMessage}

--- a/src/js/components/OptionalVolumesComponent.jsx
+++ b/src/js/components/OptionalVolumesComponent.jsx
@@ -4,8 +4,8 @@ import React from "react/addons";
 import DuplicableRowControls from "../components/DuplicableRowControls";
 import DuplicableRowsMixin from "../mixins/DuplicableRowsMixin";
 import FormGroupComponent from "../components/FormGroupComponent";
-import OptionalContainerVolumesComponent
-  from "../components/OptionalContainerVolumesComponent";
+import ContainerVolumesComponent
+  from "../components/ContainerVolumesComponent";
 
 var OptionalVolumesComponent = React.createClass({
   displayName: "OptionalVolumesComponent",
@@ -111,7 +111,7 @@ var OptionalVolumesComponent = React.createClass({
           {this.getVolumesRows()}
         </div>
         {this.getGeneralErrorBlock("containerVolumesLocal")}
-        <OptionalContainerVolumesComponent
+        <ContainerVolumesComponent
           errorIndices={this.props.errorIndices}
           getErrorMessage={this.props.getErrorMessage}
           fields={this.props.fields} />

--- a/src/js/components/OptionalVolumesComponent.jsx
+++ b/src/js/components/OptionalVolumesComponent.jsx
@@ -4,9 +4,17 @@ import React from "react/addons";
 import DuplicableRowControls from "../components/DuplicableRowControls";
 import DuplicableRowsMixin from "../mixins/DuplicableRowsMixin";
 import FormGroupComponent from "../components/FormGroupComponent";
+import OptionalContainerVolumesComponent
+  from "../components/OptionalContainerVolumesComponent";
 
 var OptionalVolumesComponent = React.createClass({
   displayName: "OptionalVolumesComponent",
+
+  propTypes: {
+    errorIndices: React.PropTypes.object.isRequired,
+    fields: React.PropTypes.object.isRequired,
+    getErrorMessage: React.PropTypes.func.isRequired
+  },
 
   mixins: [DuplicableRowsMixin],
 
@@ -103,6 +111,10 @@ var OptionalVolumesComponent = React.createClass({
           {this.getVolumesRows()}
         </div>
         {this.getGeneralErrorBlock("containerVolumesLocal")}
+        <OptionalContainerVolumesComponent
+          errorIndices={this.props.errorIndices}
+          getErrorMessage={this.props.getErrorMessage}
+          fields={this.props.fields} />
       </div>
     );
   }

--- a/src/js/constants/AppFormErrorMessages.js
+++ b/src/js/constants/AppFormErrorMessages.js
@@ -22,7 +22,7 @@ const applicationFieldValidationErrors = Util.deepFreeze({
     "Mode must not be empty",
     "Container Path and Host Path have to be set."
   ],
-  containerVolumesLocal: [
+  localVolumes: [
     "Size must be a non-negative number",
     "Container Path must be a valid path",
     "Container Path and Size have to be set"

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -27,7 +27,7 @@ const defaultFieldValues = Object.freeze({
 
 const duplicableRowFields = [
   "containerVolumes",
-  "containerVolumesLocal",
+  "localVolumes",
   "dockerPortMappings",
   "dockerParameters",
   "env",
@@ -56,10 +56,10 @@ const validationRules = {
     AppFormValidators.containerVolumesModeNotEmpty,
     AppFormValidators.containerVolumesIsNotEmpty
   ],
-  "containerVolumesLocal": [
-    AppFormValidators.containerVolumesLocalSize,
-    AppFormValidators.containerVolumesLocalPath,
-    AppFormValidators.containerVolumesLocalIsNotEmpty
+  "localVolumes": [
+    AppFormValidators.localVolumesSize,
+    AppFormValidators.localVolumesPath,
+    AppFormValidators.localVolumesIsNotEmpty
   ],
   "cpus": [AppFormValidators.cpus],
   "disk": [AppFormValidators.disk],
@@ -101,7 +101,7 @@ const resolveFieldIdToAppKeyMap = {
   cmd: "cmd",
   constraints: "constraints",
   containerVolumes: "container.volumes",
-  containerVolumesLocal: "container.volumes",
+  localVolumes: "container.volumes",
   cpus: "cpus",
   disk: "disk",
   dockerForcePullImage: "container.docker.forcePullImage",
@@ -200,7 +200,7 @@ const resolveAppKeyToFieldIdMap = {
   "container.docker.privileged": ["dockerPrivileged"],
   "container.volumes": [
     "containerVolumes",
-    "containerVolumesLocal"
+    "localVolumes"
   ],
   "healthChecks": ["healthChecks"]
 };

--- a/src/js/stores/transforms/AppFormFieldToModelTransforms.js
+++ b/src/js/stores/transforms/AppFormFieldToModelTransforms.js
@@ -163,13 +163,7 @@ const AppFormFieldToModelTransforms = {
   uris: (uris) => lazy(uris.split(","))
     .map((uri) => uri.trim())
     .filter((uri) => uri != null && uri !== "")
-    .value(),
-  volumes: (volumes) => {
-    return volumes.map(volume => {
-      volume.mode = "RW";
-      return volume;
-    });
-  }
+    .value()
 };
 
 export default Object.freeze(AppFormFieldToModelTransforms);

--- a/src/js/stores/transforms/AppFormFieldToModelTransforms.js
+++ b/src/js/stores/transforms/AppFormFieldToModelTransforms.js
@@ -45,7 +45,7 @@ const AppFormFieldToModelTransforms = {
       })
       .value();
   },
-  containerVolumesLocal: rows => {
+  localVolumes: rows => {
     rows = rows.filter(row => {
       return ["containerPath", "persistentSize"].every(key => {
         return row[key] != null && row[key] !== "";

--- a/src/js/stores/transforms/AppFormModelPostProcess.js
+++ b/src/js/stores/transforms/AppFormModelPostProcess.js
@@ -33,8 +33,8 @@ const AppFormModelPostProcess = {
     }
 
     if ((container.docker == null || container.docker.image == null ||
-      container.docker.image === "") &&
-      container.volumes != null) {
+        container.docker.image === "") &&
+        container.volumes != null) {
       delete container.docker;
       container.volumes = container.volumes.filter(row => {
         return row.hostPath == null;

--- a/src/js/stores/transforms/AppFormModelPostProcess.js
+++ b/src/js/stores/transforms/AppFormModelPostProcess.js
@@ -32,6 +32,15 @@ const AppFormModelPostProcess = {
       return;
     }
 
+    if ((container.docker == null || container.docker.image == null ||
+      container.docker.image === "") &&
+      container.volumes != null) {
+      delete container.docker;
+      container.volumes = container.volumes.filter(row => {
+        return row.hostPath == null;
+      });
+    }
+
     container.type = container.docker != null ? "DOCKER" : "MESOS";
 
     let isEmpty = (Util.isArray(container.volumes) &&

--- a/src/js/stores/transforms/AppFormModelPostProcess.js
+++ b/src/js/stores/transforms/AppFormModelPostProcess.js
@@ -81,36 +81,6 @@ const AppFormModelPostProcess = {
     if (isEmpty) {
       app.healthChecks = [];
     }
-  },
-  volumes: app => {
-    if (app.container == null) {
-      app.container = {
-        type: "MESOS"
-      };
-    }
-    if (app.container.volumes == null) {
-      app.container.volumes = [];
-    }
-
-    app.container.volumes = app.container.volumes.filter(
-      volume => volume.persistent == null
-    );
-
-    app.container.volumes = app.container.volumes.concat(
-      app.volumes.map(
-        volume => {
-          return {
-            containerPath: volume.path,
-            persistent: {
-              size: volume.size
-            },
-            mode: volume.mode
-          };
-        }
-      )
-    );
-
-    delete app.volumes;
   }
 };
 

--- a/src/js/stores/transforms/AppFormModelToFieldTransforms.js
+++ b/src/js/stores/transforms/AppFormModelToFieldTransforms.js
@@ -35,7 +35,7 @@ const AppFormModelToFieldTransforms = {
         return row;
       });
   },
-  containerVolumesLocal: (volumes) => {
+  localVolumes: (volumes) => {
     return volumes
       .filter(row => row.persistent != null)
       .map((row, i) => {

--- a/src/js/stores/validators/AppFormValidators.js
+++ b/src/js/stores/validators/AppFormValidators.js
@@ -159,12 +159,12 @@ const AppFormValidators = {
   ports: (ports) => Util.isStringAndEmpty(ports) ||
     ports.split(",")
       .every((port) => port.toString().trim().match(/^[0-9]+$/)),
-  containerVolumesLocalSize: (obj) =>
+  localVolumesSize: (obj) =>
     Util.isStringAndEmpty(obj.persistentSize) ||
     !!obj.persistentSize.toString().match(/^[0-9\.]+$/),
-  containerVolumesLocalPath: (obj) => isValidPath(obj.containerPath) &&
+  localVolumesPath: (obj) => isValidPath(obj.containerPath) &&
     !obj.containerPath.match(/\//),
-  containerVolumesLocalIsNotEmpty: (obj) =>
+  localVolumesIsNotEmpty: (obj) =>
     (!Util.isStringAndEmpty(obj.persistentSize) &&
     !Util.isStringAndEmpty(obj.containerPath)) ||
     (Util.isStringAndEmpty(obj.persistentSize) &&

--- a/src/test/units/AppFormTransforms.test.js
+++ b/src/test/units/AppFormTransforms.test.js
@@ -76,7 +76,7 @@ describe("App Form Field to Model Transform", function () {
               mode: "RW"
             }
           ];
-          expect(AppFormTransforms.FieldToModel.containerVolumesLocal(
+          expect(AppFormTransforms.FieldToModel.localVolumes(
             localVolumesArray
           )).to.deep.equal(expectedLocalVolumesArray);
         });
@@ -90,7 +90,7 @@ describe("App Form Field to Model Transform", function () {
             }
           ];
           var expectedEmptyArray = [];
-          expect(AppFormTransforms.FieldToModel.containerVolumesLocal(
+          expect(AppFormTransforms.FieldToModel.localVolumes(
             localVolumesArray
           )).to.deep.equal(expectedEmptyArray);
         });
@@ -429,7 +429,7 @@ describe("App Form Model To Field Transform", function () {
             consecutiveKey: 0
           }
         ];
-        expect(AppFormTransforms.ModelToField.containerVolumesLocal(
+        expect(AppFormTransforms.ModelToField.localVolumes(
           containerVolumesWithLocalVolume
         )).to.deep.equal(expectedLocalVolumesArray);
       });
@@ -465,7 +465,7 @@ describe("App Form Model To Field Transform", function () {
             consecutiveKey: 1
           }
         ];
-        expect(AppFormTransforms.ModelToField.containerVolumesLocal(
+        expect(AppFormTransforms.ModelToField.localVolumes(
           containerVolumesWithLocalVolumes
         )).to.deep.equal(expectedLocalVolumesArray);
       });
@@ -506,7 +506,7 @@ describe("App Form Model To Field Transform", function () {
             consecutiveKey: 1
           }
         ];
-        expect(AppFormTransforms.ModelToField.containerVolumesLocal(
+        expect(AppFormTransforms.ModelToField.localVolumes(
           containerVolumesWithMixedVolumes
         )).to.deep.equal(expectedLocalVolumesArray);
       });
@@ -520,7 +520,7 @@ describe("App Form Model To Field Transform", function () {
           }
         ];
         var expectedLocalVolumesArray = [];
-        expect(AppFormTransforms.ModelToField.containerVolumesLocal(
+        expect(AppFormTransforms.ModelToField.localVolumes(
           containerVolumesWithDockerVolume
         )).to.deep.equal(expectedLocalVolumesArray);
       });
@@ -528,7 +528,7 @@ describe("App Form Model To Field Transform", function () {
       it("should return an empty array", function () {
         var containerVolumesWithoutVolume = [];
         var expectedLocalVolumesArray = [];
-        expect(AppFormTransforms.ModelToField.containerVolumesLocal(
+        expect(AppFormTransforms.ModelToField.localVolumes(
           containerVolumesWithoutVolume
         )).to.deep.equal(expectedLocalVolumesArray);
       });

--- a/src/test/units/AppFormValidators.test.js
+++ b/src/test/units/AppFormValidators.test.js
@@ -686,21 +686,21 @@ describe("App Form Validators", function () {
           var volume = {
             persistentSize: "abc"
           };
-          expect(this.validatior.containerVolumesLocalSize(volume)).to.be.false;
+          expect(this.validatior.localVolumesSize(volume)).to.be.false;
         });
 
         it("should be a number value", function () {
           var volume = {
             persistentSize: "1024"
           };
-          expect(this.validatior.containerVolumesLocalSize(volume)).to.be.true;
+          expect(this.validatior.localVolumesSize(volume)).to.be.true;
         });
 
         it("should not be a negative value", function () {
           var volume = {
             persistentSize: "-1024"
           };
-          expect(this.validatior.containerVolumesLocalSize(volume)).to.be.false;
+          expect(this.validatior.localVolumesSize(volume)).to.be.false;
         });
       });
       describe("path", function () {
@@ -708,35 +708,35 @@ describe("App Form Validators", function () {
           var volume = {
             containerPath: ""
           };
-          expect(this.validatior.containerVolumesLocalPath(volume)).to.be.true;
+          expect(this.validatior.localVolumesPath(volume)).to.be.true;
         });
 
         it("should not be a not contain a space", function () {
           var volume = {
             containerPath: "ab c"
           };
-          expect(this.validatior.containerVolumesLocalPath(volume)).to.be.false;
+          expect(this.validatior.localVolumesPath(volume)).to.be.false;
         });
 
         it("should be a string value", function () {
           var volume = {
             containerPath: "abc"
           };
-          expect(this.validatior.containerVolumesLocalPath(volume)).to.be.true;
+          expect(this.validatior.localVolumesPath(volume)).to.be.true;
         });
 
         it("should not contain a slash string value", function () {
           var volume = {
             containerPath: "ab/c"
           };
-          expect(this.validatior.containerVolumesLocalPath(volume)).to.be.false;
+          expect(this.validatior.localVolumesPath(volume)).to.be.false;
         });
 
         it("should not begin with a slash string value", function () {
           var volume = {
             containerPath: "/abc"
           };
-          expect(this.validatior.containerVolumesLocalPath(volume)).to.be.false;
+          expect(this.validatior.localVolumesPath(volume)).to.be.false;
         });
       });
       describe("all fields", function () {
@@ -746,7 +746,7 @@ describe("App Form Validators", function () {
             persistentSize: ""
           };
 
-          expect(this.validatior.containerVolumesLocalIsNotEmpty(volume))
+          expect(this.validatior.localVolumesIsNotEmpty(volume))
             .to.be.false;
         });
 
@@ -756,7 +756,7 @@ describe("App Form Validators", function () {
             persistentSize: "12"
           };
 
-          expect(this.validatior.containerVolumesLocalIsNotEmpty(volume))
+          expect(this.validatior.localVolumesIsNotEmpty(volume))
             .to.be.false;
         });
 
@@ -766,7 +766,7 @@ describe("App Form Validators", function () {
             persistentSize: "12"
           };
 
-          expect(this.validatior.containerVolumesLocalIsNotEmpty(volume))
+          expect(this.validatior.localVolumesIsNotEmpty(volume))
             .to.be.true;
         });
       });

--- a/src/test/units/LocalVolumesComponent.test.jsx
+++ b/src/test/units/LocalVolumesComponent.test.jsx
@@ -9,7 +9,7 @@ describe("Optional Volumes Component", function () {
   describe("(no volume)", () => {
     var component = shallow(
       <LocalVolumesComponent errorIndices={{}}
-        fields={{"containerVolumesLocal": null}}
+        fields={{"localVolumes": null}}
         getErrorMessage={()=>{}}/>
     );
 
@@ -29,12 +29,12 @@ describe("Optional Volumes Component", function () {
     it("should have the right title", () => {
       expect(component.find("h4").first().props().children)
         .to.equal("Persistent Local Volumes");
-    })
+    });
   });
   describe("(one volume)", () => {
     var component = render(
       <LocalVolumesComponent errorIndices={{}}
-        fields={{"containerVolumesLocal": [{
+        fields={{"localVolumes": [{
           consecutiveKey: "0",
           containerPath: "",
           persistentSize: "1024"
@@ -44,7 +44,7 @@ describe("Optional Volumes Component", function () {
 
     it("should have the right size id", () => {
       expect(component.find("input").get(0).attribs.id)
-        .to.equal("containerVolumesLocal.persistent.size.0");
+        .to.equal("localVolumes.persistent.size.0");
     });
 
     it("should have the right size value", () => {
@@ -54,7 +54,7 @@ describe("Optional Volumes Component", function () {
 
     it("should have the right path id", () => {
       expect(component.find("input").get(1).attribs.id)
-        .to.equal("containerVolumesLocal.containerPath.0");
+        .to.equal("localVolumes.containerPath.0");
     });
 
     it("should have the right path value", () => {

--- a/src/test/units/LocalVolumesComponent.test.jsx
+++ b/src/test/units/LocalVolumesComponent.test.jsx
@@ -2,14 +2,14 @@ import {expect} from "chai";
 import {render, shallow} from "enzyme";
 
 import React from "react/addons";
-import OptionalVolumesComponent
-  from "../../js/components/OptionalVolumesComponent.jsx";
+import LocalVolumesComponent
+  from "../../js/components/LocalVolumesComponent.jsx";
 
 describe("Optional Volumes Component", function () {
   describe("(no volume)", () => {
     var component = shallow(
-      <OptionalVolumesComponent errorIndices={{}}
-        fields={{"volumes": null}}
+      <LocalVolumesComponent errorIndices={{}}
+        fields={{"containerVolumesLocal": null}}
         getErrorMessage={()=>{}}/>
     );
 
@@ -33,7 +33,7 @@ describe("Optional Volumes Component", function () {
   });
   describe("(one volume)", () => {
     var component = render(
-      <OptionalVolumesComponent errorIndices={{}}
+      <LocalVolumesComponent errorIndices={{}}
         fields={{"containerVolumesLocal": [{
           consecutiveKey: "0",
           containerPath: "",


### PR DESCRIPTION
This moves the docker container volumes setting from the container section to the volumes section. Docker volumes are only shown if a docker image is set.

![image](https://cloud.githubusercontent.com/assets/156010/13113540/b96762f8-d58f-11e5-857e-d1ad43870adf.png)

![image](https://cloud.githubusercontent.com/assets/156010/13113556/c5a22a1c-d58f-11e5-9623-1c759a93d697.png)


Closes mesosphere/marathon#3239