### PR TITLE
Show serverside errors gracefully

### DIFF
--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -118,16 +118,18 @@ var AppModalComponent = React.createClass({
   getGeneralErrorBlock: function () {
     var error = this.state.error;
 
-    if (this.state.jsonMode && error != null) {
+    if (error == null) {
+      return null;
+    }
+
+    if (this.state.jsonMode && !Util.isString(error)) {
       error = Object.keys(error).map(key => {
         return `${key}: ${error[key]}`;
       });
-    } else if (error != null) {
-      error = error["general"];
     }
 
-    if (error == null) {
-      return null;
+    if (!this.state.jsonMode && Util.isObject(error)) {
+      error = AppFormErrorMessages.getGeneralMessage("general");
     }
 
     if (Util.isArray(error)) {


### PR DESCRIPTION
The changes introduced in https://github.com/mesosphere/marathon-ui/pull/692 unfortunately produced some side-effects as illustrated in https://github.com/mesosphere/marathon/issues/3537. This PR is an attempt at fixing at least the surfacing of the errors.

As can be seen in the .gif, there are still some problems when switching between JSON and normal editors: a proper validation needs to be re-run. Those fixes are outside of this PR.


![servers](https://cloud.githubusercontent.com/assets/1078545/13962970/ae1ea5f2-f063-11e5-96cc-ab73717f1078.gif)

This fixes https://github.com/mesosphere/marathon/issues/3537