### PR TITLE
Ensure API errors with unknown status or missing data are caught

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - \#3233 - Cannot remove a constraint
 - \#3159 - Show args in configuration tab
 - \#3430 - Uncaught TypeError when creating an empty application
+- \#3457 - Ensure unknown API errors are caught
 
 ## 0.15.6 - 2016-02-23
 - \#3192 - Adapt default Mem/CPU settings

--- a/src/js/components/modals/GroupModalComponent.jsx
+++ b/src/js/components/modals/GroupModalComponent.jsx
@@ -89,7 +89,7 @@ var GroupModalComponent = React.createClass({
       this.onCreateGroup();
     } else {
       let generalError = "Error creating group or invalid group name supplied";
-      if (data.message != null) {
+      if (data != null && data.message != null) {
         generalError = data.message;
       }
       if (status === 409) {

--- a/src/js/mixins/AppActionsHandlerMixin.jsx
+++ b/src/js/mixins/AppActionsHandlerMixin.jsx
@@ -35,9 +35,16 @@ var bindOneTimeEvents = function (store, resolverEvents, handlers) {
 };
 
 var callErrorDialog = function (settings) {
-  var message = Messages[settings.statusCode] ||
-    settings.errorMessage.message ||
-    settings.errorMessage;
+  var {statusCode, errorMessage} = settings;
+  var message = "Unknown error.";
+
+  if (statusCode != null && Messages[statusCode] != null) {
+    message = Messages[statusCode];
+  } else if (errorMessage != null) {
+    message = errorMessage.message != null
+      ? errorMessage.message
+      : errorMessage;
+  }
 
   DialogActions.alert({
     message: `${settings.messagePrefix}${message}`,


### PR DESCRIPTION
This introduces a much more defensive approach when dealing with unexpected API responses, for example `{status: 405}` with no body. 

https://github.com/mesosphere/marathon/issues/3457 