### PR TITLE
Fix various create/edit modal issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 ## Unversioned
+### Fixed
+- \#3552 - Editing an App: Switching between JSON and normal Editor
+  produces a broken UX
+
+### Changed
+- \#3426 - Improve ports validation
+- \#3559 - Create Modal: always show Port Index for host ports
+- \#3424 - Maintain "assign random port" settings after JSON mode switch
+
 ### Added
 - VIP labels in port definitions
 

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -276,6 +276,7 @@ var AppModalComponent = React.createClass({
             style={{display: "none"}} />
           <div className="modal-header">
             <input id="json-toggle" type="checkbox" name="checkbox"
+              checked={state.jsonMode}
               className="toggle" onChange={this.onJSONToggleChange} />
             <label htmlFor="json-toggle">JSON Mode</label>
             <h2 className="modal-title">

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -152,14 +152,10 @@ var AppModalComponent = React.createClass({
       return null;
     }
 
-    if (this.state.jsonMode && !Util.isString(error)) {
+    if (Util.isObject(error)) {
       error = Object.keys(error).map(key => {
         return `${key}: ${error[key]}`;
       });
-    }
-
-    if (!this.state.jsonMode && Util.isObject(error)) {
-      error = AppFormErrorMessages.getGeneralMessage("general");
     }
 
     if (Util.isArray(error)) {

--- a/src/js/stores/validators/AppFormValidators.js
+++ b/src/js/stores/validators/AppFormValidators.js
@@ -117,19 +117,23 @@ const AppFormValidators = {
   },
 
   healthChecksGracePeriod: (obj) => {
-    return !!obj.gracePeriodSeconds.toString().match(/^[0-9]+$/);
+    return obj.gracePeriodSeconds &&
+      !!obj.gracePeriodSeconds.toString().match(/^[0-9]+$/);
   },
 
   healthChecksInterval: (obj) => {
-    return !!obj.intervalSeconds.toString().match(/^[0-9]+$/);
+    return obj.intervalSeconds &&
+      !!obj.intervalSeconds.toString().match(/^[0-9]+$/);
   },
 
   healthChecksTimeout: (obj) => {
-    return !!obj.timeoutSeconds.toString().match(/^[0-9]+$/);
+    return obj.timeoutSeconds &&
+      !!obj.timeoutSeconds.toString().match(/^[0-9]+$/);
   },
 
   healthChecksMaxConsecutiveFailures: (obj) => {
-    return !!obj.maxConsecutiveFailures.toString().match(/^[0-9]+$/);
+    return obj.maxConsecutiveFailures &&
+      !!obj.maxConsecutiveFailures.toString().match(/^[0-9]+$/);
   },
 
   instances: (value) => !Util.isStringAndEmpty(value) &&


### PR DESCRIPTION
This PR addresses various issues within the create/edit modal dialog.

Closes https://github.com/mesosphere/marathon/issues/3426
Closes https://github.com/mesosphere/marathon/issues/3552
Closes https://github.com/mesosphere/marathon/issues/3559
Closes https://github.com/mesosphere/marathon/issues/3424

~~and introduces a "quickfix" for the issue as described in https://github.com/mesosphere/marathon/issues/3595#issuecomment-203540080~~

**Update**: removing the quickfix part and restoring the bug until we have a proper fix. 

(**obsolete**) The quickfix (which suggests the user to switch to the JSON editor if dealing with a `BRIDGE` mode container) is meant as a quick response to the severe problem reported in the [linked issue](https://github.com/mesosphere/marathon/issues/3595) so we can release a bugfix version asap. 

#### Video 1
showing the UI "giving up" when `BRIDGE` mode is selected, thus preventing the user from accidentally overwriting the `portMappings`:

![wf1](https://cloud.githubusercontent.com/assets/1078545/14153438/1bc762c4-f6b8-11e5-9eee-1319840ffdab.gif)

#### Video 2
showing the now disabled port input fields as described in https://github.com/mesosphere/marathon/issues/3559

![wf2](https://cloud.githubusercontent.com/assets/1078545/14153475/3f5abbd2-f6b8-11e5-8bab-04b7cbfb7467.gif)

#### Video 3
displaying all server-side validation errors in both the JSON and the normal edit modal:


![wf3](https://cloud.githubusercontent.com/assets/1078545/14153600/bfe3d658-f6b8-11e5-9275-8adc628fca49.gif)


cc @gkleiman @aquamatthias @leemunroe @aldipower @orlandohohmeier