### PR TITLE
Remove unnecessary active class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - \#3426 - Improve ports validation
 - \#3559 - Create Modal: always show Port Index for host ports
 - \#3424 - Maintain "assign random port" settings after JSON mode switch
+- \#3554 - Remove unncessary active class
 
 ### Added
 - VIP labels in port definitions

--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -399,6 +399,7 @@ var AppListComponent = React.createClass({
             title="No Applications Created"
             message={message}>
           <Link className="btn btn-lg btn-success"
+              activeClassName=""
               to={path}
               query={newAppModalQuery}>
             Create Application


### PR DESCRIPTION
This fixes https://github.com/mesosphere/marathon/issues/3554 by setting the `activeClassName` prop to an empty string. This is necessary because the `active` class is otherwise automatically assigned to the `Link` element because react-router matches the current URL path.