### PR TITLE
Fix application error invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unversioned
+### Fixed
+- \#3494 - Create application button stays disabled
+
 ## 0.16.0 - 2016-03-14
 ### Added
 - \#3017 - Move application Search Bar to the Header

--- a/src/js/components/AppConfigEditFormComponent.jsx
+++ b/src/js/components/AppConfigEditFormComponent.jsx
@@ -114,8 +114,10 @@ var AppConfigEditFormComponent = React.createClass({
   onFormChange: function (fieldId) {
     var responseErrorMessages = this.state.responseErrorMessages;
 
-    if (responseErrorMessages != null &&
-        responseErrorMessages[fieldId] != null) {
+    // At present we assume that the supplied filed value as well as the general
+    // config is valid.
+    if (responseErrorMessages != null) {
+      delete responseErrorMessages["general"];
       delete responseErrorMessages[fieldId];
     }
 

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -92,6 +92,7 @@ var AppModalComponent = React.createClass({
       });
     } else {
       this.setState({
+        appIsValid: false,
         error: AppFormStore.responseErrors
       });
     }


### PR DESCRIPTION
Change the application error invalidation and assume that the supplied field values as well as the whole config is valid on app form change.

Closes mesosphere/marathon#3494