### PR TITLE
Port fix for 3092 to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - \#3655 - Apps with no volumes reported as stateful
 - \#3369 - Constraint validation message
 - \#3671 - Scrolling issue with create modal
+- \#3092 - Delayed applications can appear to be running
 
 ### Changed
 - \#3426 - Improve ports validation

--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -129,8 +129,6 @@ function detectMigrationApiSupport(app) {
 }
 
 function detectAppStatus(app) {
-  app.status = AppStatus.RUNNING;
-
   if (app.deployments.length > 0) {
     const results = app.readinessCheckResults;
     app.status = AppStatus.DEPLOYING;
@@ -157,6 +155,8 @@ function detectAppStatus(app) {
     }
   } else if (app.instances === 0 && app.tasksRunning === 0) {
     app.status = AppStatus.SUSPENDED;
+  } else if (app.tasksRunning > 0) {
+    app.status = AppStatus.RUNNING;
   }
 }
 


### PR DESCRIPTION
This is essentially a rewrite of https://github.com/mesosphere/marathon-ui/pull/733 to comply with current `master`.