### PR TITLE
Fix various create/edit modal issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 ## Unversioned
+### Fixed
+- \#3552 - Editing an App: Switching between JSON and normal Editor
+  produces a broken UX
+
+### Changed
+- \#3426 - Improve ports validation
+- \#3559 - Create Modal: always show Port Index for host ports
+- \#3424 - Maintain "assign random port" settings after JSON mode switch
+
 ### Added
 - VIP labels in port definitions
 

--- a/src/js/components/AppConfigEditFormComponent.jsx
+++ b/src/js/components/AppConfigEditFormComponent.jsx
@@ -6,6 +6,7 @@ import AppsEvents from "../events/AppsEvents";
 import AppFormErrorMessages from "../constants/AppFormErrorMessages";
 import AppFormStore from "../stores/AppFormStore";
 import AppsStore from "../stores/AppsStore";
+import ContainerConstants from "../constants/ContainerConstants";
 import ContainerSettingsComponent
   from "../components/ContainerSettingsComponent";
 import ContentComponent from "../components/ContentComponent";
@@ -15,6 +16,8 @@ import FormGroupComponent from "../components/FormGroupComponent";
 import HealthChecksComponent from "../components/HealthChecksComponent";
 import MenuComponent from "../components/MenuComponent";
 import MenuItemComponent from "../components/MenuItemComponent";
+import OptionalDockerPortMappingsComponent
+  from "../components/OptionalDockerPortMappingsComponent";
 import OptionalEnvironmentComponent
   from "../components/OptionalEnviromentComponent";
 import OptionalLabelsComponent from "../components/OptionalLabelsComponent";
@@ -176,6 +179,39 @@ var AppConfigEditFormComponent = React.createClass({
     this.onMenuChange("volumes");
   },
 
+  setViewPorts: function () {
+    this.onMenuChange("ports");
+  },
+
+  getOptionalPortsComponent: function () {
+    var state = this.state;
+
+    if (state.fields.dockerNetwork === ContainerConstants.NETWORK.BRIDGE) {
+      return (
+        <OptionalDockerPortMappingsComponent
+          errorIndices={state.errorIndices}
+          fields={state.fields}
+          getErrorMessage={this.getErrorMessage}
+          handleModeToggle={this.props.handleModeToggle}
+          hasVIP={this.hasVIP()} />
+      );
+    }
+
+    const type = state.fields.dockerNetwork === ContainerConstants.NETWORK.HOST
+      ? ContainerConstants.TYPE.DOCKER
+      : ContainerConstants.TYPE.MESOS;
+
+    return (
+      <OptionalPortsAndServiceDiscoveryComponent
+        containerType={type}
+        errorIndices={state.errorIndices}
+        fields={state.fields}
+        getErrorMessage={this.getErrorMessage}
+        handleModeToggle={this.props.handleModeToggle}
+        hasVIP={this.hasVIP()} />
+    );
+  },
+
   getPortsPanelTitle: function () {
     var title = "Ports";
 
@@ -327,15 +363,11 @@ var AppConfigEditFormComponent = React.createClass({
               errorIndices={state.errorIndices}
               fields={state.fields}
               getErrorMessage={this.getErrorMessage}
+              openPorts={this.setViewPorts}
               openVolumes={this.setViewVolumes}/>
           </SectionComponent>
           <SectionComponent sectionId="ports">
-            <OptionalPortsAndServiceDiscoveryComponent
-              errorIndices={state.errorIndices}
-              fields={state.fields}
-              getErrorMessage={this.getErrorMessage}
-              handleModeToggle={this.props.handleModeToggle}
-              hasVIP={this.hasVIP()} />
+            {this.getOptionalPortsComponent()}
           </SectionComponent>
           <SectionComponent sectionId="env">
             <OptionalEnvironmentComponent

--- a/src/js/components/ContainerSettingsComponent.jsx
+++ b/src/js/components/ContainerSettingsComponent.jsx
@@ -28,6 +28,7 @@ var ContainerSettingsComponent = React.createClass({
   propTypes: {
     fields: React.PropTypes.object.isRequired,
     getErrorMessage: React.PropTypes.func.isRequired,
+    openPorts: React.PropTypes.func,
     openVolumes: React.PropTypes.func
   },
 
@@ -177,6 +178,12 @@ var ContainerSettingsComponent = React.createClass({
           volumes <a onClick={this.props.openVolumes}>
             in the Volumes section
           </a>.
+        </div>
+        <div>
+          You can configure your Docker
+          ports <a onClick={this.props.openPorts}>
+          in the Ports section
+        </a>.
         </div>
       </div>
     );

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -276,6 +276,7 @@ var AppModalComponent = React.createClass({
             style={{display: "none"}} />
           <div className="modal-header">
             <input id="json-toggle" type="checkbox" name="checkbox"
+              checked={state.jsonMode}
               className="toggle" onChange={this.onJSONToggleChange} />
             <label htmlFor="json-toggle">JSON Mode</label>
             <h2 className="modal-title">

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -152,14 +152,10 @@ var AppModalComponent = React.createClass({
       return null;
     }
 
-    if (this.state.jsonMode && !Util.isString(error)) {
+    if (Util.isObject(error)) {
       error = Object.keys(error).map(key => {
         return `${key}: ${error[key]}`;
       });
-    }
-
-    if (!this.state.jsonMode && Util.isObject(error)) {
-      error = AppFormErrorMessages.getGeneralMessage("general");
     }
 
     if (Util.isArray(error)) {

--- a/src/js/mixins/DuplicableRowsMixin.jsx
+++ b/src/js/mixins/DuplicableRowsMixin.jsx
@@ -24,6 +24,13 @@ var DuplicableRowsMixin = {
   },
 
   componentWillReceiveProps: function (nextProps) {
+    Object.keys(this.duplicableRowsScheme).forEach(key => {
+      if (!nextProps.fields.hasOwnProperty(key)) {
+        throw new Error(`Please ensure ${key} is defined in
+          AppFormStore#duplicableRowFields.`);
+      }
+    });
+
     this.setState({
       rows: this.getPopulatedRows(nextProps.fields)
     }, this.enforceMinRows);

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -24,6 +24,7 @@ const duplicableRowFields = Object.freeze([
   "containerVolumes",
   "localVolumes",
   "dockerParameters",
+  "dockerPortMappings",
   "env",
   "healthChecks",
   "labels",
@@ -101,6 +102,7 @@ const resolveFieldIdToAppKeyMap = {
   dockerNetwork: "container.docker.network",
   dockerParameters: "container.docker.parameters",
   dockerPrivileged: "container.docker.privileged",
+  dockerPortMappings: "container.docker.portMappings",
   healthChecks: "healthChecks",
   instances: "instances",
   env: "env",
@@ -165,13 +167,13 @@ const responseAttributePathToFieldIdMap = {
   "/portDefinitions[{INDEX}]/name": "portDefinitions/{INDEX}/name",
   "/portDefinitions[{INDEX}]/port": "portDefinitions/{INDEX}/port",
   "/portDefinitions[{INDEX}]/protocol": "portDefinitions/{INDEX}/protocol",
-  "/container/docker/portMappings": "portDefinitions",
+  "/container/docker/portMappings": "dockerPortMappings",
   "/container/docker/portMappings[{INDEX}]/containerPort":
-    "portDefinitions/{INDEX}/port",
+    "dockerPortMappings/{INDEX}/port",
   "/container/docker/portMappings[{INDEX}]/protocol":
-    "portDefinitions/{INDEX}/protocol",
-  "/container/docker/portMappings[{INDEX}]/hostPort": "portDefinitions",
-  "/container/docker/portMappings[{INDEX}]/servicePort": "portDefinitions",
+    "dockerPortMappings/{INDEX}/protocol",
+  "/container/docker/portMappings[{INDEX}]/hostPort": "dockerPortMappings",
+  "/container/docker/portMappings[{INDEX}]/servicePort": "dockerPortMappings",
   "/labels": "labels",
   "/uris": "uris",
   "/user": "user",
@@ -188,7 +190,7 @@ const resolveAppKeyToFieldIdMap = {
   "container.docker.forcePullImage": ["dockerForcePullImage"],
   "container.docker.image": ["dockerImage"],
   "container.docker.network": ["dockerNetwork"],
-  "container.docker.portMappings": ["portDefinitions"],
+  "container.docker.portMappings": ["dockerPortMappings"],
   "container.docker.parameters": ["dockerParameters"],
   "container.docker.privileged": ["dockerPrivileged"],
   "container.volumes": [
@@ -334,14 +336,6 @@ function populateFieldsFromModel(app, fields) {
   // The env/labels-object should be treated as an object itself,
   // so it's excluded.
   var paths = Util.detectObjectPaths(app, null, ["env", "labels"]);
-
-  var dockerNetwork =
-    objectPath.get(app, "container.docker.network");
-
-  if (dockerNetwork != null &&
-      dockerNetwork === ContainerConstants.NETWORK.BRIDGE) {
-    paths = paths.filter(appKey => appKey !== "portDefinitions");
-  }
 
   paths.forEach(appKey => {
     var fieldIdArray = resolveAppKeyToFieldIdMap[appKey];

--- a/src/js/stores/transforms/AppFormModelPostProcess.js
+++ b/src/js/stores/transforms/AppFormModelPostProcess.js
@@ -33,9 +33,9 @@ const AppFormModelPostProcess = {
       return;
     }
 
-    if ((container.docker == null || container.docker.image == null ||
-        container.docker.image === "") &&
-        container.volumes != null) {
+    if (container.docker == null &&
+        container.volumes != null &&
+        container.volumes.length > 0) {
       delete container.docker;
       container.volumes = container.volumes.filter(row => {
         return row.hostPath == null;
@@ -45,21 +45,6 @@ const AppFormModelPostProcess = {
     container.type = container.docker != null
       ? ContainerConstants.TYPE.DOCKER
       : ContainerConstants.TYPE.MESOS;
-
-    if (container.type === ContainerConstants.TYPE.DOCKER &&
-        container.docker.network === ContainerConstants.NETWORK.BRIDGE &&
-        app.portDefinitions != null) {
-      container.docker.portMappings =
-        app.portDefinitions.map(portDefinition => {
-          var definition = Object.assign({}, portDefinition);
-          definition.containerPort = definition.port;
-          delete definition.port;
-          if (definition.hostPort == null) {
-            definition.hostPort = 0;
-          }
-          return definition;
-        });
-    }
 
     let isEmpty = (Util.isArray(container.volumes) &&
         container.volumes.length === 0 ||

--- a/src/js/stores/transforms/AppFormModelToFieldTransforms.js
+++ b/src/js/stores/transforms/AppFormModelToFieldTransforms.js
@@ -2,6 +2,18 @@ import HealthCheckProtocols from "../../constants/HealthCheckProtocols";
 import HealthCheckPortTypes from "../../constants/HealthCheckPortTypes";
 import Util from "../../helpers/Util";
 
+function transformPortDefinitionRows (portDefinitionRows, portField) {
+  return portDefinitionRows.map((row, i) => {
+    row[portField] = row[portField];
+    row.consecutiveKey = i;
+    if (row.labels != null && row.labels["VIP_0"] != null) {
+      row.vip = row.labels["VIP_0"];
+      delete row.labels["VIP_0"];
+    }
+    return row;
+  });
+}
+
 const AppFormModelToFieldTransforms = {
   acceptedResourceRoles: (acceptedResourceRoles) => {
     return acceptedResourceRoles != null
@@ -12,6 +24,9 @@ const AppFormModelToFieldTransforms = {
     return constraints
       .map((constraint) => constraint.join(":"))
       .join(", ");
+  },
+  dockerPortMappings: portMappings => {
+    return transformPortDefinitionRows(portMappings, "containerPort");
   },
   dockerParameters: (parameters) => {
     return parameters
@@ -79,20 +94,7 @@ const AppFormModelToFieldTransforms = {
       });
   },
   portDefinitions: portDefinition => {
-    return portDefinition
-      .map((row, i) => {
-        if (row.containerPort != null) {
-          row.port = row.containerPort;
-        }
-        if (row.labels != null && row.labels["VIP_0"] != null) {
-          row.vip = row.labels["VIP_0"];
-          delete row.labels["VIP_0"];
-        }
-        row.isRandomPort = false;
-        row.consecutiveKey = i;
-
-        return row;
-      });
+    return transformPortDefinitionRows(portDefinition, "port");
   },
   uris: (uris) => uris
     .join(", "),

--- a/src/js/stores/validators/AppFormValidators.js
+++ b/src/js/stores/validators/AppFormValidators.js
@@ -117,19 +117,23 @@ const AppFormValidators = {
   },
 
   healthChecksGracePeriod: (obj) => {
-    return !!obj.gracePeriodSeconds.toString().match(/^[0-9]+$/);
+    return obj.gracePeriodSeconds != null &&
+      !!obj.gracePeriodSeconds.toString().match(/^[0-9]+$/);
   },
 
   healthChecksInterval: (obj) => {
-    return !!obj.intervalSeconds.toString().match(/^[0-9]+$/);
+    return obj.intervalSeconds != null &&
+      !!obj.intervalSeconds.toString().match(/^[0-9]+$/);
   },
 
   healthChecksTimeout: (obj) => {
-    return !!obj.timeoutSeconds.toString().match(/^[0-9]+$/);
+    return obj.timeoutSeconds != null &&
+      !!obj.timeoutSeconds.toString().match(/^[0-9]+$/);
   },
 
   healthChecksMaxConsecutiveFailures: (obj) => {
-    return !!obj.maxConsecutiveFailures.toString().match(/^[0-9]+$/);
+    return obj.maxConsecutiveFailures != null &&
+      !!obj.maxConsecutiveFailures.toString().match(/^[0-9]+$/);
   },
 
   instances: (value) => !Util.isStringAndEmpty(value) &&
@@ -161,6 +165,7 @@ const AppFormValidators = {
     Util.isStringAndEmpty(obj.containerPath)),
 
   portDefinitionsPortIsValid: (obj) => {
+    // TODO is this needed?
     if (obj.isRandomPort === false) {
       return obj.port != null && obj.port !== "" && isValidPort(obj.port);
     }

--- a/src/test/units/AppFormModelPostProcess.test.js
+++ b/src/test/units/AppFormModelPostProcess.test.js
@@ -71,69 +71,6 @@ describe("App Form Model Post Process", function () {
       expect(app.cmd).to.equal(null);
     });
 
-    it("transforms portDefinitions to dockerPortMapping if bridge network",
-        function () {
-      var app = {
-        container: {
-          docker: {
-            image: "group/image",
-            network: ContainerConstants.NETWORK.BRIDGE
-          }
-        },
-        portDefinitions: [
-          {
-            port: 1,
-            protocol: "tcp",
-            name: "port1"
-          },
-          {
-            port: 2,
-            protocol: "tcp",
-            name: "port2"
-          }
-        ]
-      };
-
-      AppFormModelPostProcess.container(app);
-
-      expect(app).to.deep.equal({
-        container: {
-          type: ContainerConstants.TYPE.DOCKER,
-          docker: {
-            image: "group/image",
-            network: ContainerConstants.NETWORK.BRIDGE,
-            portMappings: [
-              {
-                containerPort: 1,
-                hostPort: 0,
-                protocol: "tcp",
-                name: "port1"
-              },
-              {
-                containerPort: 2,
-                hostPort: 0,
-                protocol: "tcp",
-                name: "port2"
-              }
-            ]
-          }
-        },
-        // This won't be removed in the transformator
-        portDefinitions: [
-          {
-            port: 1,
-            protocol: "tcp",
-            name: "port1"
-          },
-          {
-            port: 2,
-            protocol: "tcp",
-            name: "port2"
-          }
-        ]
-      });
-    });
-
   });
 
   describe("health checks", function () {

--- a/src/test/units/AppFormTransforms.test.js
+++ b/src/test/units/AppFormTransforms.test.js
@@ -133,6 +133,134 @@ describe("App Form Field to Model Transform", function () {
       ])).to.deep.equal([]);
     });
 
+    describe("dockerPortMappings", function () {
+      it("to the equivalent container.docker.portMappings", function () {
+        expect(AppFormTransforms.FieldToModel.dockerPortMappings([
+          {
+            consecutiveKey: 1,
+            containerPort: 0,
+            protocol: "tcp",
+            name: "testport",
+            vip: null
+          }
+        ])).to.deep.equal([
+          {
+            containerPort: 0,
+            protocol: "tcp",
+            name: "testport"
+          }
+        ]);
+      });
+
+      it("preserving labels", function () {
+        expect(AppFormTransforms.FieldToModel.dockerPortMappings([
+          {
+            consecutiveKey: 1,
+            containerPort: 8000,
+            protocol: "tcp",
+            labels: {"testlabel": "testvalue"},
+            name: "testport",
+            vip: null
+          }
+        ])).to.deep.equal([
+          {
+            containerPort: 8000,
+            protocol: "tcp",
+            labels: {"testlabel": "testvalue"},
+            name: "testport"
+          }
+        ]);
+      });
+
+      it("preserving unknown keys", function () {
+        expect(AppFormTransforms.FieldToModel.dockerPortMappings([
+          {
+            containerPort: 8080,
+            label: {},
+            consecutiveKey: 1
+          }
+        ])).to.deep.equal([
+          {
+            containerPort: 8080,
+            label: {}
+          }
+        ]);
+      });
+
+      it("setting the right default value for port", function () {
+        expect(AppFormTransforms.FieldToModel.dockerPortMappings([
+          {
+            consecutiveKey: 2,
+            protocol: "tcp"
+          }
+        ])).to.deep.equal([
+          {
+            containerPort: 0,
+            protocol: "tcp"
+          }
+        ]);
+
+        expect(AppFormTransforms.FieldToModel.dockerPortMappings([
+          {
+            consecutiveKey: 3,
+            protocol: "tcp",
+            containerPort: null
+          }
+        ])).to.deep.equal([
+          {
+            containerPort: 0,
+            protocol: "tcp"
+          }
+        ]);
+      });
+
+      it("setting the right default value for name", function () {
+        expect(AppFormTransforms.FieldToModel.dockerPortMappings([
+          {
+            consecutiveKey: 2,
+            name: "",
+            protocol: "tcp"
+          }
+        ])).to.deep.equal([
+          {
+            name: null,
+            containerPort: 0,
+            protocol: "tcp"
+          }
+        ]);
+      });
+
+      it("to a cleaned array of multiple objects", function () {
+        expect(AppFormTransforms.FieldToModel.dockerPortMappings([
+          {
+            consecutiveKey: 1,
+            containerPort: 0,
+            protocol: "tcp",
+            name: "testport",
+            label: {}
+          },
+          {
+            consecutiveKey: 2,
+            containerPort: 0,
+            protocol: "udp",
+            name: "testport2"
+          }
+        ])).to.deep.equal([
+          {
+            containerPort: 0,
+            protocol: "tcp",
+            name: "testport",
+            label: {}
+          },
+          {
+            containerPort: 0,
+            protocol: "udp",
+            name: "testport2"
+          }
+        ]);
+      });
+    });
+
     it("dockerPrivileged is checked", function () {
       expect(AppFormTransforms.FieldToModel.dockerPrivileged(true))
         .to.be.true;
@@ -215,15 +343,15 @@ describe("App Form Field to Model Transform", function () {
         .to.deep.equal([]);
     });
 
-    describe("portDefinitions", function () {
-      it("tansforms to cleaned array of one object", function () {
+    describe("portDefinitions rows", function () {
+      it("to the equivalent portDefinitions on the model", function () {
         expect(AppFormTransforms.FieldToModel.portDefinitions([
           {
             consecutiveKey: 1,
-            isRandomPort: false,
             port: 8000,
             protocol: "tcp",
-            name: "testport"
+            name: "testport",
+            vip: null
           }
         ])).to.deep.equal([
           {
@@ -234,7 +362,27 @@ describe("App Form Field to Model Transform", function () {
         ]);
       });
 
-      it("preserves unknown keys", function () {
+      it("preserving labels", function () {
+        expect(AppFormTransforms.FieldToModel.portDefinitions([
+          {
+            consecutiveKey: 1,
+            port: 8000,
+            protocol: "tcp",
+            labels: {"testlabel": "testvalue"},
+            name: "testport",
+            vip: null
+          }
+        ])).to.deep.equal([
+          {
+            port: 8000,
+            protocol: "tcp",
+            labels: {"testlabel": "testvalue"},
+            name: "testport"
+          }
+        ]);
+      });
+
+      it("preserving unknown keys", function () {
         expect(AppFormTransforms.FieldToModel.portDefinitions([
           {
             port: 8080,
@@ -249,13 +397,24 @@ describe("App Form Field to Model Transform", function () {
         ]);
       });
 
-      it("set 0 port if isRandomPort true", function () {
+      it("setting the right default value for port", function () {
         expect(AppFormTransforms.FieldToModel.portDefinitions([
           {
             consecutiveKey: 2,
-            isRandomPort: true,
-            port: 8000,
             protocol: "tcp"
+          }
+        ])).to.deep.equal([
+          {
+            port: 0,
+            protocol: "tcp"
+          }
+        ]);
+
+        expect(AppFormTransforms.FieldToModel.portDefinitions([
+          {
+            consecutiveKey: 3,
+            protocol: "tcp",
+            port: null
           }
         ])).to.deep.equal([
           {
@@ -265,41 +424,40 @@ describe("App Form Field to Model Transform", function () {
         ]);
       });
 
-      it("set 0 port if no port is given", function () {
+      it("setting the right default value for name", function () {
         expect(AppFormTransforms.FieldToModel.portDefinitions([
           {
             consecutiveKey: 2,
-            isRandomPort: false,
+            name: "",
             protocol: "tcp"
           }
         ])).to.deep.equal([
           {
+            name: null,
             port: 0,
             protocol: "tcp"
           }
         ]);
       });
 
-      it("transforms to cleaned array of multiple objects", function () {
+      it("to a cleaned array of multiple objects", function () {
         expect(AppFormTransforms.FieldToModel.portDefinitions([
           {
             consecutiveKey: 1,
-            isRandomPort: false,
-            port: 8000,
+            port: 0,
             protocol: "tcp",
             name: "testport",
             label: {}
           },
           {
             consecutiveKey: 2,
-            isRandomPort: true,
-            port: 8001,
+            port: 0,
             protocol: "udp",
             name: "testport2"
           }
         ])).to.deep.equal([
           {
-            port: 8000,
+            port: 0,
             protocol: "tcp",
             name: "testport",
             label: {}
@@ -337,7 +495,7 @@ describe("App Form Model To Field Transform", function () {
     });
 
     describe("portDefinitions", function () {
-      it("to array with consecutiveKey and isRandomPort", function () {
+      it("to array with consecutiveKey", function () {
         expect(AppFormTransforms.ModelToField.portDefinitions([
           {
             port: 1,
@@ -355,19 +513,16 @@ describe("App Form Model To Field Transform", function () {
         ])).to.deep.equal([
           {
             consecutiveKey: 0,
-            isRandomPort: false,
             port: 1,
             protocol: "tcp"
           },
           {
             consecutiveKey: 1,
-            isRandomPort: false,
             port: 2,
             protocol: "udp"
           },
           {
             consecutiveKey: 2,
-            isRandomPort: false,
             port: 3,
             servicePort: 3,
             protocol: "tcp"
@@ -388,7 +543,6 @@ describe("App Form Model To Field Transform", function () {
         ])).to.deep.equal([
           {
             consecutiveKey: 0,
-            isRandomPort: false,
             port: 1,
             hostPort: 8,
             servicePort: 5,
@@ -399,22 +553,6 @@ describe("App Form Model To Field Transform", function () {
         ]);
       });
 
-      it("copies containerPort to port", function () {
-        expect(AppFormTransforms.ModelToField.portDefinitions([
-          {
-            containerPort: 1,
-            protocol: "tcp"
-          }
-        ])).to.deep.equal([
-          {
-            consecutiveKey: 0,
-            isRandomPort: false,
-            containerPort: 1,
-            port: 1,
-            protocol: "tcp"
-          }
-        ]);
-      });
     });
 
     it("dockerParameters to array with consecutiveKey", function () {
@@ -425,6 +563,67 @@ describe("App Form Model To Field Transform", function () {
         {key: "key1", value: "value1", consecutiveKey: 0},
         {key: "key2", value: "value2", consecutiveKey: 1}
       ]);
+    });
+
+    describe("dockerPortMappings", function () {
+      it("to array with consecutiveKey", function () {
+        expect(AppFormTransforms.ModelToField.dockerPortMappings([
+          {
+            containerPort: 1,
+            protocol: "tcp"
+          },
+          {
+            containerPort: 2,
+            protocol: "udp"
+          },
+          {
+            containerPort: 3,
+            servicePort: 3,
+            protocol: "tcp"
+          }
+        ])).to.deep.equal([
+          {
+            consecutiveKey: 0,
+            containerPort: 1,
+            protocol: "tcp"
+          },
+          {
+            consecutiveKey: 1,
+            containerPort: 2,
+            protocol: "udp"
+          },
+          {
+            consecutiveKey: 2,
+            containerPort: 3,
+            servicePort: 3,
+            protocol: "tcp"
+          }
+        ]);
+      });
+
+      it("preserves unknown keys", function () {
+        expect(AppFormTransforms.ModelToField.dockerPortMappings([
+          {
+            containerPort: 1,
+            hostPort: 8,
+            servicePort: 5,
+            protocol: "tcp",
+            name: "testport",
+            label: {}
+          }
+        ])).to.deep.equal([
+          {
+            consecutiveKey: 0,
+            containerPort: 1,
+            hostPort: 8,
+            servicePort: 5,
+            protocol: "tcp",
+            name: "testport",
+            label: {}
+          }
+        ]);
+      });
+
     });
 
     it("containerVolumes to array with consecutiveKey", function () {


### PR DESCRIPTION
This PR addresses various issues within the create/edit modal dialog.

Closes https://github.com/mesosphere/marathon/issues/3426
Closes https://github.com/mesosphere/marathon/issues/3552
Closes https://github.com/mesosphere/marathon/issues/3559
Closes https://github.com/mesosphere/marathon/issues/3424

It also introduces a separation of concerns in how the `portDefinitions` and the `container.docker.portMappings` are handled, which

closes https://github.com/mesosphere/marathon/issues/3595



#### Video 1
Showing how the UI deals with ports in HOST mode and BRIDGE mode when creating a new application.

![ports](https://cloud.githubusercontent.com/assets/1078545/14209663/86e49180-f825-11e5-90a6-d8bb982fcdb4.gif)

#### Video 2
Showing how the UI allows editing the portMappings and portDefinitions indepentently, depending on the networking mode of the app.

![editingports](https://cloud.githubusercontent.com/assets/1078545/14209702/a8eb5c0a-f825-11e5-88cf-661e693e40d4.gif)




cc @gkleiman @aquamatthias @leemunroe @aldipower @orlandohohmeier