### PR TITLE
Improve usability of empty groups

### DIFF
--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -433,7 +433,9 @@ var AppListComponent = React.createClass({
   },
 
   getInlineDialog: function (appNodes = []) {
-    var {props, state} = this;
+    var state = this.state;
+    var {currentGroup} = this.props;
+
     var path = this.getCurrentPathname();
 
     var pageIsLoading = state.fetchState === States.STATE_LOADING;
@@ -455,8 +457,8 @@ var AppListComponent = React.createClass({
       modal: "new-app"
     };
 
-    if (props.currentGroup != null && props.currentGroup !== "/") {
-      newAppModalQuery.groupId = props.currentGroup;
+    if (currentGroup != null && currentGroup !== "/") {
+      newAppModalQuery.groupId = currentGroup;
     }
 
     if (pageIsLoading) {

--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -434,7 +434,7 @@ var AppListComponent = React.createClass({
 
   getInlineDialog: function (appNodes = []) {
     var {props, state} = this;
-    var path = this.context.router.getCurrentPathname();
+    var path = this.getCurrentPathname();
 
     var pageIsLoading = state.fetchState === States.STATE_LOADING;
     var pageHasApps = state.apps.length > 0;

--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -433,16 +433,31 @@ var AppListComponent = React.createClass({
   },
 
   getInlineDialog: function (appNodes = []) {
-    var state = this.state;
+    var {props, state} = this;
+    var path = this.context.router.getCurrentPathname();
 
     var pageIsLoading = state.fetchState === States.STATE_LOADING;
     var pageHasApps = state.apps.length > 0;
+    var pageHasFilters = Object.keys(this.getQueryParamObject()).length > 0;
     var pageHasNoRunningApps = !pageIsLoading &&
       !pageHasApps &&
       state.fetchState !== States.STATE_UNAUTHORIZED &&
       state.fetchState !== States.STATE_FORBIDDEN &&
       state.fetchState !== States.STATE_ERROR;
-    var pageHasNoMatchingApps = pageHasApps && appNodes.length === 0;
+    var pageHasNoMatchingApps = pageHasApps &&
+      appNodes.length === 0 &&
+      pageHasFilters;
+    var pageHasEmptyGroup = !pageIsLoading &&
+      appNodes.length === 0 &&
+      !pageHasFilters;
+
+    var newAppModalQuery = {
+      modal: "new-app"
+    };
+
+    if (props.currentGroup != null && props.currentGroup !== "/") {
+      newAppModalQuery.groupId = props.currentGroup;
+    }
 
     if (pageIsLoading) {
       let message = "Please wait while applications are being retrieved";
@@ -467,8 +482,8 @@ var AppListComponent = React.createClass({
             title="No Applications Created"
             message={message}>
           <Link className="btn btn-lg btn-success"
-              to="apps"
-              query={{modal: "new-app"}}>
+              to={path}
+              query={newAppModalQuery}>
             Create Application
           </Link>
         </CenteredInlineDialogComponent>
@@ -482,6 +497,21 @@ var AppListComponent = React.createClass({
           <Link className="btn btn-lg btn-success"
               to="apps">
             Show all Applications
+          </Link>
+        </CenteredInlineDialogComponent>
+      );
+    }
+
+    if (pageHasEmptyGroup) {
+      let message = "No Applications in this Group.";
+      return (
+        <CenteredInlineDialogComponent additionalClasses="muted"
+          title="No Applications Created"
+          message={message}>
+          <Link className="btn btn-lg btn-success"
+            to={path}
+            query={newAppModalQuery}>
+            Create Application
           </Link>
         </CenteredInlineDialogComponent>
       );

--- a/src/js/components/TabPanesComponent.jsx
+++ b/src/js/components/TabPanesComponent.jsx
@@ -73,7 +73,7 @@ var TabPanesComponent = React.createClass({
   },
 
   getTabId: function () {
-    var path = this.context.router.getCurrentPathname();
+    var path = this.getCurrentPathname();
 
     var hasTab = tabs.find(tab => tab.id === path);
 
@@ -85,7 +85,7 @@ var TabPanesComponent = React.createClass({
   },
 
   render: function () {
-    var path = this.context.router.getCurrentPathname();
+    var path = this.getCurrentPathname();
     var state = this.state;
     var groupId = state.currentGroup;
 

--- a/src/js/components/modals/GroupModalComponent.jsx
+++ b/src/js/components/modals/GroupModalComponent.jsx
@@ -2,6 +2,7 @@ import classNames from "classnames";
 var React = require("react/addons");
 
 import AppFormValidators from "../../stores/validators/AppFormValidators";
+import AppsActions from "../../actions/AppsActions";
 import GroupsActions from "../../actions/GroupsActions";
 import GroupsStore from "../../stores/GroupsStore";
 import GroupsEvents from "../../events/GroupsEvents";
@@ -78,6 +79,7 @@ var GroupModalComponent = React.createClass({
   },
 
   onCreateGroup: function () {
+    AppsActions.requestApps();
     this.destroy();
   },
 

--- a/src/js/mixins/QueryParamsMixin.jsx
+++ b/src/js/mixins/QueryParamsMixin.jsx
@@ -22,6 +22,13 @@ var QueryParamsMixin = {
     router: React.PropTypes.func
   },
 
+  getCurrentPathname: function () {
+    var router = this.context.router;
+    return router
+      ? router.getCurrentPathname()
+      : {};
+  },
+
   getClearLinkForFilter: function (filterQueryParamKey,
       caption = "Clear",
       className = null) {

--- a/src/test/units/AppListComponent.test.js
+++ b/src/test/units/AppListComponent.test.js
@@ -7,7 +7,17 @@ import AppsEvents from "../../js/events/AppsEvents";
 import AppListComponent from "../../js/components/AppListComponent";
 import AppListItemComponent from "../../js/components/AppListItemComponent";
 
+class SyntheticContext {
+  get router() {
+    return {
+      getCurrentQuery: () => this.currentQuery,
+      getCurrentPathname: () => this.currentPathname
+    };
+  }
+}
+
 describe("AppListComponent", function () {
+  var context = new SyntheticContext();
 
   before(function () {
     var apps = [
@@ -128,14 +138,8 @@ describe("AppListComponent", function () {
   describe("when the user applies a text filter", function () {
 
     it("displays the exact matching app", function () {
-      var context = {
-        router: {
-          getCurrentQuery: function () {
-            return {
-              filterText: "app-exact"
-            };
-          }
-        }
+      context.currentQuery = {
+        filterText: "app-exact"
       };
 
       this.component = shallow(
@@ -154,14 +158,8 @@ describe("AppListComponent", function () {
     });
 
     it("handles fuzzy app search input", function () {
-      var context = {
-        router: {
-          getCurrentQuery: function () {
-            return {
-              filterText: "appsleep"
-            };
-          }
-        }
+      context.currentQuery = {
+        filterText: "appsleep"
       };
 
       this.component = shallow(
@@ -181,14 +179,8 @@ describe("AppListComponent", function () {
     });
 
     it("displays the exact matching group", function () {
-      var context = {
-        router: {
-          getCurrentQuery: function () {
-            return {
-              filterText: "apps"
-            };
-          }
-        }
+      context.currentQuery = {
+        filterText: "apps"
       };
 
       this.component = shallow(
@@ -211,16 +203,9 @@ describe("AppListComponent", function () {
     });
 
     it("handles fuzzy group search input", function () {
-      var context = {
-        router: {
-          getCurrentQuery: function () {
-            return {
-              filterText: "fuzz"
-            };
-          }
-        }
+      context.currentQuery = {
+        filterText: "fuzz"
       };
-
       this.component = shallow(
         <AppListComponent currentGroup="/" />,
         {context}
@@ -239,14 +224,8 @@ describe("AppListComponent", function () {
     });
 
     it("shows the right result for deeply nested paths", function () {
-      var context = {
-        router: {
-          getCurrentQuery: function () {
-            return {
-              filterText: "app-omega"
-            };
-          }
-        }
+      context.currentQuery = {
+        filterText: "app-omega"
       };
 
       this.component = shallow(
@@ -265,14 +244,8 @@ describe("AppListComponent", function () {
     });
 
     it("shows the best match first", function () {
-      var context = {
-        router: {
-          getCurrentQuery: function () {
-            return {
-              filterText: "app"
-            };
-          }
-        }
+      context.currentQuery = {
+        filterText: "app"
       };
 
       this.component = shallow(
@@ -315,14 +288,8 @@ describe("AppListComponent", function () {
     });
 
     it("returns 0 results when no matches are found", function () {
-      var context = {
-        router: {
-          getCurrentQuery: function () {
-            return {
-              filterText: "nope"
-            };
-          }
-        }
+      context.currentQuery = {
+        filterText: "nope"
       };
 
       this.component = shallow(
@@ -339,14 +306,8 @@ describe("AppListComponent", function () {
     });
 
     it("shows no items for empty groups", function () {
-      var context = {
-        router: {
-          getCurrentQuery: function () {
-            return {
-              filterText: "nope"
-            };
-          }
-        }
+      context.currentQuery = {
+        filterText: "nope"
       };
 
       this.component = shallow(


### PR DESCRIPTION
This (partially) closes https://github.com/mesosphere/marathon/issues/3383 

ACs
- empty groups are shown immediately after creation
- a better CTA is shown when inside an empty group
  - the CTA Create Application respects the current URL
  - the "No matching apps" CTA is shown when the user applies filters/search

Demo:
![emptygroupsux](https://cloud.githubusercontent.com/assets/1078545/13638346/1c67cd48-e60c-11e5-9ec4-eea1907f2797.gif)


**Please Note** this PR does not fix the tech-debt part of the linked issue.