### PR TITLE
Prevent CTA in empty group change when clicking

### DIFF
--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -432,6 +432,12 @@ var AppListComponent = React.createClass({
     return null;
   },
 
+  pageHasFilters: function () {
+    return Object.keys(this.getQueryParamObject())
+        .filter(queryParam => ["modal", "groupId"].indexOf(queryParam) === -1)
+        .length > 0;
+  },
+
   getInlineDialog: function (appNodes = []) {
     var state = this.state;
     var {currentGroup} = this.props;
@@ -440,7 +446,7 @@ var AppListComponent = React.createClass({
 
     var pageIsLoading = state.fetchState === States.STATE_LOADING;
     var pageHasApps = state.apps.length > 0;
-    var pageHasFilters = Object.keys(this.getQueryParamObject()).length > 0;
+    var pageHasFilters = this.pageHasFilters();
     var pageHasNoRunningApps = !pageIsLoading &&
       !pageHasApps &&
       state.fetchState !== States.STATE_UNAUTHORIZED &&


### PR DESCRIPTION
As noticed by @leemunroe in https://github.com/mesosphere/marathon-ui/pull/679#issuecomment-194596335 the CTA was changing when clicking the button. This fixes it:

![emptyfix](https://cloud.githubusercontent.com/assets/1078545/13665812/7aba32bc-e6ae-11e5-9bf3-7ee88579610b.gif)
