### PR TITLE
Simplify tab panes

### DIFF
--- a/src/css/components/pane.less
+++ b/src/css/components/pane.less
@@ -6,13 +6,13 @@
   line-height: 30px;
 }
 
-.tab-pane.active.flex-container {
+.tab-pane {
   display: flex;
   flex: 1;
   flex-direction: column;
   min-height: 100vh;
 
-  .wrapper {
+  .app-list-wrapper {
     display: flex;
     flex: 1;
 

--- a/src/js/components/DeploymentsListComponent.jsx
+++ b/src/js/components/DeploymentsListComponent.jsx
@@ -14,9 +14,14 @@ var DeploymentListComponent = React.createClass({
   displayName: "DeploymentListComponent",
 
   getInitialState: function () {
+    var deployments = DeploymentStore.deployments;
+    var fetchState = deployments.length > 0
+      ? States.STATE_SUCCESS
+      : States.STATE_LOADING;
+
     return {
-      deployments: DeploymentStore.deployments,
-      fetchState: States.STATE_LOADING,
+      deployments: deployments,
+      fetchState: fetchState,
       sortKey: null,
       sortDescending: false,
       errorMessage: ""

--- a/src/js/components/TabPaneComponent.jsx
+++ b/src/js/components/TabPaneComponent.jsx
@@ -25,10 +25,11 @@ var TabPaneComponent = React.createClass({
   },
 
   render: function () {
-    var classSet = classNames({
-      "active": this.props.isActive,
-      "tab-pane": true
-    }, this.props.className);
+    if (!this.props.isActive) {
+      return null;
+    }
+
+    var classSet = classNames("tab-pane active", this.props.className);
 
     return (
       <div className={classSet}>

--- a/src/js/components/TabPaneComponent.jsx
+++ b/src/js/components/TabPaneComponent.jsx
@@ -21,7 +21,7 @@ var TabPaneComponent = React.createClass({
       return null;
     }
 
-    var classSet = classNames("tab-pane active", this.props.className);
+    var classSet = classNames("tab-pane", this.props.className);
 
     return (
       <div className={classSet}>

--- a/src/js/components/TabPaneComponent.jsx
+++ b/src/js/components/TabPaneComponent.jsx
@@ -7,20 +7,12 @@ var TabPaneComponent = React.createClass({
   propTypes: {
     children: React.PropTypes.node,
     className: React.PropTypes.string,
-    isActive: React.PropTypes.bool,
-    onActivate: React.PropTypes.func
-  },
-
-  componentDidUpdate: function (prevProps) {
-    if (!prevProps.isActive && this.props.isActive) {
-      this.props.onActivate();
-    }
+    isActive: React.PropTypes.bool
   },
 
   getDefaultProps: function () {
     return {
-      isActive: false,
-      onActivate: function () {}
+      isActive: false
     };
   },
 

--- a/src/js/components/TabPanesComponent.jsx
+++ b/src/js/components/TabPanesComponent.jsx
@@ -89,8 +89,8 @@ var TabPanesComponent = React.createClass({
     return (
       <TogglableTabsComponent activeTabId={this.getTabId()}
           className="container-fluid content">
-        <TabPaneComponent id={tabs[0].id} className="flex-container">
-          <div className="wrapper">
+        <TabPaneComponent id={tabs[0].id}>
+          <div className="app-list-wrapper">
             <SidebarComponent groupId={state.currentGroup} />
             <main>
               <div className="contextual-bar">

--- a/src/js/components/TogglableTabsComponent.jsx
+++ b/src/js/components/TogglableTabsComponent.jsx
@@ -39,9 +39,7 @@ export default React.createClass({
           activeTabId={this.props.activeTabId}
           onTabClick={this.props.onTabClick}
           tabs={this.props.tabs} />
-        <div className="tab-content">
-          {childNodes}
-        </div>
+        {childNodes}
       </div>
     );
   }


### PR DESCRIPTION
Fixes mesosphere/marathon#3363

This PR prevents inactive tab panes being rendered and hidden. Along the way I removed some of the no-longer required nested `div` elements and cleaned up the styles. 

Re-rendering the deployment list each time the deployment tab was activated highlighted the fact that we were show the loading dialog on every render, I optimised this inline with the app list. 

No changelog as (hopefully!) no functionality was changed. 