### PR TITLE
Remove ports entirely in favor of portDefinitions

### DIFF
--- a/src/js/components/modals/EditAppModalComponent.jsx
+++ b/src/js/components/modals/EditAppModalComponent.jsx
@@ -67,12 +67,6 @@ var EditAppModalComponent = React.createClass({
       AppVersionsStore.getAppConfigVersion(props.appId, props.appVersion)
     );
 
-    // This strips out the depricated ports field,
-    // if portDefinitions are set
-    if (app.portDefinitions != null && app.ports != null) {
-      delete app.ports;
-    }
-
     this.setState({
       app: app
     });

--- a/src/js/constants/AppConfigDefaults.js
+++ b/src/js/constants/AppConfigDefaults.js
@@ -7,8 +7,7 @@ export const AppConfigFormDefaultValues = Util.deepFreeze({
   cpus: 1,
   mem: 128,
   disk: 0,
-  instances: 1,
-  ports: "0"
+  instances: 1
 });
 
 // Default values for an 'empty' app config, or the JSON editor
@@ -18,8 +17,7 @@ export const AppConfigDefaultValues = Util.deepFreeze({
   cpus: 1,
   mem: 128,
   disk: 0,
-  instances: 1,
-  ports: [ 0 ]
+  instances: 1
 });
 
 // Complete app configuration with default values
@@ -45,6 +43,10 @@ export const AllAppConfigDefaultValues = Util.deepFreeze(
     },
     labels: {},
     acceptedResourceRoles: null,
-    portDefinitions: []
+    portDefinitions: [{
+      "labels": {},
+      "port": 0,
+      "protocol": "tcp"
+    }]
   })
 );

--- a/src/js/stores/transforms/AppFormModelToFieldTransforms.js
+++ b/src/js/stores/transforms/AppFormModelToFieldTransforms.js
@@ -78,8 +78,6 @@ const AppFormModelToFieldTransforms = {
         return row;
       });
   },
-  ports: (ports) => ports
-    .join(", "),
   portDefinitions: portDefinition => {
     return portDefinition
       .map((row, i) => {

--- a/src/test/fixtures/minimalAppFullConfig.json
+++ b/src/test/fixtures/minimalAppFullConfig.json
@@ -13,9 +13,12 @@
   "uris": [],
   "fetch": [],
   "storeUrls": [],
-  "ports": [
-    12345
-  ],
+  "portDefinitions": [{
+    "labels": {},
+    "port": 0,
+    "protocol": "tcp"
+  }],
+  "ports": [0],
   "requirePorts": false,
   "backoffSeconds": 1,
   "backoffFactor": 1.15,

--- a/src/test/scenarios/requestSpecificApplicationVersion.test.js
+++ b/src/test/scenarios/requestSpecificApplicationVersion.test.js
@@ -10,6 +10,9 @@ import AppVersionsActions from "../../js/actions/AppVersionsActions";
 import AppVersionsEvents from "../../js/events/AppVersionsEvents";
 import AppVersionsStore from "../../js/stores/AppVersionsStore";
 
+var server = config.localTestserverURI;
+config.apiURL = "http://" + server.address + ":" + server.port + "/";
+
 describe("request specific application version", function () {
 
   it("updates the AppVersionsStore on success", function (done) {
@@ -64,8 +67,7 @@ describe("request specific application version", function () {
           );
           expect(config).to.deep.equal({
             id: "/app-id",
-            cmd: "some --cmd",
-            ports: [12345]
+            cmd: "some --cmd"
           });
         }, done);
       });
@@ -92,7 +94,6 @@ describe("request specific application version", function () {
           expect(config).to.deep.equal({
             id: "/app-id",
             cmd: "some --cmd",
-            ports: [12345],
             labels: {testing: "123"}
           });
         }, done);

--- a/src/test/units/AppFormTransforms.test.js
+++ b/src/test/units/AppFormTransforms.test.js
@@ -678,11 +678,6 @@ describe("App Form Model To Field Transform", function () {
 
     });
 
-    it("ports array to string", function () {
-      expect(AppFormTransforms.ModelToField.ports([12233, 12244, 12255]))
-        .to.equal("12233, 12244, 12255");
-    });
-
     it("uris string to an array of uris", function () {
       expect(AppFormTransforms.ModelToField
           .uris(["http://test.de/", "http://test.com"]))


### PR DESCRIPTION
This PR finally addresses the issue of conflicting `ports` and `portDefinitions` by removing the `ports` entirely from the UI.

This fixes mesosphere/marathon#3470
