### PR TITLE
Fix #3542: ports validation error text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - \#3430 - Uncaught TypeError when creating an empty application
 - \#3457 - Ensure unknown API errors are caught
 - \#3440 - Append trailing slash when creating an app within a group
+- \#3542 - Ports validation error text should be red
 
 ## 0.15.6 - 2016-02-23
 - \#3192 - Adapt default Mem/CPU settings

--- a/src/css/components/modal.less
+++ b/src/css/components/modal.less
@@ -29,10 +29,6 @@
     padding-bottom: 5px;
   }
 
-  .help-block {
-    color: @loblolly;
-  }
-
   .modal-header {
     border-bottom: none;
     border-radius: @modal-border-radius @modal-border-radius 0 0;

--- a/src/css/layout/form.less
+++ b/src/css/layout/form.less
@@ -113,7 +113,7 @@
 }
 
 .help-block {
-  color: @oslo-gray;
+  color: @loblolly;
 }
 
 .has-error {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/156010/13948174/e316ab28-f01e-11e5-89f9-e1e3b71dbe1d.png)

This closes mesosphere/marathon#3542