### PR TITLE
Append trailing slash when creating app inside group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - \#3159 - Show args in configuration tab
 - \#3430 - Uncaught TypeError when creating an empty application
 - \#3457 - Ensure unknown API errors are caught
+- \#3440 - Append trailing slash when creating an app within a group
 
 ## 0.15.6 - 2016-02-23
 - \#3192 - Adapt default Mem/CPU settings

--- a/src/js/components/Marathon.jsx
+++ b/src/js/components/Marathon.jsx
@@ -77,7 +77,7 @@ var Marathon = React.createClass({
 
     if (modalQuery === "new-app") {
       let groupId = params.groupId != null
-        ? decodeURIComponent(params.groupId)
+        ? `${decodeURIComponent(params.groupId)}/`
         : null;
       modal = this.getNewAppModal(groupId);
     } else if (modalQuery === "about") {


### PR DESCRIPTION
![trailing](https://cloud.githubusercontent.com/assets/1078545/13709335/aa665e22-e7b3-11e5-84f3-21ad4073b49c.gif)

This fixes https://github.com/mesosphere/marathon/issues/3440