### PR TITLE
Fix 3459 and 3518: Add Residency only if persistent local volumes are defined

### DIFF
--- a/src/js/actions/AppsActions.js
+++ b/src/js/actions/AppsActions.js
@@ -51,7 +51,11 @@ var AppsActions = {
     }
 
     if (newAppAttributes.container != null &&
-      newAppAttributes.container.volumes != null) {
+        newAppAttributes.container.volumes != null &&
+        newAppAttributes.container.volumes.some(
+          volume => volume.persistent != null
+        )
+    ) {
       newAppAttributes.residency = {
         relaunchEscalationTimeoutSeconds: 10,
         taskLostBehavior: "WAIT_FOREVER"


### PR DESCRIPTION
Add residency settings only to relevant applications which are only applications
which have volumes defined which have a persitent attribute in the object.

This closes mesosphere/marathon#3495

This closes mesosphere/marathon#3518