### PR TITLE
Fix - Update Marathon docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ mesos-slave:
     - MESOS_DOCKER_STOP_TIMEOUT=60secs
     - MESOS_RESOURCES=cpus:4;mem:1280;disk:25600;ports(*):[12000-12999]
 marathon-service:
-  image: mesosphere/marathon-test:1ec751bba551
+  image: mesosphere/marathon:latest-dev
   expose:
     - "8080"
   links:


### PR DESCRIPTION
Use `mesosphere/marathon:latest-dev` instead of `mesosphere/marathon-test`