### PR TITLE
Refactor #3482: provide flat apps and groups list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - \#3459 - UI docker volumes validation issue
 - \#3518 - residency added even if no volumes are requested
 - \#3557 - Ports validation errors
+- \#3482 - Empty groups produce duplicate key in App List
 
 ## 0.16.0 - 2016-03-14
 ### Added

--- a/src/js/stores/schemes/groupScheme.js
+++ b/src/js/stores/schemes/groupScheme.js
@@ -17,7 +17,9 @@ const groupScheme = {
   tasksStaged: 0,
   tasksRunning: 0,
   tasksHealthy: 0,
-  tasksUnhealthy: 0
+  tasksUnhealthy: 0,
+  isGroup: true,
+  id: null
 };
 
 export default Util.deepFreeze(groupScheme);

--- a/src/js/stores/schemes/groupScheme.js
+++ b/src/js/stores/schemes/groupScheme.js
@@ -1,0 +1,23 @@
+import Util from "../../helpers/Util";
+
+import HealthStatus from "../../constants/HealthStatus";
+
+const groupScheme = {
+  totalCpus: 0,
+  totalMem: 0,
+  instances: 0,
+  health: [
+    {quantity: 0, state: HealthStatus.HEALTHY},
+    {quantity: 0, state: HealthStatus.UNHEALTHY},
+    {quantity: 0, state: HealthStatus.UNKNOWN},
+    {quantity: 0, state: HealthStatus.STAGED},
+    {quantity: 0, state: HealthStatus.OVERCAPACITY},
+    {quantity: 0, state: HealthStatus.UNSCHEDULED}
+  ],
+  tasksStaged: 0,
+  tasksRunning: 0,
+  tasksHealthy: 0,
+  tasksUnhealthy: 0
+};
+
+export default Util.deepFreeze(groupScheme);

--- a/src/test/scenarios/requestApplications.test.js
+++ b/src/test/scenarios/requestApplications.test.js
@@ -44,8 +44,8 @@ describe("request applications and groups", function () {
   });
 
   it("calculate total resources", function () {
-    expect(AppsStore.apps[0].totalMem).to.equal(500);
-    expect(AppsStore.apps[0].totalCpus).to.equal(20);
+    expect(AppsStore.apps[1].totalMem).to.equal(500);
+    expect(AppsStore.apps[1].totalCpus).to.equal(20);
   });
 
   it("handles failure gracefully", function (done) {
@@ -325,13 +325,13 @@ describe("request applications and groups", function () {
     });
 
     it("handles emtpy groups", function () {
-      var emptyGroup = AppsStore.apps[1];
+      var emptyGroup = AppsStore.apps[0];
       expect(emptyGroup.id).to.eql("/empty-group");
       expect(emptyGroup.isGroup).to.be.true;
     });
 
     it("handles nested applications", function () {
-      var nestedApp = AppsStore.apps[2];
+      var nestedApp = AppsStore.apps[1];
       expect(nestedApp.id).to.eql("/non-empty-group/app-2");
     });
   });

--- a/src/test/units/AppListComponent.test.js
+++ b/src/test/units/AppListComponent.test.js
@@ -38,6 +38,14 @@ describe("AppListComponent", function () {
         cpus: 1
       },
       {
+        id: "/group-alpha",
+        isGroup: true
+      },
+      {
+        id: "/group-alpha/group-beta",
+        isGroup: true
+      },
+      {
         id: "/group-alpha/app-1",
         instances: 1,
         mem: 16,
@@ -56,6 +64,10 @@ describe("AppListComponent", function () {
         cpus: 1
       },
       {
+        id: "/apps",
+        isGroup: true
+      },
+      {
         id: "/apps/sleep",
         instances: 1,
         mem: 16,
@@ -68,10 +80,42 @@ describe("AppListComponent", function () {
         cpus: 1
       },
       {
+        id: "/fuzzy",
+        isGroup: true
+      },
+      {
+        id: "/fuzzy/apps",
+        isGroup: true
+      },
+      {
         id: "/fuzzy/apps/app",
         instances: 1,
         mem: 16,
         cpus: 1
+      },
+      {
+        id: "/group-with-long-name",
+        isGroup: true
+      },
+      {
+        id: "/group-with-long-name/group-with-long-name",
+        isGroup: true
+      },
+      {
+        id: "/group-with-long-name/group-with-long-name/" +
+        "group-with-long-name",
+        isGroup: true
+      },
+      {
+        id: "/group-with-long-name/group-with-long-name/" +
+        "group-with-long-name/group-with-long-name",
+        isGroup: true
+      },
+      {
+        id: "/group-with-long-name/group-with-long-name/" +
+        "group-with-long-name/group-with-long-name/" +
+        "group-with-long-name",
+        isGroup: true
       },
       {
         id: "/group-with-long-name/group-with-long-name/" +


### PR DESCRIPTION
This PR changes the way the `AppsStore` handles the data from the groups endpoint and provides a flat list of apps and groups with aggregated data. This does not provide a tree structure yet.

This replaces #708 

This closes mesosphere/marathon#3482