### PR TITLE
Feature - 3240: Add volumes tab to application page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - \#3157 - Filter apps by attached volumes
 - \#3127 - Show groups as part of search results
 - \#966  - Allow creating empty groups
+- \#3240 - Add volumes tab to application page
 
 ### Changed
 - \#3078 - Always show download button for logs

--- a/src/css/components/app-page.less
+++ b/src/css/components/app-page.less
@@ -1,0 +1,9 @@
+/* =========
+ * App Page component
+ */
+.volume-status, .volume-detached {
+  color: @alizarin-crimson;
+}
+.volume-attached {
+  color: @emerald;
+}

--- a/src/css/components/modal.less
+++ b/src/css/components/modal.less
@@ -67,6 +67,25 @@
       height: 30px;
     }
   }
+
+  .tooltip-container {
+    display: inline-block;
+    margin-left: @horizontal-spacing-unit*0.5;
+
+    .icon {
+      opacity: .4;
+    }
+
+    &:hover {
+      .icon {
+        opacity: 1;
+      }
+    }
+
+    .content a {
+      margin-left: @horizontal-spacing-unit*0.5;
+    }
+  }
 }
 
 @media (min-width: 768px) {
@@ -225,6 +244,13 @@
       margin-top:  @modal-body-padding;
       margin-left:  auto;
       margin-right:  auto;
+    }
+    &-link {
+      color: @dodger-blue;
+      text-decoration: underline;
+      &:hover {
+        color: @cornflower-blue;
+      }
     }
   }
 

--- a/src/css/components/volume-list.less
+++ b/src/css/components/volume-list.less
@@ -1,0 +1,12 @@
+/* ==============
+ * Volume List (Table)
+ * ==============
+ */
+.table.volume-list > tbody > tr {
+  & > .volume-detached {
+    color: @alizarin-crimson;
+  }
+  & > .volume-attached {
+    color: @emerald;
+  }
+}

--- a/src/css/layout/list.less
+++ b/src/css/layout/list.less
@@ -10,6 +10,10 @@
   margin-bottom: 0;
 }
 
+.dl-horizontal {
+  overflow: hidden;
+}
+
 @media (min-width: 768px) {
   .dl-horizontal-lg dt {
     width: 190px;

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -18,6 +18,7 @@
 @import "components/app-health-detail.less";
 @import "components/app-list.less";
 @import "components/app-status.less";
+@import "components/app-page.less";
 @import "components/badge.less";
 @import "components/breadcrumb.less";
 @import "components/deployments.less";
@@ -41,5 +42,4 @@
 @import "components/task-list.less";
 @import "components/task-file-list.less";
 @import "components/tooltip.less";
-
-
+@import "components/volume-list.less";

--- a/src/js/actions/AppsActions.js
+++ b/src/js/actions/AppsActions.js
@@ -41,6 +41,13 @@ var AppsActions = {
       });
   },
   createApp: function (newAppAttributes) {
+    if (newAppAttributes.container != null &&
+      newAppAttributes.container.volumes != null) {
+      newAppAttributes.residency = {
+        relaunchEscalationTimeoutSeconds: 10,
+        taskLostBehavior: "WAIT_FOREVER"
+      };
+    }
     this.request({
       method: "POST",
       data: newAppAttributes,

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -16,6 +16,7 @@ import DialogActions from "../actions/DialogActions";
 import DialogStore from "../stores/DialogStore";
 import DialogSeverity from "../constants/DialogSeverity";
 import HealthStatus from "../constants/HealthStatus";
+import LocalVolumesConstants from "../constants/LocalVolumesConstants";
 import Messages from "../constants/Messages";
 import States from "../constants/States";
 import TabPaneComponent from "../components/TabPaneComponent";
@@ -292,7 +293,7 @@ var AppPageComponent = React.createClass({
     }
 
     var className = classNames("volume-status", {
-      "volume-attached": volume.status === "Attached"
+      "volume-attached": volume.status === LocalVolumesConstants.STATUS.ATTACHED
     });
 
     return (

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -296,6 +296,7 @@ var AppPageComponent = React.createClass({
 
               }
               volume.taskId = task.id;
+              volume.host = task.host;
               volume.status = task.status == null
                 ? "Detached"
                 : "Attached";
@@ -338,6 +339,10 @@ var AppPageComponent = React.createClass({
         <dd>
           <a href={taskURI}>{volume.taskId}</a>
         </dd>
+        <dt>Host</dt>
+        <dd>
+          {volume.host}
+        </dd>
       </dl>
     );
   },
@@ -350,6 +355,7 @@ var AppPageComponent = React.createClass({
       if (task.localVolumes != null) {
         return memo.concat(task.localVolumes.map(volume => {
           volume.taskId = task.id;
+          volume.host = task.host;
           volume.status = task.status == null
             ? "Detached"
             : "Attached";

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -11,6 +11,7 @@ import AppVersionsActions from "../actions/AppVersionsActions";
 import AppDebugInfoComponent from "../components/AppDebugInfoComponent";
 import AppVersionListComponent from "../components/AppVersionListComponent";
 import AppVolumesListComponent from "../components/AppVolumesListComponent";
+import VolumeDetailsComponent from "../components/VolumeDetailsComponent";
 import DialogActions from "../actions/DialogActions";
 import DialogStore from "../stores/DialogStore";
 import DialogSeverity from "../constants/DialogSeverity";
@@ -302,40 +303,20 @@ var AppPageComponent = React.createClass({
   getVolumeDetails: function () {
     var {appId, volumeId} = this.state;
 
-    var volume = AppsStore.getVolumeById(appId, volumeId);;
+    var volume = AppsStore.getVolumeById(appId, volumeId);
+
     if (volume == null) {
       return null;
     }
 
-    var taskURI = "#apps/" +
+    volume.taskURI = "#apps/" +
       encodeURIComponent(this.appId) +
       "/" + encodeURIComponent(volume.taskId);
 
-    var appURI = "#apps/" +
+    volume.appURI = "#apps/" +
       encodeURIComponent(this.state.appId);
 
-    return (
-      <dl className={"dl-horizontal"}>
-        <dt>Container Path</dt>
-        <dd>{volume.containerPath}</dd>
-        <dt>Mode</dt>
-        <dd>{volume.mode}</dd>
-        <dt>Size (MiB)</dt>
-        <dd>{volume.persistent.size}</dd>
-        <dt>Application</dt>
-        <dd>
-          <a href={appURI}>{appId}</a>
-        </dd>
-        <dt>Task Id</dt>
-        <dd>
-          <a href={taskURI}>{volume.taskId}</a>
-        </dd>
-        <dt>Host</dt>
-        <dd>
-          {volume.host}
-        </dd>
-      </dl>
-    );
+    return (<VolumeDetailsComponent volume={volume} />);
   },
 
   getAppDetails: function () {

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -320,6 +320,10 @@ var AppPageComponent = React.createClass({
       });
     }
 
+    var taskURI = "#apps/" +
+      encodeURIComponent(this.state.appId) +
+      "/" + encodeURIComponent(volume.taskId);
+
     return (
       <dl className={"dl-horizontal"}>
         <dt>ID</dt>
@@ -331,7 +335,9 @@ var AppPageComponent = React.createClass({
         <dt>Size</dt>
         <dd>{volume.persistent.size}</dd>
         <dt>Task Id</dt>
-        <dd>{volume.taskId}</dd>
+        <dd>
+          <a href={taskURI}>{volume.taskId}</a>
+        </dd>
       </dl>
     );
   },

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -57,7 +57,10 @@ var AppPageComponent = React.createClass({
 
     var appId = decodeURIComponent(params.appId);
     var view = params.view;
-    var volumeId = params.volumeId;
+    var volumeId;
+    if (params.volumeId != null) {
+      volumeId = decodeURIComponent(params.volumeId);
+    }
 
     var activeTabId = `apps/${encodeURIComponent(appId)}`;
 

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -9,6 +9,7 @@ import AppStatusComponent from "../components/AppStatusComponent";
 import AppVersionsActions from "../actions/AppVersionsActions";
 import AppDebugInfoComponent from "../components/AppDebugInfoComponent";
 import AppVersionListComponent from "../components/AppVersionListComponent";
+import AppVolumesListComponent from "../components/AppVolumesListComponent";
 import DialogActions from "../actions/DialogActions";
 import DialogStore from "../stores/DialogStore";
 import DialogSeverity from "../constants/DialogSeverity";
@@ -28,7 +29,8 @@ import TasksEvents from "../events/TasksEvents";
 var tabsTemplate = [
   {id: "apps/:appId", text: "Instances"},
   {id: "apps/:appId/configuration", text: "Configuration"},
-  {id: "apps/:appId/debug", text: "Debug"}
+  {id: "apps/:appId/debug", text: "Debug"},
+  {id: "apps/:appId/volumes", text: "Volumes"}
 ];
 
 var AppPageComponent = React.createClass({
@@ -78,6 +80,8 @@ var AppPageComponent = React.createClass({
       activeTabId += "/configuration";
     } else if (view === "debug") {
       activeTabId += "/debug";
+    } else if (view === "volumes") {
+      activeTabId += "/volumes";
     } else if (view != null) {
       activeTaskId = view;
       activeViewIndex = 1;
@@ -277,11 +281,15 @@ var AppPageComponent = React.createClass({
     var state = this.state;
     var model = state.app;
 
+    var tabs = state.tabs.filter(tab =>
+      tab.text !== "Volumes" ||
+      (model.container != null && model.container.volumes != null));
+
     return (
       <TogglableTabsComponent className="page-body page-body-no-top"
           activeTabId={state.activeTabId}
           onTabClick={this.handleTabClick}
-          tabs={state.tabs} >
+          tabs={tabs} >
         <TabPaneComponent
             id={"apps/" + encodeURIComponent(state.appId)}>
           <TaskViewComponent
@@ -298,6 +306,10 @@ var AppPageComponent = React.createClass({
         <TabPaneComponent
             id={"apps/" + encodeURIComponent(state.appId) + "/debug"}>
           <AppDebugInfoComponent appId={state.appId} />
+        </TabPaneComponent>
+        <TabPaneComponent
+            id={"apps/" + encodeURIComponent(state.appId) + "/volumes"}>
+          <AppVolumesListComponent appId={state.appId} />
         </TabPaneComponent>
       </TogglableTabsComponent>
     );

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -1,4 +1,5 @@
 import React from "react/addons";
+import classNames from "classnames";
 
 import AppsEvents from "../events/AppsEvents";
 import AppsStore from "../stores/AppsStore";
@@ -286,15 +287,22 @@ var AppPageComponent = React.createClass({
       // Get the first volume from a task with the same id as provided
       // by the router. This should be unique.
       .reduce((memo, task) => {
-        return task.localVolumes
-          .filter(volume => volume.persistenceId === volumeId)
-          .reduce((memo, volume) => {
-            if (memo != null) {
-              return memo;
-            }
-            volume.taskId = task.id;
-            return volume;
-          }, null);
+        if (memo == null) {
+          return task.localVolumes
+            .filter(volume => volume.persistenceId === volumeId)
+            .reduce((memo, volume) => {
+              if (memo != null) {
+                return memo;
+
+              }
+              volume.taskId = task.id;
+              volume.status = task.status == null
+                ? "Detached"
+                : "Attached";
+              return volume;
+            }, null);
+        }
+        return memo;
       }, null);
 
     if (volume == null) {
@@ -336,6 +344,9 @@ var AppPageComponent = React.createClass({
       if (task.localVolumes != null) {
         return memo.concat(task.localVolumes.map(volume => {
           volume.taskId = task.id;
+          volume.status = task.status == null
+            ? "Detached"
+            : "Attached";
           return volume;
         }));
       }

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -354,14 +354,21 @@ var AppPageComponent = React.createClass({
       encodeURIComponent(this.state.appId) +
       "/" + encodeURIComponent(volume.taskId);
 
+    var appURI = "#apps/" +
+      encodeURIComponent(this.state.appId);
+
     return (
       <dl className={"dl-horizontal"}>
         <dt>Container Path</dt>
         <dd>{volume.containerPath}</dd>
         <dt>Mode</dt>
         <dd>{volume.mode}</dd>
-        <dt>Size</dt>
+        <dt>Size (MiB)</dt>
         <dd>{volume.persistent.size}</dd>
+        <dt>Application</dt>
+        <dd>
+          <a href={appURI}>{appId}</a>
+        </dd>
         <dt>Task Id</dt>
         <dd>
           <a href={taskURI}>{volume.taskId}</a>

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -67,9 +67,6 @@ var AppPageComponent = React.createClass({
 
     var tabs = tabsTemplate.map(function (tab) {
       var id = tab.id.replace(":appId", encodeURIComponent(appId));
-      if (activeTabId == null) {
-        activeTabId = id;
-      }
 
       return {
         id: id,

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -280,6 +280,9 @@ var AppPageComponent = React.createClass({
   getAppDetails: function () {
     var state = this.state;
     var model = state.app;
+    var volumes = model.container != null
+      ? model.container.volumes
+      : null;
 
     var tabs = state.tabs.filter(tab =>
       tab.text !== "Volumes" ||
@@ -309,7 +312,7 @@ var AppPageComponent = React.createClass({
         </TabPaneComponent>
         <TabPaneComponent
             id={"apps/" + encodeURIComponent(state.appId) + "/volumes"}>
-          <AppVolumesListComponent appId={state.appId} />
+          <AppVolumesListComponent volumes={volumes} />
         </TabPaneComponent>
       </TogglableTabsComponent>
     );

--- a/src/js/components/AppVolumesListComponent.jsx
+++ b/src/js/components/AppVolumesListComponent.jsx
@@ -75,40 +75,18 @@ var AppVolumesListComponent = React.createClass({
       .map(this.getVolumeRow);
   },
 
+  getHighlight: function (sortKey) {
+    return classNames({
+      "cell-highlighted": this.state.sortKey === sortKey
+    });
+  },
+
   render: function () {
     var state = this.state;
 
     var headerClassSet = classNames({
       "clickable": true,
       "dropup": !state.sortDescending
-    });
-
-    var idClassSet = classNames({
-      "cell-highlighted": state.sortKey === "id"
-    });
-
-    var hostClassSet = classNames({
-      "cell-highlighted": state.sortKey === "host"
-    });
-
-    var typeClassSet = classNames({
-      "cell-highlighted": state.sortKey === "type"
-    });
-
-    var containerPathClassSet = classNames({
-      "cell-highlighted": state.sortKey === "containerPath"
-    });
-
-    var sizeClassSet = classNames({
-      "cell-highlighted": state.sortKey === "size"
-    });
-
-    var modeClassSet = classNames({
-      "cell-highlighted": state.sortKey === "mode"
-    });
-
-    var statusClassSet = classNames({
-      "cell-highlighted": state.sortKey === "status"
     });
 
     if (this.props.volumes == null) {
@@ -120,43 +98,43 @@ var AppVolumesListComponent = React.createClass({
         <table className="table table-unstyled volume-list">
           <thead>
             <tr>
-              <th className={idClassSet}>
+              <th className={this.getHighlight("id")}>
                 <span onClick={this.sortBy.bind(null, "id")}
                     className={headerClassSet}>
                   ID {this.getCaret("id")}
                 </span>
               </th>
-              <th className={hostClassSet}>
+              <th className={this.getHighlight("host")}>
                 <span onClick={this.sortBy.bind(null, "host")}
                     className={headerClassSet}>
                   Host{this.getCaret("host")}
                 </span>
               </th>
-              <th className={typeClassSet}>
+              <th className={this.getHighlight("type")}>
                 <span onClick={this.sortBy.bind(null, "type")}
                     className={headerClassSet}>
                   Type {this.getCaret("type")}
                 </span>
               </th>
-              <th className={containerPathClassSet}>
+              <th className={this.getHighlight("containerPath")}>
                 <span onClick={this.sortBy.bind(null, "containerPath")}
                     className={headerClassSet}>
                   Container Path {this.getCaret("containerPath")}
                 </span>
               </th>
-              <th className={sizeClassSet}>
+              <th className={this.getHighlight("size")}>
                 <span onClick={this.sortBy.bind(null, "size")}
                     className={headerClassSet}>
                   Size(MiB) {this.getCaret("size")}
                 </span>
               </th>
-              <th className={modeClassSet}>
+              <th className={this.getHighlight("mode")}>
                 <span onClick={this.sortBy.bind(null, "mode")}
                     className={headerClassSet}>
                   Mode {this.getCaret("mode")}
                 </span>
               </th>
-              <th className={statusClassSet}>
+              <th className={this.getHighlight("status")}>
                 <span onClick={this.sortBy.bind(null, "status")}
                     className={headerClassSet}>
                   Status {this.getCaret("status")}

--- a/src/js/components/AppVolumesListComponent.jsx
+++ b/src/js/components/AppVolumesListComponent.jsx
@@ -1,7 +1,6 @@
 import classNames from "classnames";
 import React from "react/addons";
 
-import AppsStore from "../stores/AppsStore";
 import AppVolumesListItemComponent
   from "../components/AppVolumesListItemComponent";
 
@@ -11,7 +10,7 @@ var AppVolumesListComponent = React.createClass({
   displayName: "AppVolumesListComponent",
 
   propTypes: {
-    appId: React.PropTypes.string.isRequired
+    volumes: React.PropTypes.array
   },
 
   getInitialState: function () {
@@ -49,9 +48,10 @@ var AppVolumesListComponent = React.createClass({
     return null;
   },
 
-  getVolumeRow: function (volume) {
+  getVolumeRow: function (volume, index) {
     return (
       <AppVolumesListItemComponent
+        key={index}
         sortKey={this.state.sortKey}
         volume={volume}/>
     );
@@ -76,7 +76,6 @@ var AppVolumesListComponent = React.createClass({
 
   render: function () {
     var state = this.state;
-    var app = AppsStore.getCurrentApp(this.props.appId);
 
     var headerClassSet = classNames({
       "clickable": true,
@@ -107,15 +106,15 @@ var AppVolumesListComponent = React.createClass({
       "cell-highlighted": state.sortKey === "mode"
     });
 
-    if (app.container == null || app.container.volumes == null) {
+    if (this.props.volumes == null) {
       return null;
     }
 
     return (
       <div>
-        <h4>
+        <h3>
           Volumes
-        </h4>
+        </h3>
         <table className="table table-unstyled task-list">
           <thead>
             <tr>
@@ -158,7 +157,7 @@ var AppVolumesListComponent = React.createClass({
             </tr>
           </thead>
           <tbody>
-            {this.getVolumes(app.container.volumes)}
+            {this.getVolumes(this.props.volumes)}
           </tbody>
         </table>
       </div>

--- a/src/js/components/AppVolumesListComponent.jsx
+++ b/src/js/components/AppVolumesListComponent.jsx
@@ -42,7 +42,7 @@ var AppVolumesListComponent = React.createClass({
     if (volume.hostPath != null) {
       return LocalVolumesConstants.TYPES.DOCKER;
     }
-    if (volume.persistent != null) {
+    if (volume.persistent != null || volume["size"] != null) {
       return LocalVolumesConstants.TYPES.LOCAL;
     }
     return null;
@@ -63,8 +63,9 @@ var AppVolumesListComponent = React.createClass({
     return volumes
       .map((volume) => {
         volume.type = this.getVolumeType(volume);
-        if (volume.type === LocalVolumesConstants.TYPES.LOCAL) {
-          volume.size = volume.persistent.size;
+        if (volume.type === LocalVolumesConstants.TYPES.LOCAL &&
+            volume.size == null) {
+          volume.size = volume.persistent.size ;
           delete volume.persistent;
         }
 

--- a/src/js/components/AppVolumesListComponent.jsx
+++ b/src/js/components/AppVolumesListComponent.jsx
@@ -86,6 +86,10 @@ var AppVolumesListComponent = React.createClass({
       "cell-highlighted": state.sortKey === "id"
     });
 
+    var hostClassSet = classNames({
+      "cell-highlighted": state.sortKey === "host"
+    });
+
     var typeClassSet = classNames({
       "cell-highlighted": state.sortKey === "type"
     });
@@ -123,6 +127,12 @@ var AppVolumesListComponent = React.createClass({
                 <span onClick={this.sortBy.bind(null, "id")}
                     className={headerClassSet}>
                   ID {this.getCaret("id")}
+                </span>
+              </th>
+              <th className={hostClassSet}>
+                <span onClick={this.sortBy.bind(null, "host")}
+                    className={headerClassSet}>
+                  Host{this.getCaret("host")}
                 </span>
               </th>
               <th className={typeClassSet}>

--- a/src/js/components/AppVolumesListComponent.jsx
+++ b/src/js/components/AppVolumesListComponent.jsx
@@ -1,0 +1,169 @@
+import classNames from "classnames";
+import React from "react/addons";
+
+import AppsStore from "../stores/AppsStore";
+import AppVolumesListItemComponent
+  from "../components/AppVolumesListItemComponent";
+
+import Util from "../helpers/Util";
+
+var AppVolumesListComponent = React.createClass({
+  displayName: "AppVolumesListComponent",
+
+  propTypes: {
+    appId: React.PropTypes.string.isRequired
+  },
+
+  getInitialState: function () {
+    return {
+      sortKey: "id",
+      sortDescending: false
+    };
+  },
+
+  getCaret: function (sortKey) {
+    if (sortKey === this.state.sortKey) {
+      return (
+        <span className="caret"></span>
+      );
+    }
+    return null;
+  },
+
+  sortBy: function (sortKey) {
+    var state = this.state;
+
+    this.setState({
+      sortKey: sortKey,
+      sortDescending: state.sortKey === sortKey && !state.sortDescending
+    });
+  },
+
+  getVolumeType: function (volume) {
+    if (volume.hostPath != null) {
+      return "DOCKER";
+    }
+    if (volume.persistent != null) {
+      return "LOCAL";
+    }
+    return null;
+  },
+
+  getVolumeRow: function (volume) {
+    return (
+      <AppVolumesListItemComponent
+        sortKey={this.state.sortKey}
+        volume={volume}/>
+    );
+  },
+
+  getVolumes: function (volumes) {
+    var state = this.state;
+
+    return volumes
+      .map((volume) => {
+        volume.type = this.getVolumeType(volume);
+        if (volume.type === "LOCAL") {
+          volume.size = volume.persistent.size;
+          delete volume.persistent;
+        }
+
+        return volume;
+      })
+      .sort(Util.sortBy(state.sortKey, state.sortDescending))
+      .map(this.getVolumeRow);
+  },
+
+  render: function () {
+    var state = this.state;
+    var app = AppsStore.getCurrentApp(this.props.appId);
+
+    var headerClassSet = classNames({
+      "clickable": true,
+      "dropup": !state.sortDescending
+    });
+
+    var idClassSet = classNames({
+      "cell-highlighted": state.sortKey === "id"
+    });
+
+    var typeClassSet = classNames({
+      "cell-highlighted": state.sortKey === "type"
+    });
+
+    var containerPathClassSet = classNames({
+      "cell-highlighted": state.sortKey === "containerPath"
+    });
+
+    var hostPathClassSet = classNames({
+      "cell-highlighted": state.sortKey === "hostPath"
+    });
+
+    var sizeClassSet = classNames({
+      "cell-highlighted": state.sortKey === "size"
+    });
+
+    var modeClassSet = classNames({
+      "cell-highlighted": state.sortKey === "mode"
+    });
+
+    if (app.container == null || app.container.volumes == null) {
+      return null;
+    }
+
+    return (
+      <div>
+        <h4>
+          Volumes
+        </h4>
+        <table className="table table-unstyled task-list">
+          <thead>
+            <tr>
+              <th className={idClassSet}>
+                <span onClick={this.sortBy.bind(null, "id")}
+                    className={headerClassSet}>
+                  ID {this.getCaret("id")}
+                </span>
+              </th>
+              <th className={typeClassSet}>
+                <span onClick={this.sortBy.bind(null, "type")}
+                    className={headerClassSet}>
+                  Type {this.getCaret("type")}
+                </span>
+              </th>
+              <th className={containerPathClassSet}>
+                <span onClick={this.sortBy.bind(null, "containerPath")}
+                    className={headerClassSet}>
+                  Container Path {this.getCaret("containerPath")}
+                </span>
+              </th>
+              <th className={hostPathClassSet}>
+                <span onClick={this.sortBy.bind(null, "hostPath")}
+                    className={headerClassSet}>
+                  Host Path {this.getCaret("hostPath")}
+                </span>
+              </th>
+              <th className={sizeClassSet}>
+                <span onClick={this.sortBy.bind(null, "size")}
+                    className={headerClassSet}>
+                  Size(MiB) {this.getCaret("size")}
+                </span>
+              </th>
+              <th className={modeClassSet}>
+                <span onClick={this.sortBy.bind(null, "mode")}
+                    className={headerClassSet}>
+                  Mode {this.getCaret("mode")}
+                </span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {this.getVolumes(app.container.volumes)}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+});
+
+export default AppVolumesListComponent;

--- a/src/js/components/AppVolumesListComponent.jsx
+++ b/src/js/components/AppVolumesListComponent.jsx
@@ -3,7 +3,7 @@ import React from "react/addons";
 
 import AppVolumesListItemComponent
   from "../components/AppVolumesListItemComponent";
-
+import LocalVolumesConstants from "../constants/LocalVolumesConstants";
 import Util from "../helpers/Util";
 
 var AppVolumesListComponent = React.createClass({
@@ -40,10 +40,10 @@ var AppVolumesListComponent = React.createClass({
 
   getVolumeType: function (volume) {
     if (volume.hostPath != null) {
-      return "DOCKER";
+      return LocalVolumesConstants.TYPES.DOCKER;
     }
     if (volume.persistent != null) {
-      return "LOCAL";
+      return LocalVolumesConstants.TYPES.LOCAL;
     }
     return null;
   },
@@ -63,7 +63,7 @@ var AppVolumesListComponent = React.createClass({
     return volumes
       .map((volume) => {
         volume.type = this.getVolumeType(volume);
-        if (volume.type === "LOCAL") {
+        if (volume.type === LocalVolumesConstants.TYPES.LOCAL) {
           volume.size = volume.persistent.size;
           delete volume.persistent;
         }

--- a/src/js/components/AppVolumesListComponent.jsx
+++ b/src/js/components/AppVolumesListComponent.jsx
@@ -112,9 +112,6 @@ var AppVolumesListComponent = React.createClass({
 
     return (
       <div>
-        <h3>
-          Volumes
-        </h3>
         <table className="table table-unstyled task-list">
           <thead>
             <tr>

--- a/src/js/components/AppVolumesListComponent.jsx
+++ b/src/js/components/AppVolumesListComponent.jsx
@@ -106,13 +106,17 @@ var AppVolumesListComponent = React.createClass({
       "cell-highlighted": state.sortKey === "mode"
     });
 
+    var statusClassSet = classNames({
+      "cell-highlighted": state.sortKey === "status"
+    });
+
     if (this.props.volumes == null) {
       return null;
     }
 
     return (
       <div>
-        <table className="table table-unstyled task-list">
+        <table className="table table-unstyled volume-list">
           <thead>
             <tr>
               <th className={idClassSet}>
@@ -149,6 +153,12 @@ var AppVolumesListComponent = React.createClass({
                 <span onClick={this.sortBy.bind(null, "mode")}
                     className={headerClassSet}>
                   Mode {this.getCaret("mode")}
+                </span>
+              </th>
+              <th className={statusClassSet}>
+                <span onClick={this.sortBy.bind(null, "status")}
+                    className={headerClassSet}>
+                  Status {this.getCaret("status")}
                 </span>
               </th>
             </tr>

--- a/src/js/components/AppVolumesListComponent.jsx
+++ b/src/js/components/AppVolumesListComponent.jsx
@@ -98,10 +98,6 @@ var AppVolumesListComponent = React.createClass({
       "cell-highlighted": state.sortKey === "containerPath"
     });
 
-    var hostPathClassSet = classNames({
-      "cell-highlighted": state.sortKey === "hostPath"
-    });
-
     var sizeClassSet = classNames({
       "cell-highlighted": state.sortKey === "size"
     });
@@ -145,12 +141,6 @@ var AppVolumesListComponent = React.createClass({
                 <span onClick={this.sortBy.bind(null, "containerPath")}
                     className={headerClassSet}>
                   Container Path {this.getCaret("containerPath")}
-                </span>
-              </th>
-              <th className={hostPathClassSet}>
-                <span onClick={this.sortBy.bind(null, "hostPath")}
-                    className={headerClassSet}>
-                  Host Path {this.getCaret("hostPath")}
                 </span>
               </th>
               <th className={sizeClassSet}>

--- a/src/js/components/AppVolumesListItemComponent.jsx
+++ b/src/js/components/AppVolumesListItemComponent.jsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import React from "react/addons";
+import {Link} from "react-router";
 
 var AppVolumesListItemComponent = React.createClass({
   displayName: "AppVolumesListItemComponent",
@@ -36,10 +37,17 @@ var AppVolumesListItemComponent = React.createClass({
       "cell-highlighted": sortKey === "mode"
     });
 
+    var params = {
+      appId: encodeURIComponent(volume.appId),
+      volumeId: volume.persistenceId
+    };
+
     return (
       <tr>
         <td className={idClassSet}>
-          {volume.id}
+          <Link to="volumeView" params={params}>
+            {volume.persistenceId}
+          </Link>
         </td>
         <td className={typeClassSet}>
           {volume.type}

--- a/src/js/components/AppVolumesListItemComponent.jsx
+++ b/src/js/components/AppVolumesListItemComponent.jsx
@@ -10,32 +10,14 @@ var AppVolumesListItemComponent = React.createClass({
     volume: React.PropTypes.object.isRequired
   },
 
+  getHighlight: function (sortKey) {
+    return classNames({
+      "cell-highlighted": this.props.sortKey === sortKey
+    });
+  },
+
   render: function () {
     var {volume, sortKey} = this.props;
-
-    var idClassSet = classNames({
-      "cell-highlighted": sortKey === "id"
-    });
-
-    var hostClassSet = classNames({
-      "cell-highlighted": sortKey === "host"
-    });
-
-    var typeClassSet = classNames({
-      "cell-highlighted": sortKey === "type"
-    });
-
-    var containerPathClassSet = classNames({
-      "cell-highlighted": sortKey === "containerPath"
-    });
-
-    var sizeClassSet = classNames({
-      "cell-highlighted": sortKey === "size"
-    });
-
-    var modeClassSet = classNames({
-      "cell-highlighted": sortKey === "mode"
-    });
 
     var statusClassSet = classNames({
       "cell-highlighted": sortKey === "status",
@@ -52,24 +34,24 @@ var AppVolumesListItemComponent = React.createClass({
 
     return (
       <tr>
-        <td className={idClassSet}>
+        <td className={this.getHighlight("id")}>
           <Link to="volumeView" params={params}>
             {volume.persistenceId}
           </Link>
         </td>
-        <td className={hostClassSet}>
+        <td className={this.getHighlight("host")}>
           {volume.host}
         </td>
-        <td className={typeClassSet}>
+        <td className={this.getHighlight("type")}>
           {volume.type}
         </td>
-        <td className={containerPathClassSet}>
+        <td className={this.getHighlight("containerPath")}>
           {volume.containerPath}
         </td>
-        <td className={sizeClassSet}>
+        <td className={this.getHighlight("size")}>
           {volume.size}
         </td>
-        <td className={modeClassSet}>
+        <td className={this.getHighlight("mode")}>
           {volume.mode}
         </td>
         <td className={statusClassSet}>

--- a/src/js/components/AppVolumesListItemComponent.jsx
+++ b/src/js/components/AppVolumesListItemComponent.jsx
@@ -29,10 +29,6 @@ var AppVolumesListItemComponent = React.createClass({
       "cell-highlighted": sortKey === "containerPath"
     });
 
-    var hostPathClassSet = classNames({
-      "cell-highlighted": sortKey === "hostPath"
-    });
-
     var sizeClassSet = classNames({
       "cell-highlighted": sortKey === "size"
     });
@@ -69,9 +65,6 @@ var AppVolumesListItemComponent = React.createClass({
         </td>
         <td className={containerPathClassSet}>
           {volume.containerPath}
-        </td>
-        <td className={hostPathClassSet}>
-          {volume.hostPath}
         </td>
         <td className={sizeClassSet}>
           {volume.size}

--- a/src/js/components/AppVolumesListItemComponent.jsx
+++ b/src/js/components/AppVolumesListItemComponent.jsx
@@ -37,6 +37,14 @@ var AppVolumesListItemComponent = React.createClass({
       "cell-highlighted": sortKey === "mode"
     });
 
+    var statusClassSet = classNames({
+      "cell-highlighted": sortKey === "status",
+      "volume-attached": volume.status != null &&
+        volume.status.toLowerCase() === "attached",
+      "volume-detached": volume.status != null &&
+        volume.status.toLowerCase() === "detached"
+    });
+
     var params = {
       appId: encodeURIComponent(volume.appId),
       volumeId: volume.persistenceId
@@ -63,6 +71,9 @@ var AppVolumesListItemComponent = React.createClass({
         </td>
         <td className={modeClassSet}>
           {volume.mode}
+        </td>
+        <td className={statusClassSet}>
+          {volume.status}
         </td>
       </tr>
     );

--- a/src/js/components/AppVolumesListItemComponent.jsx
+++ b/src/js/components/AppVolumesListItemComponent.jsx
@@ -17,6 +17,10 @@ var AppVolumesListItemComponent = React.createClass({
       "cell-highlighted": sortKey === "id"
     });
 
+    var hostClassSet = classNames({
+      "cell-highlighted": sortKey === "host"
+    });
+
     var typeClassSet = classNames({
       "cell-highlighted": sortKey === "type"
     });
@@ -56,6 +60,9 @@ var AppVolumesListItemComponent = React.createClass({
           <Link to="volumeView" params={params}>
             {volume.persistenceId}
           </Link>
+        </td>
+        <td className={hostClassSet}>
+          {volume.host}
         </td>
         <td className={typeClassSet}>
           {volume.type}

--- a/src/js/components/AppVolumesListItemComponent.jsx
+++ b/src/js/components/AppVolumesListItemComponent.jsx
@@ -51,7 +51,7 @@ var AppVolumesListItemComponent = React.createClass({
 
     var params = {
       appId: encodeURIComponent(volume.appId),
-      volumeId: volume.persistenceId
+      volumeId: encodeURIComponent(volume.persistenceId)
     };
 
     return (

--- a/src/js/components/AppVolumesListItemComponent.jsx
+++ b/src/js/components/AppVolumesListItemComponent.jsx
@@ -1,0 +1,64 @@
+import classNames from "classnames";
+import React from "react/addons";
+
+var AppVolumesListItemComponent = React.createClass({
+  displayName: "AppVolumesListItemComponent",
+
+  propTypes: {
+    sortKey: React.PropTypes.string.isRequired,
+    volume: React.PropTypes.object.isRequired
+  },
+
+  render: function () {
+    var {volume, sortKey} = this.props;
+
+    var idClassSet = classNames({
+      "cell-highlighted": sortKey === "id"
+    });
+
+    var typeClassSet = classNames({
+      "cell-highlighted": sortKey === "type"
+    });
+
+    var containerPathClassSet = classNames({
+      "cell-highlighted": sortKey === "containerPath"
+    });
+
+    var hostPathClassSet = classNames({
+      "cell-highlighted": sortKey === "hostPath"
+    });
+
+    var sizeClassSet = classNames({
+      "cell-highlighted": sortKey === "size"
+    });
+
+    var modeClassSet = classNames({
+      "cell-highlighted": sortKey === "mode"
+    });
+
+    return (
+      <tr>
+        <td className={idClassSet}>
+          {volume.id}
+        </td>
+        <td className={typeClassSet}>
+          {volume.type}
+        </td>
+        <td className={containerPathClassSet}>
+          {volume.containerPath}
+        </td>
+        <td className={hostPathClassSet}>
+          {volume.hostPath}
+        </td>
+        <td className={sizeClassSet}>
+          {volume.size}
+        </td>
+        <td className={modeClassSet}>
+          {volume.mode}
+        </td>
+      </tr>
+    );
+  }
+});
+
+export default AppVolumesListItemComponent;

--- a/src/js/components/BreadcrumbComponent.jsx
+++ b/src/js/components/BreadcrumbComponent.jsx
@@ -14,7 +14,8 @@ var BreadcrumbComponent = React.createClass({
   propTypes: {
     appId: React.PropTypes.string,
     groupId: React.PropTypes.string,
-    taskId: React.PropTypes.string
+    taskId: React.PropTypes.string,
+    volumeId: React.PropTypes.string
   },
 
   getInitialState: function () {
@@ -61,6 +62,7 @@ var BreadcrumbComponent = React.createClass({
   didPropsChange: function (nextProps) {
     return nextProps.appId !== this.props.appId ||
       nextProps.groupId !== this.props.groupId ||
+      nextProps.volumeId !== this.props.volumeId ||
       nextProps.taskId !== this.props.taskId;
   },
 
@@ -213,6 +215,27 @@ var BreadcrumbComponent = React.createClass({
     );
   },
 
+  getVolumeLink: function () {
+    var appId = this.props.appId;
+    var volumeId = this.props.volumeId;
+    if (volumeId == null || appId == null) {
+      return null;
+    }
+
+    var params = {
+      appId: encodeURIComponent(appId),
+      volumeId: volumeId
+    };
+
+    return (
+      <li>
+        <Link to="volumeView" params={params}>
+          {volumeId}
+        </Link>
+      </li>
+    );
+  },
+
   render: function () {
     var classSet = classNames({
       breadcrumb: true,
@@ -227,6 +250,7 @@ var BreadcrumbComponent = React.createClass({
         {this.getGroupLinks()}
         {this.getAppLink()}
         {this.getTaskLink()}
+        {this.getVolumeLink()}
       </ol>
     );
   }

--- a/src/js/components/BreadcrumbComponent.jsx
+++ b/src/js/components/BreadcrumbComponent.jsx
@@ -224,7 +224,7 @@ var BreadcrumbComponent = React.createClass({
 
     var params = {
       appId: encodeURIComponent(appId),
-      volumeId: volumeId
+      volumeId: encodeURIComponent(volumeId)
     };
 
     return (

--- a/src/js/components/FormGroupComponent.jsx
+++ b/src/js/components/FormGroupComponent.jsx
@@ -12,7 +12,10 @@ var FormGroupComponent = React.createClass({
     errorMessage: React.PropTypes.string,
     fieldId: React.PropTypes.string,
     help: React.PropTypes.string,
-    label: React.PropTypes.string,
+    label: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.element
+    ]),
     onChange: React.PropTypes.func
   },
 

--- a/src/js/components/LocalVolumesComponent.jsx
+++ b/src/js/components/LocalVolumesComponent.jsx
@@ -4,6 +4,9 @@ import React from "react/addons";
 import DuplicableRowControls from "../components/DuplicableRowControls";
 import DuplicableRowsMixin from "../mixins/DuplicableRowsMixin";
 import FormGroupComponent from "../components/FormGroupComponent";
+import TooltipComponent from "../components/TooltipComponent";
+
+import ExternalLinks from "../constants/ExternalLinks";
 
 var LocalVolumesComponent = React.createClass({
   displayName: "LocalVolumesComponent",
@@ -49,6 +52,23 @@ var LocalVolumesComponent = React.createClass({
       "duplicable-row": true
     });
 
+    var containerPathTooltipMessage = (
+      <span>
+        Set any path you like, it will be available in your
+        working directory e.g. home
+        <a href={ExternalLinks.CONTAINER_PATH} target="_blank">Read more</a>.
+      </span>
+    );
+
+    var containerPathLabel = (
+      <span>
+        Container Path
+        <TooltipComponent message={containerPathTooltipMessage}>
+          <i className="icon icon-xs help" />
+        </TooltipComponent>
+      </span>
+    );
+
     return (
       <div key={row.consecutiveKey} className={rowClassSet}>
         <fieldset className="row duplicable-row"
@@ -65,7 +85,7 @@ var LocalVolumesComponent = React.createClass({
           <div className="col-sm-8">
             <FormGroupComponent
                 fieldId={`localVolumes.containerPath.${i}`}
-                label="Container Path"
+                label={containerPathLabel}
                 value={row.containerPath}>
               <input ref={`containerPath${i}`} />
             </FormGroupComponent>
@@ -100,10 +120,20 @@ var LocalVolumesComponent = React.createClass({
   },
 
   render: function () {
+    var localVolumesTooltipMessage = (
+      <span>
+        Local volumes hold state if an instance is shut down.
+        <a href={ExternalLinks.LOCAL_VOLUMES} target="_blank">Read more</a>.
+      </span>
+    );
+
     return (
       <div>
-        <h4>
+        <h4 className="subtitle">
           Persistent Local Volumes
+          <TooltipComponent message={localVolumesTooltipMessage}>
+            <i className="icon icon-xs help" />
+          </TooltipComponent>
         </h4>
         <div className="duplicable-list">
           {this.getVolumesRows()}

--- a/src/js/components/TaskDetailComponent.jsx
+++ b/src/js/components/TaskDetailComponent.jsx
@@ -288,6 +288,9 @@ var TaskDetailComponent = React.createClass({
               );
               volume.appId = app.id;
               volume.taskId = task.id;
+              volume.status = task.status == null
+                ? "Detached"
+                : "Attached";
             }
           });
           return volume;

--- a/src/js/components/TaskDetailComponent.jsx
+++ b/src/js/components/TaskDetailComponent.jsx
@@ -288,6 +288,7 @@ var TaskDetailComponent = React.createClass({
               );
               volume.appId = app.id;
               volume.taskId = task.id;
+              volume.host = task.host;
               volume.status = task.status == null
                 ? "Detached"
                 : "Attached";

--- a/src/js/components/TaskDetailComponent.jsx
+++ b/src/js/components/TaskDetailComponent.jsx
@@ -274,7 +274,7 @@ var TaskDetailComponent = React.createClass({
     var volumes = AppsStore.getVolumes(appId);
 
     if (volumes != null) {
-      volumes = volumes.filter(volume => volume.taskId = task.id);
+      volumes = volumes.filter(volume => volume.taskId === task.id);
     }
 
     return (

--- a/src/js/components/TaskDetailComponent.jsx
+++ b/src/js/components/TaskDetailComponent.jsx
@@ -246,7 +246,6 @@ var TaskDetailComponent = React.createClass({
 
   getTabs: function (task) {
     var appId = this.props.appId;
-    var app = AppsStore.getCurrentApp(appId);
 
     var activeTabId =
       `apps/${encodeURIComponent(appId)}/${encodeURIComponent(task.id)}`;
@@ -272,30 +271,10 @@ var TaskDetailComponent = React.createClass({
       activeTabId = activeTab;
     }
 
-    var volumes = [];
+    var volumes = AppsStore.getVolumes(appId);
 
-    if (task.localVolumes != null) {
-      volumes = task.localVolumes
-        .map(volume => {
-          if (app.container == null || app.container.volumes == null) {
-            return null;
-          }
-          app.container.volumes.forEach(function (volumeConfig) {
-            if (volumeConfig.containerPath &&
-                volumeConfig.containerPath === volume.containerPath) {
-              Object.keys(volumeConfig).forEach(key =>
-                volume[key] = volumeConfig[key]
-              );
-              volume.appId = app.id;
-              volume.taskId = task.id;
-              volume.host = task.host;
-              volume.status = task.status == null
-                ? "Detached"
-                : "Attached";
-            }
-          });
-          return volume;
-        });
+    if (volumes != null) {
+      volumes = volumes.filter(volume => volume.taskId = task.id);
     }
 
     return (

--- a/src/js/components/TaskDetailComponent.jsx
+++ b/src/js/components/TaskDetailComponent.jsx
@@ -268,7 +268,7 @@ var TaskDetailComponent = React.createClass({
     if (activeTab === "volumes") {
       activeTabId += "/volumes";
     } else if (activeTab != null) {
-      activeTaskId = activeTab;
+      activeTabId = activeTab;
     }
 
     task.volumes = [
@@ -303,9 +303,7 @@ var TaskDetailComponent = React.createClass({
       if (volume.containerPath == null) {
         return memo;
       }
-      console.log(volume);
       memo[volume.containerPath] = volume;
-      console.log(memo);
       return memo;
     }, {});
 
@@ -314,15 +312,12 @@ var TaskDetailComponent = React.createClass({
       return appVolumes[taskVolume.containerPath];
     });
 
-    console.log(volumes);
-
     return (
       <TogglableTabsComponent className="page-body page-body-no-top"
           activeTabId={activeTabId}
           tabs={tabs} >
         <TabPaneComponent
             id={tabs[0].id}>
-            <h3>Working Directory</h3>
             <TaskFileListComponent task={task} />
         </TabPaneComponent>
         <TabPaneComponent

--- a/src/js/components/TaskListItemComponent.jsx
+++ b/src/js/components/TaskListItemComponent.jsx
@@ -154,9 +154,16 @@ var TaskListItemComponent = React.createClass({
     var task = this.props.task;
     var sortKey = this.props.sortKey;
     var hasHealth = !!this.props.hasHealth;
-    var version = task.version == null
-      ? null
-      : new Date(task.version).toISOString();
+    var version;
+    var endpoints;
+    var status = "Waiting";
+
+    if (task.status != null) {
+      var version = new Date(task.version).toISOString();
+      var endpoints = this.getEndpoints();
+      var status = task.status;
+    }
+
     var taskId = task.id;
     var taskURI = "#apps/" +
       encodeURIComponent(this.props.appId) +
@@ -218,14 +225,14 @@ var TaskListItemComponent = React.createClass({
         <td className={idClassSet}>
           <a href={taskURI}>{taskId}</a>
           <br />
-          {this.getEndpoints()}
+          {endpoints}
         </td>
         <td className={healthClassSet} title={this.props.taskHealthMessage}>
           {this.props.taskHealthMessage}
         </td>
         <td className={statusCellClassSet}>
           <span className={statusClassSet}>
-            {task.status}
+            {status}
           </span>
         </td>
         <td className="text-center">
@@ -236,7 +243,7 @@ var TaskListItemComponent = React.createClass({
         </td>
         <td className={versionClassSet}>
           <span title={version}>
-            {new Moment(version).fromNow()}
+            {version && new Moment(version).fromNow() || "---"}
           </span>
         </td>
         <td className={updatedAtClassSet}>

--- a/src/js/components/VolumeDetailsComponent.jsx
+++ b/src/js/components/VolumeDetailsComponent.jsx
@@ -1,0 +1,37 @@
+import React from "react/addons";
+
+export default React.createClass({
+  displayName: "VolumeDetailsComponent",
+  propTypes: {
+    volume: React.PropTypes.object
+  },
+  render: function () {
+    const {volume} = this.props;
+    if (volume == null) {
+      return null;
+    }
+
+    return (
+      <dl className={"dl-horizontal"}>
+        <dt>Container Path</dt>
+        <dd>{volume.containerPath}</dd>
+        <dt>Mode</dt>
+        <dd>{volume.mode}</dd>
+        <dt>Size (MiB)</dt>
+        <dd>{volume.persistent.size}</dd>
+        <dt>Application</dt>
+        <dd>
+          <a href={volume.appURI}>{volume.appId}</a>
+        </dd>
+        <dt>Task Id</dt>
+        <dd>
+          <a href={volume.taskURI}>{volume.taskId}</a>
+        </dd>
+        <dt>Host</dt>
+        <dd>
+          {volume.host}
+        </dd>
+      </dl>
+    );
+  }
+});

--- a/src/js/constants/ExternalLinks.js
+++ b/src/js/constants/ExternalLinks.js
@@ -2,7 +2,9 @@ const ExternalLinks = {
   DOCS_STATUS: "https://mesosphere.github.io/marathon/docs/" +
     "marathon-ui.html#application-status-reference",
   DOCS_HEALTH: "https://mesosphere.github.io/marathon/docs/" +
-    "marathon-ui.html#application-health-reference"
+    "marathon-ui.html#application-health-reference",
+  LOCAL_VOLUMES: "about:blank",
+  CONTAINER_PATH: "about:blank"
 };
 
 export default Object.freeze(ExternalLinks);

--- a/src/js/constants/LocalVolumesConstants.js
+++ b/src/js/constants/LocalVolumesConstants.js
@@ -1,0 +1,12 @@
+const LocalVolumesConstants = {
+  TYPES: {
+    DOCKER: "DOCKER",
+    LOCAL: "LOCAL"
+  },
+  STATUS: {
+    ATTACHED: "Attached",
+    DETACHED: "Detached"
+  }
+};
+
+export default Object.freeze(LocalVolumesConstants);

--- a/src/js/helpers/Util.js
+++ b/src/js/helpers/Util.js
@@ -108,6 +108,18 @@ var Util = {
 
     return paths;
   },
+  sortBy: function (key, sortDescending = false) {
+    sortDescending = sortDescending ? -1 : 1;
+    return function (a, b) {
+      if (a[key] > b[key] || a[key] == null) {
+        return 1 * sortDescending;
+      }
+      if (a[key] < b[key] || b[key] == null) {
+        return -1 * sortDescending;
+      }
+      return 0;
+    };
+  },
   objectPathSet: function (obj, path, value) {
     var [initialKey] = path.split(".");
 

--- a/src/js/main.jsx
+++ b/src/js/main.jsx
@@ -12,6 +12,8 @@ var routes = (
     <Route name="group" path="group/:groupId" handler={TabPanesComponent} />
     <Route name="app" path="apps/:appId" handler={AppPageComponent} />
     <Route name="appView" path="apps/:appId/:view" handler={AppPageComponent} />
+    <Route name="volumeView" path="apps/:appId/volume/:volumeId"
+      handler={AppPageComponent} />
     <Route name="taskView" path="apps/:appId/:view/:tab"
       handler={AppPageComponent} />
     <Route name="deployments" path="deployments" handler={TabPanesComponent} />

--- a/src/js/main.jsx
+++ b/src/js/main.jsx
@@ -12,6 +12,8 @@ var routes = (
     <Route name="group" path="group/:groupId" handler={TabPanesComponent} />
     <Route name="app" path="apps/:appId" handler={AppPageComponent} />
     <Route name="appView" path="apps/:appId/:view" handler={AppPageComponent} />
+    <Route name="taskView" path="apps/:appId/:view/:tab"
+      handler={AppPageComponent} />
     <Route name="deployments" path="deployments" handler={TabPanesComponent} />
     <Redirect from="/" to="apps" />
     <NotFoundRoute name="404" handler={PageNotFoundComponent} />

--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -217,6 +217,57 @@ var AppsStore = Util.extendObject(EventEmitter.prototype, {
     return Util.deepCopy(
       this.getCurrentApp(appId).tasks.find(task => task.id === taskId)
     );
+  },
+
+  getVolumeById: function (appId, volumeId) {
+    var volumes = this.getVolumes(appId);
+
+    if (volumes == null) {
+      return null;
+    }
+
+    return volumes.reduce((memo, volume) => {
+      if (volume.persistenceId === volumeId) {
+        return volume;
+      }
+      return memo;
+    }, null);
+  },
+
+  getVolumes: function (appId) {
+    var app = this.getCurrentApp(appId);
+    var tasks = app.tasks;
+
+    if (tasks == null) {
+      return null;
+    }
+
+    return tasks
+      // Get the first volume from a task with the same id as provided
+      // by the router. This should be unique.
+      .reduce((memo, task) => {
+        if (task.localVolumes == null) {
+          return memo;
+        }
+        return memo.concat(task.localVolumes
+          .map((volume) => {
+            app.container.volumes.forEach(function (volumeConfig) {
+              if (volumeConfig.containerPath &&
+                  volumeConfig.containerPath === volume.containerPath) {
+                Object.keys(volumeConfig).forEach(key =>
+                  volume[key] = volumeConfig[key]
+                );
+              }
+            });
+            volume.appId = appId;
+            volume.taskId = task.id;
+            volume.host = task.host;
+            volume.status = task.status == null
+              ? "Detached"
+              : "Attached";
+            return volume;
+          }));
+      }, []);
   }
 });
 

--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -7,6 +7,7 @@ import AppTypes from "../constants/AppTypes";
 import ContainerConstants from "../constants/ContainerConstants";
 import AppStatus from "../constants/AppStatus";
 import HealthStatus from "../constants/HealthStatus";
+import LocalVolumesConstants from "../constants/LocalVolumesConstants";
 import TasksEvents from "../events/TasksEvents";
 import TaskStatus from "../constants/TaskStatus";
 import QueueStore from "./QueueStore";
@@ -263,8 +264,8 @@ var AppsStore = Util.extendObject(EventEmitter.prototype, {
             volume.taskId = task.id;
             volume.host = task.host;
             volume.status = task.status == null
-              ? "Detached"
-              : "Attached";
+              ? LocalVolumesConstants.STATUS.DETACHED
+              : LocalVolumesConstants.STATUS.ATTACHED;
             return volume;
           }));
       }, []);

--- a/src/test/scenarios/displayTaskDetails.test.js
+++ b/src/test/scenarios/displayTaskDetails.test.js
@@ -26,14 +26,23 @@ describe("TaskDetailComponent", function () {
     host: "example.com"
   };
 
+  var context = {
+    router: {
+      getCurrentParams: function () {
+        return {tab: ""};
+      }
+    }
+  };
+
   before(function () {
     this.model = Object.assign({}, baseModel);
 
     this.component = shallow(
       <TaskDetailComponent appId={this.model.appId}
-                           fetchState={States.STATE_SUCCESS}
-                           hasHealth={false}
-                           task={this.model} />
+         fetchState={States.STATE_SUCCESS}
+         hasHealth={false}
+         task={this.model} />,
+       {context}
     );
   });
 
@@ -69,11 +78,13 @@ describe("TaskDetailComponent", function () {
   });
 
   it("has a loading error", function () {
-    var component = shallow(<TaskDetailComponent
-      appId={this.model.appId}
-      fetchState={States.STATE_ERROR}
-      hasHealth={false}
-      task={this.model} />);
+    var component = shallow(
+      <TaskDetailComponent
+        appId={this.model.appId}
+        fetchState={States.STATE_ERROR}
+        hasHealth={false}
+        task={this.model} />,
+      {context});
     expect(component.find(".text-danger").length).to.equal(1);
   });
 
@@ -86,9 +97,10 @@ describe("TaskDetailComponent", function () {
 
       this.component = shallow(
         <TaskDetailComponent appId={this.model.appId}
-                             fetchState={States.STATE_SUCCESS}
-                             hasHealth={false}
-                             task={this.model} />
+            fetchState={States.STATE_SUCCESS}
+            hasHealth={false}
+            task={this.model} />,
+          {context}
       );
     });
 
@@ -159,9 +171,10 @@ describe("TaskDetailComponent", function () {
 
         this.component = shallow(
           <TaskDetailComponent appId={this.model.appId}
-                               fetchState={States.STATE_SUCCESS}
-                               hasHealth={false}
-                               task={this.model} />
+             fetchState={States.STATE_SUCCESS}
+             hasHealth={false}
+             task={this.model} />,
+           {context}
         );
         done();
       });

--- a/src/test/units/AppPageComponent.test.js
+++ b/src/test/units/AppPageComponent.test.js
@@ -2,6 +2,7 @@ import {expect} from "chai";
 import {shallow} from "enzyme";
 import nock from "nock";
 import expectAsync from "./../helpers/expectAsync";
+import sinon from "sinon";
 
 import config from "../../js/config/config";
 
@@ -14,6 +15,7 @@ import AppsStore from "../../js/stores/AppsStore";
 import AppStatus from "../../js/constants/AppStatus";
 import AppPageComponent from "../../js/components/AppPageComponent";
 import States from "../../js/constants/States";
+import TaskViewComponent from "../../js/components/TaskViewComponent";
 
 describe("AppPageComponent", function () {
 
@@ -124,5 +126,38 @@ describe("AppPageComponent", function () {
       AppsActions.requestApps();
     });
 
+  });
+  describe("on app request Error sets the right state", function () {
+    it("State Unauthorized", function () {
+      // this.component.onAppRequestError(null, 401);
+      this.component.instance().onAppRequestError(null, 401);
+      expect(this.component.state("fetchState"))
+        .to.equal(States.STATE_UNAUTHORIZED);
+    });
+
+    it("State Unauthorized", function () {
+      // this.component.onAppRequestError(null, 401);
+      this.component.instance().onAppRequestError(null, 403);
+      expect(this.component.state("fetchState"))
+        .to.equal(States.STATE_FORBIDDEN);
+    });
+  });
+  describe("on delete app succes ", function () {
+    it("transitions to 'apps'", function () {
+      var transitionSpy = sinon.spy();
+      var context = {
+        router: {
+          transitionTo: transitionSpy,
+          getCurrentParams: function () {
+            return {
+              appId: "/test-app-1"
+            };
+          }
+        }
+      };
+      var component = shallow(<AppPageComponent />, {context});
+      component.instance().onDeleteAppSuccess();
+      expect(transitionSpy.called).to.be.true;
+    });
   });
 });

--- a/src/test/units/AppPageComponent.test.js
+++ b/src/test/units/AppPageComponent.test.js
@@ -129,14 +129,12 @@ describe("AppPageComponent", function () {
   });
   describe("on app request Error sets the right state", function () {
     it("State Unauthorized", function () {
-      // this.component.onAppRequestError(null, 401);
       this.component.instance().onAppRequestError(null, 401);
       expect(this.component.state("fetchState"))
         .to.equal(States.STATE_UNAUTHORIZED);
     });
 
     it("State Unauthorized", function () {
-      // this.component.onAppRequestError(null, 401);
       this.component.instance().onAppRequestError(null, 403);
       expect(this.component.state("fetchState"))
         .to.equal(States.STATE_FORBIDDEN);

--- a/src/test/units/AppVolumesListComponent.test.js
+++ b/src/test/units/AppVolumesListComponent.test.js
@@ -17,7 +17,8 @@ describe("AppVolumesListComponent", () => {
       persistent: {
         size: "1536"
       },
-      mode: "XX"
+      mode: "XX",
+      status: "attached"
     },
     {
       appId: "stu",
@@ -25,7 +26,8 @@ describe("AppVolumesListComponent", () => {
       persistenceId: "x.y.z",
       containerPath: "path",
       hostPath: "Hpath",
-      mode: "XX"
+      mode: "XX",
+      status: "detached"
     }
   ];
   var component = shallow(
@@ -39,7 +41,8 @@ describe("AppVolumesListComponent", () => {
     "type",
     "containerPath",
     "size",
-    "mode"
+    "mode",
+    "status"
   ];
 
   it("contains the right LOCAL volume list item", () => {

--- a/src/test/units/AppVolumesListComponent.test.js
+++ b/src/test/units/AppVolumesListComponent.test.js
@@ -11,6 +11,7 @@ describe("AppVolumesListComponent", () => {
   var volumes = [
     {
       appId: "stu",
+      host: "127.0.0.1",
       persistenceId: "x.y.z",
       containerPath: "path",
       persistent: {
@@ -20,6 +21,7 @@ describe("AppVolumesListComponent", () => {
     },
     {
       appId: "stu",
+      host: "127.0.0.1",
       persistenceId: "x.y.z",
       containerPath: "path",
       hostPath: "Hpath",
@@ -33,6 +35,7 @@ describe("AppVolumesListComponent", () => {
 
   var sortKeys = [
     "id",
+    "host",
     "type",
     "containerPath",
     "hostPath",
@@ -96,7 +99,7 @@ describe("AppVolumesListComponent", () => {
       });
     });
   });
-  
+
   describe("if no volumes are provided", () => {
     var component = shallow(
       <AppVolumesListComponent />

--- a/src/test/units/AppVolumesListComponent.test.js
+++ b/src/test/units/AppVolumesListComponent.test.js
@@ -1,0 +1,109 @@
+import {expect} from "chai";
+import {shallow} from "enzyme";
+
+import React from "react/addons";
+import AppVolumesListComponent
+  from "../../js/components/AppVolumesListComponent";
+import AppVolumesListItemComponent
+  from "../../js/components/AppVolumesListItemComponent";
+
+describe("AppVolumesListComponent", () => {
+  var volumes = [
+    {
+      appId: "stu",
+      persistenceId: "x.y.z",
+      containerPath: "path",
+      persistent: {
+        size: "1536"
+      },
+      mode: "XX"
+    },
+    {
+      appId: "stu",
+      persistenceId: "x.y.z",
+      containerPath: "path",
+      hostPath: "Hpath",
+      mode: "XX"
+    }
+  ];
+  var component = shallow(
+    <AppVolumesListComponent
+      volumes={volumes} />
+  );
+
+  var sortKeys = [
+    "id",
+    "type",
+    "containerPath",
+    "hostPath",
+    "size",
+    "mode"
+  ];
+
+  it("contains the right LOCAL volume list item", () => {
+    expect(component.contains(
+      <AppVolumesListItemComponent
+        key={0}
+        volume={volumes[0]}
+        sortKey="id" />)).to.be.true;
+  });
+
+  it("contains the right DOCKER volume list item", () => {
+    expect(component.contains(
+      <AppVolumesListItemComponent
+        key={1}
+        volume={volumes[1]}
+        sortKey="id" />)).to.be.true;
+  });
+
+  it("Should contain 2 volumes", () => {
+    expect(component.find(AppVolumesListItemComponent)).to.have.length(2);
+  });
+
+  describe("changes sort state", () => {
+    it("should change sort direction if same sortKey is provided twice", () => {
+      component.setState({
+        sortKey: "id",
+        sortDescending: false
+      });
+      component.instance().sortBy("id");
+      expect(component.state("sortDescending")).to.be.true;
+    });
+
+    it("should change sort key to provided key", () => {
+      component.setState({
+        sortKey: "id",
+        sortDescending: false
+      });
+      component.instance().sortBy("type");
+      expect(component.state("sortKey")).to.equal("type");
+    });
+  });
+
+  describe("sorting is highlighting the right column", () => {
+    var component = shallow(
+      <AppVolumesListComponent
+        volumes={volumes} />
+    );
+    sortKeys.forEach((sortKey, index) => {
+      it(`Sorting by ${sortKey}`, () => {
+        component.setState({
+          sortKey: sortKey,
+          sortDescending: false
+        });
+        expect(component.find("th").at(index).hasClass("cell-highlighted"))
+          .to.be.true;
+      });
+    });
+  });
+  
+  describe("if no volumes are provided", () => {
+    var component = shallow(
+      <AppVolumesListComponent />
+    );
+
+    it("should contain no AppVolumesListItemComponent", () => {
+      expect(component.find(AppVolumesListItemComponent)).to.have.length(0);
+    });
+  });
+});

--- a/src/test/units/AppVolumesListComponent.test.js
+++ b/src/test/units/AppVolumesListComponent.test.js
@@ -38,7 +38,6 @@ describe("AppVolumesListComponent", () => {
     "host",
     "type",
     "containerPath",
-    "hostPath",
     "size",
     "mode"
   ];

--- a/src/test/units/AppVolumesListItemComponent.test.js
+++ b/src/test/units/AppVolumesListItemComponent.test.js
@@ -9,12 +9,13 @@ describe("AppVolumesListItemComponent", () => {
   var volume = {
     appId: "stu",
     host: "127.0.0.1",
-    persistenceId: "x.y.z",
+    persistenceId: "x#y#z",
     type: "TYPE",
     containerPath: "path",
     hostPath: "Hpath",
     size: "1536",
-    mode: "XX"
+    mode: "XX",
+    status: "Attached"
   };
   var component = shallow(
     <AppVolumesListItemComponent
@@ -28,7 +29,8 @@ describe("AppVolumesListItemComponent", () => {
     "type",
     "containerPath",
     "size",
-    "mode"
+    "mode",
+    "status"
   ];
 
   it("contains the right id", () => {
@@ -43,7 +45,7 @@ describe("AppVolumesListItemComponent", () => {
 
   it("contains the right type", () => {
     expect(component.find("td").at(2).text())
-    .to.equal(volume.type);
+      .to.equal(volume.type);
   });
 
   it("contains the right containerPath", () => {
@@ -59,6 +61,11 @@ describe("AppVolumesListItemComponent", () => {
   it("contains the right mode", () => {
     expect(component.find("td").at(5).text())
       .to.equal(volume.mode);
+  });
+
+  it("contains the right Status", () => {
+    expect(component.find("td").at(6).text())
+      .to.equal(volume.status);
   });
 
   describe("sorting is highlighting the right column", () => {

--- a/src/test/units/AppVolumesListItemComponent.test.js
+++ b/src/test/units/AppVolumesListItemComponent.test.js
@@ -1,0 +1,76 @@
+import {expect} from "chai";
+import {shallow} from "enzyme";
+
+import React from "react/addons";
+import AppVolumesListItemComponent
+  from "../../js/components/AppVolumesListItemComponent";
+
+describe("AppVolumesListItemComponent", () => {
+  var volume = {
+    appId: "stu",
+    persistenceId: "x.y.z",
+    type: "TYPE",
+    containerPath: "path",
+    hostPath: "Hpath",
+    size: "1536",
+    mode: "XX"
+  };
+  var component = shallow(
+    <AppVolumesListItemComponent
+      sortKey={"id"}
+      volume={volume} />
+  );
+
+  var sortKeys = [
+    "id",
+    "type",
+    "containerPath",
+    "hostPath",
+    "size",
+    "mode"
+  ];
+
+  it("contains the right id", () => {
+    expect(component.find("td").find("Link").first().props().children)
+      .to.equal(volume.persistenceId);
+  });
+
+  it("contains the right type", () => {
+    expect(component.find("td").at(1).text())
+      .to.equal(volume.type);
+  });
+
+  it("contains the right containerPath", () => {
+    expect(component.find("td").at(2).text())
+      .to.equal(volume.containerPath);
+  });
+
+  it("contains the right host path", () => {
+    expect(component.find("td").at(3).text())
+      .to.equal(volume.hostPath);
+  });
+
+  it("contains the right size", () => {
+    expect(component.find("td").at(4).text())
+      .to.equal(volume.size);
+  });
+
+  it("contains the right mode", () => {
+    expect(component.find("td").at(5).text())
+      .to.equal(volume.mode);
+  });
+
+  describe("sorting is highlighting the right column", () => {
+    sortKeys.forEach((sortKey, index) => {
+      it(`Sorting by ${sortKey}`, () => {
+        var component = shallow(
+          <AppVolumesListItemComponent
+            sortKey={sortKey}
+            volume={volume} />
+        );
+        expect(component.find("td").at(index).hasClass("cell-highlighted"))
+          .to.be.true;
+      });
+    });
+  });
+});

--- a/src/test/units/AppVolumesListItemComponent.test.js
+++ b/src/test/units/AppVolumesListItemComponent.test.js
@@ -27,7 +27,6 @@ describe("AppVolumesListItemComponent", () => {
     "host",
     "type",
     "containerPath",
-    "hostPath",
     "size",
     "mode"
   ];
@@ -52,18 +51,13 @@ describe("AppVolumesListItemComponent", () => {
       .to.equal(volume.containerPath);
   });
 
-  it("contains the right host path", () => {
-    expect(component.find("td").at(4).text())
-      .to.equal(volume.hostPath);
-  });
-
   it("contains the right size", () => {
-    expect(component.find("td").at(5).text())
+    expect(component.find("td").at(4).text())
       .to.equal(volume.size);
   });
 
   it("contains the right mode", () => {
-    expect(component.find("td").at(6).text())
+    expect(component.find("td").at(5).text())
       .to.equal(volume.mode);
   });
 

--- a/src/test/units/AppVolumesListItemComponent.test.js
+++ b/src/test/units/AppVolumesListItemComponent.test.js
@@ -8,6 +8,7 @@ import AppVolumesListItemComponent
 describe("AppVolumesListItemComponent", () => {
   var volume = {
     appId: "stu",
+    host: "127.0.0.1",
     persistenceId: "x.y.z",
     type: "TYPE",
     containerPath: "path",
@@ -23,6 +24,7 @@ describe("AppVolumesListItemComponent", () => {
 
   var sortKeys = [
     "id",
+    "host",
     "type",
     "containerPath",
     "hostPath",
@@ -35,28 +37,33 @@ describe("AppVolumesListItemComponent", () => {
       .to.equal(volume.persistenceId);
   });
 
-  it("contains the right type", () => {
+  it("contains the right host", () => {
     expect(component.find("td").at(1).text())
-      .to.equal(volume.type);
+      .to.equal(volume.host);
+  });
+
+  it("contains the right type", () => {
+    expect(component.find("td").at(2).text())
+    .to.equal(volume.type);
   });
 
   it("contains the right containerPath", () => {
-    expect(component.find("td").at(2).text())
+    expect(component.find("td").at(3).text())
       .to.equal(volume.containerPath);
   });
 
   it("contains the right host path", () => {
-    expect(component.find("td").at(3).text())
+    expect(component.find("td").at(4).text())
       .to.equal(volume.hostPath);
   });
 
   it("contains the right size", () => {
-    expect(component.find("td").at(4).text())
+    expect(component.find("td").at(5).text())
       .to.equal(volume.size);
   });
 
   it("contains the right mode", () => {
-    expect(component.find("td").at(5).text())
+    expect(component.find("td").at(6).text())
       .to.equal(volume.mode);
   });
 

--- a/src/test/units/LocalVolumesComponent.test.jsx
+++ b/src/test/units/LocalVolumesComponent.test.jsx
@@ -5,7 +5,7 @@ import React from "react/addons";
 import LocalVolumesComponent
   from "../../js/components/LocalVolumesComponent.jsx";
 
-describe("Optional Volumes Component", function () {
+describe("Local Volumes Component", function () {
   describe("(no volume)", () => {
     var component = shallow(
       <LocalVolumesComponent errorIndices={{}}
@@ -27,7 +27,7 @@ describe("Optional Volumes Component", function () {
     });
 
     it("should have the right title", () => {
-      expect(component.find("h4").first().props().children)
+      expect(component.find("h4").first().props().children[0])
         .to.equal("Persistent Local Volumes");
     });
   });

--- a/src/test/units/util.test.js
+++ b/src/test/units/util.test.js
@@ -669,4 +669,84 @@ describe("Util", function () {
       expect(Util.deepCopy(originalObject)).to.not.deep.equal(expectedObject);
     });
   });
+  describe("sortBy", () => {
+    it("is not null", () => {
+      expect(Util.sortBy).to.not.be.null;
+    });
+
+    it("sorts alphabetical", () => {
+      var originalUnsortedArray = [
+        {"a": "z"},
+        {"a": "a"}
+      ];
+      var expectedSortedArray = [
+        {"a": "a"},
+        {"a": "z"}
+      ];
+
+      expect(originalUnsortedArray.sort(Util.sortBy("a")))
+        .to.deep.equal(expectedSortedArray);
+    });
+
+    it("sorts alphabetical reverse", () => {
+      var originalUnsortedArray = [
+        {"a": "a"},
+        {"a": "z"}
+      ];
+      var expectedSortedArray = [
+        {"a": "z"},
+        {"a": "a"}
+      ];
+
+      expect(originalUnsortedArray.sort(Util.sortBy("a", true)))
+        .to.deep.equal(expectedSortedArray);
+    });
+
+    it("sorts alphabetical with multiple letters", () => {
+      var originalUnsortedArray = [
+        {"a": "ab"},
+        {"a": "aa"}
+      ];
+      var expectedSortedArray = [
+        {"a": "aa"},
+        {"a": "ab"}
+      ];
+
+      expect(originalUnsortedArray.sort(Util.sortBy("a")))
+        .to.deep.equal(expectedSortedArray);
+    });
+
+    it("sorts alphnumeric", () => {
+      var originalUnsortedArray = [
+        {"a": "z"},
+        {"a": "0"},
+        {"a": "a"}
+      ];
+      var expectedSortedArray = [
+        {"a": "0"},
+        {"a": "a"},
+        {"a": "z"}
+      ];
+      expect(originalUnsortedArray.sort(Util.sortBy("a")))
+        .to.deep.equal(expectedSortedArray);
+    });
+
+    it("sorts null fields to the end", () => {
+      var originalUnsortedArray = [
+        {"a": "z"},
+        {"a": "0"},
+        {"b": "a"},
+        {"a": "a"}
+      ];
+      var expectedSortedArray = [
+        {"a": "0"},
+        {"a": "a"},
+        {"a": "z"},
+        {"b": "a"}
+      ];
+
+      expect(originalUnsortedArray.sort(Util.sortBy("a")))
+        .to.deep.equal(expectedSortedArray);
+    });
+  });
 });


### PR DESCRIPTION
This introduces a new tab to the application page which shows details about the volumes associated with the application. For now this are only the configured volumes. This has been builded with the volumes at the tasks in mind.

This tab is only shown if there are any Volumes configured with the application.

This introduces a Volume tab at the Task details which has the same capabilities like the application page tab.

This introduces a detail view for a volume which has some information on the volumes as links to the parent task and application. 

This Introduces tooltips in the create and edit modal to show the user some information on local volumes.

This introduces a warning when the user tries to scale down an application which has a volume associated with it. 

This adds a work around to add a resident app if a volume is associated with it.

This closes mesosphere/marathon#3240