### PR TITLE
Suspended status for resident tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Changed
 - \#3693 - Remove unwanted sidebar filter for scheduler upgrades
 
+### Fixed
+- \#3657 - Suspended resident tasks should have a different status
+
 ## 1.1.0 - 2016-04-08
 ### Added
 - \#3670 - Add support for scheduler upgrades and readinessChecks

--- a/src/js/components/TaskListItemComponent.jsx
+++ b/src/js/components/TaskListItemComponent.jsx
@@ -159,9 +159,11 @@ var TaskListItemComponent = React.createClass({
     var status = "Waiting";
 
     if (task.status != null) {
-      var version = new Date(task.version).toISOString();
-      var endpoints = this.getEndpoints();
-      var status = task.status;
+      if (task.status !== TaskStatus.SUSPENDED) {
+        version = new Date(task.version).toISOString();
+        endpoints = this.getEndpoints();
+      }
+      status = task.status;
     }
 
     var taskId = task.id;

--- a/src/js/constants/TaskStatus.js
+++ b/src/js/constants/TaskStatus.js
@@ -1,6 +1,7 @@
 const TaskStatus = {
   STAGED: "Staged",
-  STARTED: "Started"
+  STARTED: "Started",
+  SUSPENDED: "Suspended"
 };
 
 export default Object.freeze(TaskStatus);

--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -65,6 +65,8 @@ function setTaskStatus(task) {
   } else if (task.stagedAt != null) {
     task.status = TaskStatus.STAGED;
     task.updatedAt = task.stagedAt;
+  } else if (task.localVolumes != null && task.localVolumes.length > 0) {
+    task.status = TaskStatus.SUSPENDED;
   }
 }
 


### PR DESCRIPTION
This fixes https://github.com/mesosphere/marathon/issues/3657

We should also backport this to 1.0