### PR TITLE
Fix plugin loader IE blob issue

### DIFF
--- a/src/js/plugin/PluginLoader.js
+++ b/src/js/plugin/PluginLoader.js
@@ -24,10 +24,6 @@ const PluginLoader = {
       pluginHost.setAttribute("frameborder","0");
       pluginHost.setAttribute("style",
         "position:absolute; top:-1px; left:-1px;");
-      pluginHost.setAttribute("sandbox","allow-same-origin allow-scripts");
-      pluginHost.setAttribute("src", URL.createObjectURL(new Blob([
-        `<html><head></head><body>${pluginId}</body></html>`
-      ], {type: "text/html"})));
 
       function handlePluginHostLoad() {
         pluginHost.removeEventListener("load", handlePluginHostLoad);


### PR DESCRIPTION
IE has a problem (hardly surprising) to render HTML blobs within an iFrame. The respect sections have been removed as it's not mandatory to provide such a blob to enable plugin loading.