### PR TITLE
Fix app modal error highlighting issue

### DIFF
--- a/src/js/components/MenuItemComponent.jsx
+++ b/src/js/components/MenuItemComponent.jsx
@@ -15,12 +15,8 @@ var MenuItemComponent = React.createClass({
 
   getInitialState:  function () {
     return {
-      id: "menu-item-" + Util.getUniqueId(),
+      id: "menu-item-" + Util.getUniqueId()
     };
-  },
-
-  shouldComponentUpdate: function (newProps) {
-    return this.props.selected !== newProps.selected;
   },
 
   render: function () {


### PR DESCRIPTION
![app-modal-error-highlighting mov](https://cloud.githubusercontent.com/assets/647035/13639103/689cf4d8-e60f-11e5-8abf-767cdc834f64.gif)
Remove the `shouldComponent`check as it prevents rendering on classname change and is unnecessary.

Closes mesosphere/marathon#3436