### PR TITLE
Use CSS transforms for better performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - \#3102 - Updating environment variables sometimes deletes entries
 - \#3242 - Treat "value" attribute in server-side validation errors as general
   error
+- \#3304 - Marathon UI hangs after being open for a while
 
 ## 0.15.6 - 2016-02-23
 - \#3192 - Adapt default Mem/CPU settings

--- a/src/css/components/loading-bar.less
+++ b/src/css/components/loading-bar.less
@@ -23,5 +23,5 @@
 }
 
 @keyframes move {
-  to { background-position: 12px 12px; }
+  to { transform: translate3D(-24px, 0, 0); }
 }


### PR DESCRIPTION
This fixes the high CPU usage as expressed in https://github.com/mesosphere/marathon/issues/3304 

The bug happens when several apps are deploying at once.


Before:

![before](https://cloud.githubusercontent.com/assets/1078545/13322769/559a7736-dbd6-11e5-8d6c-2dadae714df4.gif)

After:

![after](https://cloud.githubusercontent.com/assets/1078545/13322774/5947a638-dbd6-11e5-9ace-ac671de412c3.gif)


**Question**: Should we backport this fix to a new  `0.15.7` ?