### PR TITLE
Set docker network to HOST by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 - \#3552 - Editing an App: Switching between JSON and normal Editor
   produces a broken UX
 - \#3564 - Add link to Docker section for Ports
-- 
+- \#3519 - The default Docker network should be host
+- \#3587 - Not specifying "network" config causes mesos to thrash
+
 ### Changed
 - \#3426 - Improve ports validation
 - \#3559 - Create Modal: always show Port Index for host ports

--- a/src/js/components/ContainerSettingsComponent.jsx
+++ b/src/js/components/ContainerSettingsComponent.jsx
@@ -137,7 +137,6 @@ var ContainerSettingsComponent = React.createClass({
                 value={props.fields[fieldIds.dockerNetwork]}
                 onChange={this.handleSingleFieldUpdate}>
               <select defaultValue="">
-                <option value="">Select</option>
                 <option value={ContainerConstants.NETWORK.HOST}>
                   Host
                 </option>

--- a/src/js/stores/transforms/AppFormModelPostProcess.js
+++ b/src/js/stores/transforms/AppFormModelPostProcess.js
@@ -58,6 +58,13 @@ const AppFormModelPostProcess = {
       if (Util.isStringAndEmpty(app.cmd)) {
         app.cmd = null;
       }
+
+      if (app.container != null &&
+          app.container.type === ContainerConstants.TYPE.DOCKER &&
+          app.container.docker.network == null) {
+        Util.objectPathSet(app, "container.docker.network",
+          ContainerConstants.NETWORK.HOST);
+      }
     }
   },
   fetch: (app) => {

--- a/src/js/stores/transforms/AppFormModelToFieldTransforms.js
+++ b/src/js/stores/transforms/AppFormModelToFieldTransforms.js
@@ -2,7 +2,7 @@ import HealthCheckProtocols from "../../constants/HealthCheckProtocols";
 import HealthCheckPortTypes from "../../constants/HealthCheckPortTypes";
 import Util from "../../helpers/Util";
 
-function transformPortDefinitionRows (portDefinitionRows, portField) {
+function transformPortDefinitionRows(portDefinitionRows, portField) {
   return portDefinitionRows.map((row, i) => {
     row[portField] = row[portField];
     row.consecutiveKey = i;

--- a/src/test/units/AppFormModelPostProcess.test.js
+++ b/src/test/units/AppFormModelPostProcess.test.js
@@ -71,6 +71,39 @@ describe("App Form Model Post Process", function () {
       expect(app.cmd).to.equal(null);
     });
 
+    it("sets network mode to HOST when not specified", function () {
+      var app = {
+        container: {
+          docker: {
+            image: "group/image"
+          },
+          type: "DOCKER"
+        }
+      };
+      var app2 = Object.assign({}, app);
+      AppFormModelPostProcess.container(app2);
+
+      expect(app2.container.docker.network)
+        .to.equal(ContainerConstants.NETWORK.HOST);
+    });
+
+    it("sets network mode to HOST when nothing is selected", function () {
+      var app = {
+        container: {
+          docker: {
+            image: "group/image",
+            network: ContainerConstants.NETWORK.BRIDGE
+          },
+          type: "DOCKER"
+        }
+      };
+      var app2 = Object.assign({}, app);
+      AppFormModelPostProcess.container(app2);
+
+      expect(app2.container.docker.network)
+        .to.equal(ContainerConstants.NETWORK.BRIDGE);
+    });
+
   });
 
   describe("health checks", function () {


### PR DESCRIPTION
This PR ensures that `container.docker.network` is set to `HOST` by default. 

This fixes https://github.com/mesosphere/marathon/issues/3587 and https://github.com/mesosphere/marathon/issues/3519


![default-host](https://cloud.githubusercontent.com/assets/1078545/14242770/1f094130-fa52-11e5-9c9f-8709a6deaab8.gif)