### PR TITLE
Add missing CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 ### Fixed
 - \#3552 - Editing an App: Switching between JSON and normal Editor
   produces a broken UX
-
+- \#3564 - Add link to Docker section for Ports
+- 
 ### Changed
 - \#3426 - Improve ports validation
 - \#3559 - Create Modal: always show Port Index for host ports


### PR DESCRIPTION
Add link to Docker section for Ports #3564 was also closed in https://github.com/mesosphere/marathon-ui/pull/721