### PR TITLE
Fix  3458 - Adjust dialog styles

### DIFF
--- a/src/css/components/modal.less
+++ b/src/css/components/modal.less
@@ -241,19 +241,15 @@
 
   &.warning {
     .modal-header {
-      color: @modal-dialog-warning-color
-    }
+      color: @modal-dialog-warning-color;
 
-    .modal-content::before{
-      background-color: @modal-dialog-warning-color;
+      &::before {
+        background-color: @modal-dialog-warning-color;
+      }
     }
 
     .modal-footer {
       justify-content: center;
-
-      .btn-default:hover {
-        border-color: @modal-dialog-warning-color;
-      }
 
       .btn-success {
         background-color: @modal-dialog-warning-color;
@@ -277,10 +273,14 @@
 
   &.danger {
     .modal-header {
-      color: @modal-dialog-danger-color
+      color: @modal-dialog-danger-color;
+
+      &::before {
+        background-color: @modal-dialog-danger-color;
+      }
     }
 
-    .modal-content::before, .modal-footer .btn-success {
+    .modal-footer .btn-success {
       background-color: @modal-dialog-danger-color;
       border-color: @modal-dialog-danger-color;
 

--- a/src/js/mixins/AppActionsHandlerMixin.jsx
+++ b/src/js/mixins/AppActionsHandlerMixin.jsx
@@ -217,7 +217,7 @@ var AppActionsHandlerMixin = {
       actionButtonLabel: "Continue Scaling",
       message: (
         <div>
-          <div>Scaling down will cause any existing local volumes to
+          <div>Scaling down ${appId} will cause any existing local volumes to
             be detached from destroyed instances. <a href="about:blank"
                 target="_blank"
                 className="modal-body-link">
@@ -230,7 +230,7 @@ var AppActionsHandlerMixin = {
         </div>
       ),
       severity: DialogSeverity.WARNING,
-      title: `Caution: ${appId} is a stateful application`
+      title: "Scale Stateful Application"
     });
 
     DialogStore.handleUserResponse(dialogId, () => {


### PR DESCRIPTION
Adjust the dialog/modal styles to fix the following issues:

* Dialog severity color mismatch
* Wrong button hover state in warnings (orange border)

I've also adjusted the persistent volume app scale down warning as the dialog title should not include the app id. App ids tend to be rather long, as they include the full group path and it looks odd having them in a dialog title.

Closes mesosphere/marathon#3458

/cc @leemunroe 