### PR TITLE
Update the JSON tooltip link to the docs

### DIFF
--- a/src/js/components/AppConfigJSONEditorComponent.jsx
+++ b/src/js/components/AppConfigJSONEditorComponent.jsx
@@ -56,8 +56,8 @@ var AppConfigJSONEditorComponent = React.createClass({
   render: function () {
     var tooltipMessage = (
       <span>
-        This is the JSON editor
-        docs: <a href={ExternalLinks.JSON_EDITOR} target="_blank">Read more</a>.
+        Use the JSON editor to enter Marathon Application definitions manually.
+        <a href={ExternalLinks.JSON_EDITOR} target="_blank">Read more here</a>.
       </span>
     );
 

--- a/src/js/constants/ExternalLinks.js
+++ b/src/js/constants/ExternalLinks.js
@@ -8,7 +8,8 @@ const ExternalLinks = {
   CONTAINER_PATH:
     "http://mesosphere.github.io/marathon/docs/persistent-volumes.html",
   PORTS: "https://mesosphere.github.io/marathon/docs/ports.html",
-  JSON_EDITOR: "about:blank"
+  JSON_EDITOR: "https://mesosphere.github.io/marathon/docs/generated/" +
+    "api.html#v2_apps_post"
 };
 
 export default Object.freeze(ExternalLinks);


### PR DESCRIPTION
This fixes mesosphere/marathon#3558

![screen shot 2016-03-23 at 12 07 56](https://cloud.githubusercontent.com/assets/1078545/13983457/260fa48a-f0f0-11e5-8f82-3ae493e0bff1.png)

Link points to https://mesosphere.github.io/marathon/docs/generated/api.html#v2_apps_post which is the most comprehensive app definition documentation available online.

cc @leemunroe