### PR TITLE
Manually bump ansi-styles after unpublishing

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -81,7 +81,7 @@
       "from": "ansi-regex@>=2.0.0 <3.0.0"
     },
     "ansi-styles": {
-      "version": "2.2.0",
+      "version": "2.2.1",
       "from": "ansi-styles@>=2.1.0 <3.0.0"
     },
     "ansicolors": {


### PR DESCRIPTION
`ansi-styles` 2.2.0 was "unpublished" from npm, which breaks our builds. Bumping manually to 2.2.1 as suggested in https://github.com/chalk/ansi-styles/issues/17