### PR TITLE
Show empty groups in app list

### DIFF
--- a/src/js/actions/AppsActions.js
+++ b/src/js/actions/AppsActions.js
@@ -7,13 +7,15 @@ import AppsEvents from "../events/AppsEvents";
 
 var AppsActions = {
   requestApps: function () {
+    const embed = "embed=group.groups&embed=group.apps&" +
+      "embed=group.apps.deployments&embed=group.apps.counts";
     this.request({
-      url: `${config.apiURL}v2/apps`
+      url: `${config.apiURL}v2/groups?${embed}`
     })
-      .success(function (apps) {
+      .success(function (groups) {
         AppDispatcher.dispatch({
           actionType: AppsEvents.REQUEST_APPS,
-          data: apps
+          data: groups
         });
       })
       .error(function (error) {

--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -192,33 +192,33 @@ var AppListComponent = React.createClass({
   getGroupsFromApps: function (apps) {
     var groups = [];
 
-    apps.forEach(app => {
-      var pathParts = app.id.split("/");
+    apps.filter(app => !app.isGroup)
+      .forEach(app => {
+        var pathParts = app.id.split("/");
 
-      // Remove app name
-      pathParts.pop();
+        // Remove app name
+        pathParts.pop();
 
-      // Create groups
-      pathParts.forEach((pathPart, index, pathParts) => {
-        // We can ignore the first part as all app/group ids begin with a slash
-        if (index === 0) {
-          return;
-        }
+        // Create groups
+        pathParts.forEach((pathPart, index, pathParts) => {
+          // Ignore the first part as all app/group ids that begin with a slash
+          if (index === 0) {
+            return;
+          }
 
-        let groupId = pathParts.slice(0, index + 1).join("/");
-        let group = groups.find(item => {
-          return item.id === groupId;
+          let groupId = pathParts.slice(0, index + 1).join("/");
+          let group = groups.find(item => {
+            return item.id === groupId;
+          });
+
+          if (group == null) {
+            group = initGroupNode(groupId, app);
+            groups.push(group);
+          } else {
+            updateGroupNode(group, app);
+          }
         });
-
-        if (group == null) {
-          group = initGroupNode(groupId, app);
-          groups.push(group);
-        } else {
-          updateGroupNode(group, app);
-        }
       });
-
-    });
 
     return groups;
   },

--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -401,7 +401,7 @@ var AppListComponent = React.createClass({
       });
     } else {
       items = this.sortItems(items,
-        (a,b) => SortUtil.compareValues(a[sortKey],b[sortKey]) * sortDirection
+        (a, b) => SortUtil.compareValues(a[sortKey], b[sortKey]) * sortDirection
       );
     }
 

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -120,11 +120,10 @@ var AppListItemComponent = React.createClass({
     var model = this.props.model;
     var router = this.context.router;
     if (model.isGroup) {
-      let query = router.getCurrentQuery();
       let param = {
         groupId: encodeURIComponent(model.id)
       };
-      router.transitionTo("group", param, query);
+      router.transitionTo("group", param);
     } else {
       router.transitionTo("app", {appId: encodeURIComponent(model.id)});
     }

--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -153,7 +153,9 @@ function processEmptyGroup(group) {
   });
 }
 
-function processAppsAndGroups(group, apps = []) {
+// TODO: refactor to adhere to /groups endpoint structures.
+// https://github.com/mesosphere/marathon/issues/3383
+function processAppsAndEmptyGroups(group, apps = []) {
   if (group.apps != null && group.apps.length > 0) {
     group.apps.forEach(app => {
       apps.push(processApp(app));
@@ -163,7 +165,7 @@ function processAppsAndGroups(group, apps = []) {
   }
 
   if (group.groups != null && group.groups.length > 0) {
-    group.groups.forEach(group => processAppsAndGroups(group, apps));
+    group.groups.forEach(group => processAppsAndEmptyGroups(group, apps));
   }
 
   return apps;
@@ -246,7 +248,7 @@ QueueStore.on(QueueEvents.CHANGE, function () {
 AppDispatcher.register(function (action) {
   switch (action.actionType) {
     case AppsEvents.REQUEST_APPS:
-      storeData.apps = processAppsAndGroups(action.data.body);
+      storeData.apps = processAppsAndEmptyGroups(action.data.body);
       applyAppDelayStatusOnAllApps(storeData.apps, QueueStore.queue);
       AppsStore.emit(AppsEvents.CHANGE);
       break;

--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -146,10 +146,27 @@ function processApp(app) {
   return app;
 }
 
-function processApps(apps) {
-  return apps.map(function (app) {
-    return processApp(app);
+function processEmptyGroup(group) {
+  return Object.assign(processApp({id: group.id}), {
+    isGroup: true,
+    status: null
   });
+}
+
+function processAppsAndGroups(group, apps = []) {
+  if (group.apps != null && group.apps.length > 0) {
+    group.apps.forEach(app => {
+      apps.push(processApp(app));
+    });
+  } else if (group.id !== "/") {
+    apps.push(processEmptyGroup(group));
+  }
+
+  if (group.groups != null && group.groups.length > 0) {
+    group.groups.forEach(group => processAppsAndGroups(group, apps));
+  }
+
+  return apps;
 }
 
 function applyAppDelayStatus(app, queue) {
@@ -189,7 +206,6 @@ function applyAppDelayStatusOnAllApps(apps, queue) {
 }
 
 var AppsStore = Util.extendObject(EventEmitter.prototype, {
-  // Array of apps objects received from the "apps/"-endpoint
   get apps() {
     return Util.deepCopy(storeData.apps);
   },
@@ -230,7 +246,7 @@ QueueStore.on(QueueEvents.CHANGE, function () {
 AppDispatcher.register(function (action) {
   switch (action.actionType) {
     case AppsEvents.REQUEST_APPS:
-      storeData.apps = processApps(action.data.body.apps);
+      storeData.apps = processAppsAndGroups(action.data.body);
       applyAppDelayStatusOnAllApps(storeData.apps, QueueStore.queue);
       AppsStore.emit(AppsEvents.CHANGE);
       break;

--- a/src/test/scenarios/createApplication.test.js
+++ b/src/test/scenarios/createApplication.test.js
@@ -32,7 +32,8 @@ describe("Create Application", function () {
         };
 
         nock(config.apiURL)
-          .get("/v2/apps")
+          .get("/v2/groups")
+          .query(true)
           .reply(200, nockResponse);
 
         AppsStore.once(AppsEvents.CHANGE, done);
@@ -1153,7 +1154,8 @@ describe("Create Application", function () {
           };
 
           nock(config.apiURL)
-            .get("/v2/apps")
+            .get("/v2/groups")
+            .query(true)
             .reply(200, nockResponse);
 
           AppsStore.once(AppsEvents.CHANGE, done);

--- a/src/test/scenarios/deleteApplication.test.js
+++ b/src/test/scenarios/deleteApplication.test.js
@@ -22,7 +22,8 @@ describe("Delete Application", function () {
     };
 
     nock(config.apiURL)
-      .get("/v2/apps")
+      .get("/v2/groups")
+      .query(true)
       .reply(200, nockResponse);
 
     AppsStore.once(AppsEvents.CHANGE, done);

--- a/src/test/scenarios/queueUpdate.test.js
+++ b/src/test/scenarios/queueUpdate.test.js
@@ -25,7 +25,8 @@ describe("queue update", function () {
     };
 
     nock(config.apiURL)
-      .get("/v2/apps")
+      .get("/v2/groups")
+      .query(true)
       .reply(200, nockResponse);
 
     AppsStore.once(AppsEvents.CHANGE, done);

--- a/src/test/scenarios/requestApplications.test.js
+++ b/src/test/scenarios/requestApplications.test.js
@@ -25,7 +25,8 @@ describe("request applications", function () {
     };
 
     nock(config.apiURL)
-      .get("/v2/apps")
+      .get("/v2/groups")
+      .query(true)
       .reply(200, nockResponse);
 
     AppsStore.once(AppsEvents.CHANGE, done);
@@ -43,7 +44,8 @@ describe("request applications", function () {
 
   it("handles failure gracefully", function (done) {
     nock(config.apiURL)
-      .get("/v2/apps")
+      .get("/v2/groups")
+      .query(true)
       .reply(404, {message: "Guru Meditation"});
 
     AppsStore.once(AppsEvents.REQUEST_APPS_ERROR, function (error) {
@@ -57,7 +59,8 @@ describe("request applications", function () {
 
   it("handles unauthorized errors gracefully", function (done) {
     nock(config.apiURL)
-      .get("/v2/apps")
+      .get("/v2/groups")
+      .query(true)
       .reply(401, {message: "Unauthorized access"});
 
     AppsStore.once(AppsEvents.REQUEST_APPS_ERROR,
@@ -85,7 +88,8 @@ describe("request applications", function () {
       };
 
       nock(config.apiURL)
-        .get("/v2/apps")
+        .get("/v2/groups")
+        .query(true)
         .reply(200, nockResponse);
 
       AppsStore.once(AppsEvents.CHANGE, done);
@@ -130,7 +134,8 @@ describe("request applications", function () {
       };
 
       nock(config.apiURL)
-        .get("/v2/apps")
+        .get("/v2/groups")
+        .query(true)
         .reply(200, nockResponse);
 
       AppsStore.once(AppsEvents.CHANGE, done);
@@ -172,7 +177,8 @@ describe("request applications", function () {
       };
 
       nock(config.apiURL)
-        .get("/v2/apps")
+        .get("/v2/groups")
+        .query(true)
         .reply(200, nockResponse);
 
       AppsStore.once(AppsEvents.CHANGE, done);
@@ -210,7 +216,8 @@ describe("request applications", function () {
       };
 
       nock(config.apiURL)
-        .get("/v2/apps")
+        .get("/v2/groups")
+        .query(true)
         .reply(200, nockResponse);
 
       AppsStore.once(AppsEvents.CHANGE, done);
@@ -248,7 +255,8 @@ describe("request applications", function () {
       };
 
       nock(config.apiURL)
-        .get("/v2/apps")
+        .get("/v2/groups")
+        .query(true)
         .reply(200, nockResponse);
 
       AppsStore.once(AppsEvents.CHANGE, done);

--- a/src/test/scenarios/requestApplications.test.js
+++ b/src/test/scenarios/requestApplications.test.js
@@ -10,7 +10,10 @@ import AppsEvents from "../../js/events/AppsEvents";
 import HealthStatus from "../../js/constants/HealthStatus";
 import AppTypes from "../../js/constants/AppTypes";
 
-describe("request applications", function () {
+var server = config.localTestserverURI;
+config.apiURL = "http://" + server.address + ":" + server.port + "/";
+
+describe("request applications and groups", function () {
 
   before(function (done) {
     var nockResponse = {
@@ -21,6 +24,9 @@ describe("request applications", function () {
         cpus: 4
       }, {
         id: "/app-2"
+      }],
+      groups: [{
+        id: "/group"
       }]
     };
 
@@ -34,7 +40,7 @@ describe("request applications", function () {
   });
 
   it("updates the AppsStore on success", function () {
-    expect(AppsStore.apps).to.have.length(2);
+    expect(AppsStore.apps).to.have.length(3);
   });
 
   it("calculate total resources", function () {
@@ -279,6 +285,56 @@ describe("request applications", function () {
     });
   });
 
+  describe("application groups", function () {
+    before(function (done) {
+      var nockResponse = {
+        id: "/",
+        apps: [{
+          id: "/app-1",
+          tasksHealthy: 0,
+          tasksUnhealthy: 0,
+          tasksRunning: 1,
+          tasksStaged: 0,
+          instances: 0
+        }],
+        groups: [{
+          id: "/empty-group",
+          apps: [],
+          groups: []
+        }, {
+          id: "/non-empty-group",
+          apps: [{
+            id: "/non-empty-group/app-2",
+            tasksHealthy: 0,
+            tasksUnhealthy: 0,
+            tasksRunning: 1,
+            tasksStaged: 0,
+            instances: 0
+          }],
+          groups: []
+        }]
+      };
+
+      nock(config.apiURL)
+        .get("/v2/groups")
+        .query(true)
+        .reply(200, nockResponse);
+
+      AppsStore.once(AppsEvents.CHANGE, done);
+      AppsActions.requestApps();
+    });
+
+    it("handles emtpy groups", function () {
+      var emptyGroup = AppsStore.apps[1];
+      expect(emptyGroup.id).to.eql("/empty-group");
+      expect(emptyGroup.isGroup).to.be.true;
+    });
+
+    it("handles nested applications", function () {
+      var nestedApp = AppsStore.apps[2];
+      expect(nestedApp.id).to.eql("/non-empty-group/app-2");
+    });
+  });
 });
 
 describe("on single app request", function () {

--- a/src/test/scenarios/restartApplication.test.js
+++ b/src/test/scenarios/restartApplication.test.js
@@ -21,7 +21,8 @@ describe("Restart Application", function () {
     };
 
     nock(config.apiURL)
-      .get("/v2/apps")
+      .get("/v2/groups")
+      .query(true)
       .reply(200, nockResponse);
 
     AppsStore.once(AppsEvents.CHANGE, done);

--- a/src/test/scenarios/scaleApplication.test.js
+++ b/src/test/scenarios/scaleApplication.test.js
@@ -21,7 +21,8 @@ describe("Scale Application", function () {
     };
 
     nock(config.apiURL)
-      .get("/v2/apps")
+      .get("/v2/groups")
+      .query(true)
       .reply(200, nockResponse);
 
     AppsStore.once(AppsEvents.CHANGE, done);

--- a/src/test/scenarios/updateApplication.test.js
+++ b/src/test/scenarios/updateApplication.test.js
@@ -21,7 +21,8 @@ describe("Update Application", function () {
     };
 
     nock(config.apiURL)
-      .get("/v2/apps")
+      .get("/v2/groups")
+      .query(true)
       .reply(200, nockResponse);
 
     AppsStore.once(AppsEvents.CHANGE, done);

--- a/src/test/units/AppListComponent.test.js
+++ b/src/test/units/AppListComponent.test.js
@@ -70,6 +70,13 @@ describe("AppListComponent", function () {
         instances: 1,
         mem: 16,
         cpus: 1
+      },
+      {
+        id: "/empty-group",
+        instances: 0,
+        mem: 0,
+        cpus: 0,
+        isGroup: true
       }
     ];
 
@@ -92,6 +99,7 @@ describe("AppListComponent", function () {
 
     expect(appNames).to.deep.equal([
       "apps",
+      "empty-group",
       "fuzzy",
       "group-alpha",
       "group-with-long-name",
@@ -319,6 +327,30 @@ describe("AppListComponent", function () {
 
       this.component = shallow(
         <AppListComponent currentGroup="/" />,
+        {context}
+      );
+
+      var appNames = this.component
+        .find(AppListItemComponent)
+        .map(app => app.props().model.id);
+
+      expect(appNames).to.have.length(0);
+      this.component.instance().componentWillUnmount();
+    });
+
+    it("shows no items for empty groups", function () {
+      var context = {
+        router: {
+          getCurrentQuery: function () {
+            return {
+              filterText: "nope"
+            };
+          }
+        }
+      };
+
+      this.component = shallow(
+        <AppListComponent currentGroup="/empty-group" />,
         {context}
       );
 

--- a/src/test/units/AppPageComponent.test.js
+++ b/src/test/units/AppPageComponent.test.js
@@ -118,7 +118,8 @@ describe("AppPageComponent", function () {
       });
 
       nock(config.apiURL)
-        .get("/v2/apps")
+        .get("/v2/groups")
+        .query(true)
         .reply(401, {"message": "Unauthorized access"});
 
       AppsActions.requestApps();


### PR DESCRIPTION
~~**Please note** : In order to test this PR, you will need to check out and build this unmerged PR : https://github.com/mesosphere/marathon/pull/3370~~

Please note that deployments will never show up for empty groups : The deployment for an empty group is a zero step deployment - it finishes right away. That means that there is a noticeable "gap" between creating an empty group and seeing it show up in the list. 
To alleviate this, we could think of possible solutions: for example, we could "push" a ghost entry to the AppsStore until it will eventually overwritten by the next poll. Alternatively, we could trigger a `AppsActions.requestApps()` immediately after `CREATE_GROUP` is emitted. 

Either way, that's a UX improvement out of scope for this PR.


Here is the final result:


![groups](https://cloud.githubusercontent.com/assets/1078545/13471876/ca6c0cce-e0b2-11e5-8e05-ba1725e6d09a.gif)


cc @leemunroe 


**PS** @aldipower I told you it was not just 5 lines of code! :laughing: 