### PR TITLE
Remove "Waiting for user action..." from sidebar Status filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unversioned
+### Changed
+- \#3693 - Remove unwanted sidebar filter for scheduler upgrades
+
 ## 1.1.0 - 2016-04-08
 ### Added
 - \#3670 - Add support for scheduler upgrades and readinessChecks

--- a/src/js/components/SidebarStatusFilterComponent.jsx
+++ b/src/js/components/SidebarStatusFilterComponent.jsx
@@ -8,6 +8,7 @@ import FilterTypes from "../constants/FilterTypes";
 import QueryParamsMixin from "../mixins/QueryParamsMixin";
 
 import {statusNameMapping} from "../constants/LabelMapping";
+import {statusFilters} from "../constants/LabelMapping";
 
 var SidebarStatusFilterComponent = React.createClass({
   displayName: "SidebarStatusFilterComponent",
@@ -78,7 +79,7 @@ var SidebarStatusFilterComponent = React.createClass({
         .split(",")
         .filter((statusKey) => {
           let status = statusKey.toString();
-          let existingStatus = Object.keys(statusNameMapping).indexOf(status);
+          let existingStatus = Object.keys(statusFilters).indexOf(status);
           return existingStatus !== -1;
         });
     }
@@ -107,7 +108,7 @@ var SidebarStatusFilterComponent = React.createClass({
   getStatusNodes: function () {
     var state = this.state;
 
-    return Object.keys(statusNameMapping).map((key, i) => {
+    return Object.keys(statusFilters).map((key, i) => {
       var optionText = statusNameMapping[key];
 
       var checkboxProps = {

--- a/src/js/constants/LabelMapping.js
+++ b/src/js/constants/LabelMapping.js
@@ -10,3 +10,11 @@ export const statusNameMapping = Util.deepFreeze({
   [AppStatus.WAITING]: "Waiting",
   [AppStatus.WAITING_FOR_USER_ACTION]: "Waiting for user action..."
 });
+
+export const statusFilters = Object.freeze([
+  AppStatus.RUNNING,
+  AppStatus.DEPLOYING,
+  AppStatus.SUSPENDED,
+  AppStatus.DELAYED,
+  AppStatus.WAITING
+]);


### PR DESCRIPTION
This partially closes https://github.com/mesosphere/marathon/issues/3693

For the remaining ACs, we need a publicly available docs page that's currently missing.