### PR TITLE
Feature/add navbar mountpoint

### DIFF
--- a/src/css/components/dropdown.less
+++ b/src/css/components/dropdown.less
@@ -56,9 +56,5 @@
         width: 100%;
       }
     }
-
-    .text-danger {
-      color: @text-color-danger-light;
-    }
   }
 }

--- a/src/css/components/dropdown.less
+++ b/src/css/components/dropdown.less
@@ -2,6 +2,11 @@
  * Dropdown
  * ==============
  */
+
+.dropdown-header {
+  font-size: @base-font-size; /* Bootstrap override */
+}
+
 .dropdown {
   margin: 0 0 @base-spacing-unit*2 0;
 

--- a/src/css/layout/text.less
+++ b/src/css/layout/text.less
@@ -2,6 +2,11 @@
  * Text
  * ==============
  */
+
+.text-danger {
+  color: @text-color-danger-light;
+}
+
 .text-warning {
   color: @starship;
 }

--- a/src/js/components/Marathon.jsx
+++ b/src/js/components/Marathon.jsx
@@ -13,6 +13,7 @@ import EditAppModalComponent from "../components/modals/EditAppModalComponent";
 import HelpModalComponent from "../components/modals/HelpModalComponent";
 import NavTabsComponent from "../components/NavTabsComponent";
 import HelpMenuComponent from "./HelpMenuComponent";
+import PluginMountPointComponent from "../components/PluginMountPointComponent";
 
 import AppsActions from "../actions/AppsActions";
 import DeploymentActions from "../actions/DeploymentActions";
@@ -23,6 +24,7 @@ import PluginActions from "../actions/PluginActions";
 import "../plugin/PluginInterface";
 import PluginStore from "../stores/PluginStore";
 import PluginEvents from "../events/PluginEvents";
+import PluginMountPoints from "../plugin/shared/PluginMountPoints";
 
 import tabs from "../constants/tabs";
 
@@ -276,6 +278,8 @@ var Marathon = React.createClass({
             <div className="nav navbar-nav navbar-right">
               <AppListFilterComponent />
               <HelpMenuComponent />
+              <PluginMountPointComponent
+                placeId={PluginMountPoints.NAVBAR_TOP_RIGHT} />
             </div>
           </div>
         </nav>

--- a/src/js/plugin/shared/PluginMountPoints.js
+++ b/src/js/plugin/shared/PluginMountPoints.js
@@ -1,7 +1,8 @@
 import Util from "../../helpers/Util";
 
 const PluginMountPoints = {
-  "SIDEBAR_BOTTOM": "SIDEBAR_BOTTOM"
+  "SIDEBAR_BOTTOM": "SIDEBAR_BOTTOM",
+  "NAVBAR_TOP_RIGHT": "NAVBAR_TOP_RIGHT",
 };
 
 export default Util.fixObject(PluginMountPoints, "PLUGIN_MOUNT_POINTS_");


### PR DESCRIPTION
This PR does a couple of things:

1) Add a navbar mountpoint for plugins
2) Extract text-danger for reuse
3) override bootstrap's default text-size for `.dropdown-header`
