### PR TITLE
Handle undefined attributes in create app action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - \#3304 - Marathon UI hangs after being open for a while
 - \#3233 - Cannot remove a constraint
 - \#3159 - Show args in configuration tab
+- \#3430 - Uncaught TypeError when creating an empty application
 
 ## 0.15.6 - 2016-02-23
 - \#3192 - Adapt default Mem/CPU settings

--- a/src/js/actions/AppsActions.js
+++ b/src/js/actions/AppsActions.js
@@ -43,6 +43,13 @@ var AppsActions = {
       });
   },
   createApp: function (newAppAttributes) {
+    if (newAppAttributes == null) {
+      AppDispatcher.dispatch({
+        actionType: AppsEvents.CREATE_APP_ERROR
+      });
+      return;
+    }
+
     if (newAppAttributes.container != null &&
       newAppAttributes.container.volumes != null) {
       newAppAttributes.residency = {

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -84,7 +84,7 @@ var AppModalComponent = React.createClass({
 
   onCreateAppError: function (data, status) {
     // All status below 300 are actually not an error
-    if (status < 300) {
+    if (status != null && status < 300) {
       this.onCreateApp();
     } else if (status === 409 && data.deployments != null) {
       // a 409 error without deployments is a field conflict

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -474,7 +474,7 @@ function processResponseErrors(responseErrors, response, statusCode) {
       }).join(", ");
     });
 
-  } else if (statusCode >= 300) {
+  } else if (statusCode == null || statusCode >= 300) {
     responseErrors.general =
       AppFormErrorMessages.getGeneralMessage("appCreation");
   }

--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -323,11 +323,8 @@ AppDispatcher.register(function (action) {
       AppsStore.emit(AppsEvents.CHANGE);
       break;
     case AppsEvents.CREATE_APP_ERROR:
-      AppsStore.emit(
-        AppsEvents.CREATE_APP_ERROR,
-        action.data.body,
-        action.data.status
-      );
+      var {body, status} = action.data ? action.data : {};
+      AppsStore.emit(AppsEvents.CREATE_APP_ERROR, body, status);
       break;
     case AppsEvents.DELETE_APP:
       storeData.apps =


### PR DESCRIPTION
Dispatch an error if `newAppAttributes` in create app action is undefined/null; don't perform `newAppAttributes` adjustment and `v2/apps` requests.

Closes mesosphere/marathon#3430