### PR TITLE
Allow passing JSX as dialog message

### DIFF
--- a/src/js/components/ConfirmDialoglComponent.jsx
+++ b/src/js/components/ConfirmDialoglComponent.jsx
@@ -11,7 +11,10 @@ var ConfirmDialogComponent = React.createClass({
   propTypes: {
     data: React.PropTypes.shape({
       actionButtonLabel: React.PropTypes.string.isRequired,
-      message: React.PropTypes.string.isRequired,
+      message: React.PropTypes.oneOfType([
+        React.PropTypes.string,
+        React.PropTypes.node
+      ]).isRequired,
       severity: React.PropTypes.string.isRequired,
       title: React.PropTypes.string.isRequired
     }).isRequired,


### PR DESCRIPTION
This gets rid of the React warning when passing JSX instead of a string.