### PR TITLE
Refactor error parsing to new structure

### DIFF
--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -176,7 +176,7 @@ const responseAttributePathToFieldIdMap = {
   "/ports": "ports",
   "/uris": "uris",
   "/user": "user",
-  "value": "general"
+  "self": "general"
 };
 
 /**
@@ -388,13 +388,15 @@ function processResponseErrors(responseErrors, response, statusCode) {
   } else if (statusCode === 422 && response != null &&
       Util.isArray(response.details)) {
     response.details.forEach(detail => {
-      var attributePath = detail.attribute.length
-        ? detail.attribute
-        : "general";
-      var fieldId = resolveResponseAttributePathToFieldId(attributePath) ||
-        attributePath;
-      responseErrors[fieldId] =
-        AppFormErrorMessages.lookupServerResponseMessage(detail.error);
+      var path = detail.path;
+      var fieldId = resolveResponseAttributePathToFieldId(path) || path;
+      if (detail.errors.length >= 1) {
+        responseErrors[fieldId] =
+          AppFormErrorMessages.lookupServerResponseMessage(detail.errors[0]);
+      } else {
+        responseErrors[fieldId] =
+          AppFormErrorMessages.lookupServerResponseMessage(response.message);
+      }
     });
 
   } else if (statusCode === 409 && responseHasDeployments) {

--- a/src/test/scenarios/createApplication.test.js
+++ b/src/test/scenarios/createApplication.test.js
@@ -212,10 +212,11 @@ describe("Create Application", function () {
         nock(config.apiURL)
           .post("/v2/apps")
           .reply(422, {
+            "message": "Object is not valid",
             "details": [{
-              "attribute": "value",
-              "error": "Groups and Applications may not have the same " +
-                "identifier: /sleep"
+              "path": "self",
+              "errors": ["Groups and Applications may not have the same " +
+                "identifier: /sleep"]
             }]
           });
 
@@ -223,6 +224,31 @@ describe("Create Application", function () {
           id: "sleep/my-app"
         });
       });
+
+      it("processes a 422 error response with no error details correctly",
+        function (done) {
+
+          AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
+            expectAsync(function () {
+              expect(AppFormStore.responseErrors.general)
+                .to.equal("Object is not valid");
+            }, done);
+          });
+
+          nock(config.apiURL)
+            .post("/v2/apps")
+            .reply(422, {
+              "message": "Object is not valid",
+              "details": [{
+                "path": "self",
+                "errors": []
+              }]
+            });
+
+          AppsActions.createApp({
+            id: "sleep/my-app"
+          });
+        });
 
       it("processes error response codes 300 to 499 correctly",
         function (done) {
@@ -1216,8 +1242,8 @@ describe("Create Application", function () {
             .post("/v2/apps")
             .reply(422, {
               "details": [{
-                "attribute": "id",
-                "error": "error on id attribute"
+                "path": "id",
+                "errors": ["error on id attribute"]
               }]
             });
 


### PR DESCRIPTION
Fixes mesosphere/marathon#3337

One note: if multiple errors are returned from the API (which is a possibility now errors is an array), only the first is entered into the form store. If the errors array is empty, the message is entered instead. 

I wasn't able to force multiple errors from the API so I think this is reasonably defensive. 