### PR TITLE
Check task detail properties

### DIFF
--- a/src/js/components/TaskDetailComponent.jsx
+++ b/src/js/components/TaskDetailComponent.jsx
@@ -126,6 +126,30 @@ var TaskDetailComponent = React.createClass({
     ));
   },
 
+  getStatus: function () {
+    var props = this.props;
+    var task = props.task;
+    if (task == null || task.status == null) {
+      return <dd className="text-muted">Unknown</dd>;
+    }
+    return <dd>{task.status}</dd>;
+  },
+
+  getVersion: function () {
+    var props = this.props;
+    var task = props.task;
+    if (task == null || task.version == null) {
+      return <dd className="text-muted">None</dd>;
+    }
+    return (
+      <dd>
+        <time dateTime={task.version}>
+          {task.version}
+        </time>
+      </dd>
+    );
+  },
+
   getTaskHealthComponent: function () {
     var props = this.props;
     var task = props.task;
@@ -188,14 +212,10 @@ var TaskDetailComponent = React.createClass({
           <dt>Service Discovery</dt>
           {this.getServiceDiscovery()}
           <dt>Status</dt>
-          <dd>{task.status}</dd>
+          {this.getStatus()}
           {timeFields}
           <dt>Version</dt>
-          <dd>
-            <time dateTime={task.version}>
-              {task.version}
-            </time>
-          </dd>
+          {this.getVersion()}
           <dt>Health</dt>
           <dd className={healthClassSet}>{props.taskHealthMessage}</dd>
           <dt>Mesos details</dt>

--- a/src/js/components/TaskListItemComponent.jsx
+++ b/src/js/components/TaskListItemComponent.jsx
@@ -154,7 +154,9 @@ var TaskListItemComponent = React.createClass({
     var task = this.props.task;
     var sortKey = this.props.sortKey;
     var hasHealth = !!this.props.hasHealth;
-    var version = new Date(task.version).toISOString();
+    var version = task.version == null
+      ? null
+      : new Date(task.version).toISOString();
     var taskId = task.id;
     var taskURI = "#apps/" +
       encodeURIComponent(this.props.appId) +


### PR DESCRIPTION
Partially addresses (but does not completely fix) mesosphere/marathon#3376

This is a quick fix that stops the whole UI crashing when a task without a `version` field is encountered. 

FAO @kolloch 