### PR TITLE
Fix/3431 disable create button by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - \#3269 - Sort ENV variables in application details page
 - \#3243 - Simplify port management in Marathon UI
 - \#3305 - Redesign Create/Edit modal and add JSON editor toggle
+- \#3431 - Disable the create application button until valid data was
+  provided
 
 ### Fixed
 - \#3133 - Interrupted scaling operations can leave the health bar in an

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -38,7 +38,7 @@ var AppModalComponent = React.createClass({
     // is clicked, therefore it is held in the modal state rather than props
     return {
       app: app,
-      appIsValid: true,
+      appIsValid: false,
       error: null,
       force: false,
       jsonMode: false


### PR DESCRIPTION
![disable-create-button](https://cloud.githubusercontent.com/assets/647035/13634603/d2de2a6a-e5f6-11e5-8360-1a465a72cb70.gif)
Adjust the app config modal initial state to disable the create application button until valid data was provided.



Closes mesosphere/marathon#3431