### PR TITLE
Breadcrumb group links add extra trailing doubleslash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - \#3369 - Constraint validation message
 - \#3671 - Scrolling issue with create modal
 - \#3092 - Delayed applications can appear to be running
+- \#3663 - Apps created from inside a group have a double forward-slash in
+  their ID
 
 ### Changed
 - \#3426 - Improve ports validation

--- a/src/js/components/BreadcrumbComponent.jsx
+++ b/src/js/components/BreadcrumbComponent.jsx
@@ -164,7 +164,7 @@ var BreadcrumbComponent = React.createClass({
 
     var pathParts = groupId.split("/").slice(0, -1);
     return pathParts.map((name, i) => {
-      var id = pathParts.slice(0, i + 1).join("/") + "/";
+      var id = pathParts.slice(0, i + 1).join("/");
       return (
         <li key={id}>
           <Link to="group"

--- a/src/test/units/BreadcrumbComponent.test.js
+++ b/src/test/units/BreadcrumbComponent.test.js
@@ -56,10 +56,10 @@ describe("BreadcrumbComponent", function () {
 
     // routes must be URIEncoded
     expect(linkTargets).to.deep.equal([
-                                        "%2Fgroup-a%2F",
-                                        "%2Fgroup-a%2Fgroup-b%2F",
-                                        "%2Fgroup-a%2Fgroup-b%2Fgroup-c%2F"
-                                      ]);
+      "%2Fgroup-a",
+      "%2Fgroup-a%2Fgroup-b",
+      "%2Fgroup-a%2Fgroup-b%2Fgroup-c"
+    ]);
   });
 
   it("shows the application, if supplied", function () {


### PR DESCRIPTION
This fixes https://github.com/mesosphere/marathon/issues/3663