### PR TITLE
Switch to object to boost performance

### DIFF
--- a/src/js/components/AppConfigEditFormComponent.jsx
+++ b/src/js/components/AppConfigEditFormComponent.jsx
@@ -141,7 +141,7 @@ var AppConfigEditFormComponent = React.createClass({
   getErrorMessage: function (fieldId) {
     var state = this.state;
     var errorIndex = state.errorIndices[fieldId];
-    if (errorIndex != null && !Util.isArray(errorIndex)) {
+    if (errorIndex != null && !Util.isObject(errorIndex)) {
       return AppFormErrorMessages.getFieldMessage(fieldId, errorIndex);
     }
     if (state.responseErrorMessages[fieldId] != null) {

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -252,7 +252,7 @@ function updateErrorIndices(fieldId, value, errorIndices) {
   var errorIndex = getValidationErrorIndex(fieldId, value);
   if (errorIndex > -1) {
     if (value.consecutiveKey != null) {
-      Util.initKeyValue(errorIndices, fieldId, []);
+      Util.initKeyValue(errorIndices, fieldId, {});
       errorIndices[fieldId][value.consecutiveKey] = errorIndex;
     } else {
       errorIndices[fieldId] = errorIndex;


### PR DESCRIPTION
This fixes https://github.com/mesosphere/marathon/issues/3577

Demo on Safari OSX:

![safarifix](https://cloud.githubusercontent.com/assets/1078545/14116103/6eb2d084-f5de-11e5-8916-607d17566094.gif)

#### Background 

Using a sparse array to keep track of consecutive row keys with arbitrary values, such as `213456342` has some major performance hits on certain browsers (i.e. Safari OSX) when using `.slice()` (as done by `Util.deepCopy`). It turns out that when calling `.slice()` on such arrays, will probably iterate through all the `null` values before reaching ours.

By switching to a dictionary, we improve the performance from `O(n)` to `O(1)`. Not bad!

Thanks to @aldipower for the help on this one.