### PR TITLE
Display and filter only applications with persistent local volumes

### DIFF
--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -254,7 +254,9 @@ var AppListComponent = React.createClass({
         return;
       }
       filterCounts.appsStatusesCount[item.status]++;
-      if (item.container != null && item.container.volumes != null) {
+      if (item.container != null &&
+        item.container.volumes.filter(item => item.persistent != null)
+          .length > 0) {
         filterCounts.appsVolumesCount++;
       }
       item.health.forEach(health => {
@@ -310,7 +312,8 @@ var AppListComponent = React.createClass({
           return false;
         }
 
-        return true;
+        return item.container.volumes.filter(item => item.persistent != null)
+          .length > 0;
       });
     }
 
@@ -328,7 +331,9 @@ var AppListComponent = React.createClass({
       // Update filter counts
       if (!item.isGroup) {
         filterCounts.appsStatusesCount[item.status]++;
-        if (item.container != null && item.container.volumes != null) {
+        if (item.container != null &&
+          item.container.volumes.filter(item => item.persistent != null)
+            .length > 0) {
           filterCounts.appsVolumesCount++;
         }
         item.health.forEach(health => {

--- a/src/js/components/SidebarVolumesFilterComponent.jsx
+++ b/src/js/components/SidebarVolumesFilterComponent.jsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import React from "react/addons";
 
 import AppsStore from "../stores/AppsStore";
@@ -41,6 +42,20 @@ var SidebarVolumesFilterComponent = React.createClass({
     });
   },
 
+  getVolumesBadge: function () {
+    var state = this.state;
+
+    if (state.appsVolumesCount === 0) {
+      return null;
+    }
+
+    return (
+      <span className="badge">
+        {state.appsVolumesCount.toLocaleString()}
+      </span>
+    );
+  },
+
   render: function () {
     var state = this.state;
 
@@ -49,6 +64,10 @@ var SidebarVolumesFilterComponent = React.createClass({
       id: `volumesFilter`,
       checked: this.getQueryParamValue(FilterTypes.VOLUMES)
     };
+
+    var labelClassName = classNames({
+      "text-muted": state.appsVolumesCount === 0
+    });
 
     return (
       <div>
@@ -59,11 +78,9 @@ var SidebarVolumesFilterComponent = React.createClass({
           <li className="checkbox">
             <input {...checkboxProps}
               onChange={this.handleChange} />
-            <label htmlFor={checkboxProps.id}>
+            <label htmlFor={checkboxProps.id} className={labelClassName}>
               Volumes
-              <span className="badge">
-                {state.appsVolumesCount.toLocaleString()}
-              </span>
+              {this.getVolumesBadge()}
             </label>
           </li>
         </ul>


### PR DESCRIPTION
This fixes the volumes filter only to show applications which have a persistent local volume defined with them.