### PR TITLE
Do not parse AutoIT configuration in highlight.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -92,6 +92,7 @@ var webpackConfig = {
         exclude: /node_modules/
       }
     ],
+    noParse: [/autoit\.js/],
     postLoaders: [
       {
         loader: "transform/cacheable?envify"


### PR DESCRIPTION
The build just started failing for me despite restarting Gulp and even restarting my machine. Without this patch I was getting the error detailed in https://github.com/isagalaev/highlight.js/issues/895. With this patch, everything works smoothly. 

H/T @pierlo-upitup for providing the fix.