### PR TITLE
Fix - 3557: port validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - \#3494 - Create application button stays disabled
 - \#3459 - UI docker volumes validation issue
 - \#3518 - residency added even if no volumes are requested
+- \#3557 - Ports validation errors
 
 ## 0.16.0 - 2016-03-14
 ### Added

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -161,11 +161,11 @@ const responseAttributePathToFieldIdMap = {
     "healthChecks/{INDEX}/maxConsecutiveFailures",
   "/instances": "instances",
   "/mem": "mem",
-  "portDefinitions": "portDefinitions",
-  "portDefinitions[{INDEX}]/name": "portDefinitions/{INDEX}/name",
-  "portDefinitions[{INDEX}]/port": "portDefinitions/{INDEX}/port",
-  "portDefinitions[{INDEX}]/protocol": "portDefinitions/{INDEX}/protocol",
-  "container/docker/portMappings": "portDefinitions",
+  "/portDefinitions": "portDefinitions",
+  "/portDefinitions[{INDEX}]/name": "portDefinitions/{INDEX}/name",
+  "/portDefinitions[{INDEX}]/port": "portDefinitions/{INDEX}/port",
+  "/portDefinitions[{INDEX}]/protocol": "portDefinitions/{INDEX}/protocol",
+  "/container/docker/portMappings": "portDefinitions",
   "/container/docker/portMappings[{INDEX}]/containerPort":
     "portDefinitions/{INDEX}/port",
   "/container/docker/portMappings[{INDEX}]/protocol":

--- a/src/js/stores/transforms/AppFormFieldToModelTransforms.js
+++ b/src/js/stores/transforms/AppFormFieldToModelTransforms.js
@@ -140,6 +140,9 @@ const AppFormFieldToModelTransforms = {
       .map(portDefinition => {
         var definition = Object.assign({}, portDefinition);
         definition.port = parseInt(definition.port, 10);
+        if (definition.name != null) {
+          definition.name = definition.name === "" ? null : definition.name;
+        }
         if (definition.port == null ||
             isNaN(definition.port) ||
             definition.isRandomPort) {

--- a/src/js/stores/transforms/AppFormFieldToModelTransforms.js
+++ b/src/js/stores/transforms/AppFormFieldToModelTransforms.js
@@ -140,8 +140,8 @@ const AppFormFieldToModelTransforms = {
       .map(portDefinition => {
         var definition = Object.assign({}, portDefinition);
         definition.port = parseInt(definition.port, 10);
-        if (definition.name != null) {
-          definition.name = definition.name === "" ? null : definition.name;
+        if (definition.name === "") {
+          definition.name = null;
         }
         if (definition.port == null ||
             isNaN(definition.port) ||

--- a/src/js/stores/transforms/AppFormModelToFieldTransforms.js
+++ b/src/js/stores/transforms/AppFormModelToFieldTransforms.js
@@ -83,9 +83,6 @@ const AppFormModelToFieldTransforms = {
   portDefinitions: portDefinition => {
     return portDefinition
       .map((row, i) => {
-        if (row.name != null) {
-          row.name = row.name === "" ? null : row.name;
-        }
         if (row.containerPort != null) {
           row.port = row.containerPort;
         }

--- a/src/js/stores/transforms/AppFormModelToFieldTransforms.js
+++ b/src/js/stores/transforms/AppFormModelToFieldTransforms.js
@@ -83,6 +83,9 @@ const AppFormModelToFieldTransforms = {
   portDefinitions: portDefinition => {
     return portDefinition
       .map((row, i) => {
+        if (row.name != null) {
+          row.name = row.name === "" ? null : row.name;
+        }
         if (row.containerPort != null) {
           row.port = row.containerPort;
         }


### PR DESCRIPTION
This PR assumes that with an empty string port name that the name should be null. Further the portDefinitions errors are now also surfaced to the ui.

This closes mesosphere/marathon#3557