### PR TITLE
Show args in application configuration tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
   error
 - \#3304 - Marathon UI hangs after being open for a while
 - \#3233 - Cannot remove a constraint
+- \#3159 - Show args in configuration tab
 
 ## 0.15.6 - 2016-02-23
 - \#3192 - Adapt default Mem/CPU settings

--- a/src/js/components/AppVersionComponent.jsx
+++ b/src/js/components/AppVersionComponent.jsx
@@ -228,6 +228,12 @@ var AppVersionComponent = React.createClass({
         return <dd key={uri+i}>{linkNode}</dd>;
       });
 
+    var argsNode = (appVersion.args == null || appVersion.args.length === 0)
+      ? <UnspecifiedNodeComponent />
+      : appVersion.args.map(function (arg, i) {
+        return <dd key={`args-${i}`}>{arg}</dd>;
+      });
+
     return (
       <div>
         {this.getApplyButton()}
@@ -275,6 +281,8 @@ var AppVersionComponent = React.createClass({
           {urisNode}
           <dt>User</dt>
           {invalidateValue(appVersion.user)}
+          <dt>Args</dt>
+          {argsNode}
           <dt>Version</dt>
           {invalidateValue(appVersion.version)}
         </dl>

--- a/src/test/units/AppVersionComponent.test.js
+++ b/src/test/units/AppVersionComponent.test.js
@@ -11,7 +11,7 @@ describe("AppVersionComponent", function () {
     this.model = {
       "id": "/sleep10",
       "cmd": "sleep 10",
-      "args": null,
+      "args": ["arg1", "arg2"],
       "user": "testuser",
       "env": {},
       "instances": 14,
@@ -162,8 +162,13 @@ describe("AppVersionComponent", function () {
     expect(this.rows.at(41).props().children[0]).to.equal("testuser");
   });
 
+  it("has correct args", function () {
+    expect(this.rows.at(43).text()).to.equal("arg1");
+    expect(this.rows.at(44).text()).to.equal("arg2");
+  });
+
   it("has correct version", function () {
-    expect(this.rows.at(43).props().children[0])
+    expect(this.rows.at(46).props().children[0])
       .to.equal("2015-06-29T12:57:02.269Z");
   });
 


### PR DESCRIPTION
This (partially) fixes https://github.com/mesosphere/marathon/issues/3159#issuecomment-192226554 

<img width="667" alt="screen shot 2016-03-07 at 10 43 05" src="https://cloud.githubusercontent.com/assets/1078545/13565750/5603c48c-e452-11e5-9007-2dfacc6291f7.png">


if `args` are present, it shows a definition list with a term per item.