### PR TITLE
Fix - 3763 Enable multiple general errors from server response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unversioned
+### Fixed
+- \#3763 - Enable multiple general errors from server response
+
 ## 1.1.1 - 2016-04-13
 ### Added
 - \#3658 - Allow Kill & Wipe for resident tasks

--- a/src/js/components/modals/AppModalComponent.jsx
+++ b/src/js/components/modals/AppModalComponent.jsx
@@ -141,12 +141,19 @@ var AppModalComponent = React.createClass({
 
     if (Util.isObject(error)) {
       error = Object.keys(error).map(key => {
-        return `${key}: ${error[key]}`;
+        var errorMsg = error[key];
+        if (Util.isArray(errorMsg)) {
+          return errorMsg.map(message => {
+            return `${key}: ${message}`;
+          });
+        }
+        return `${key}: ${errorMsg}`;
       });
     }
 
     if (Util.isArray(error)) {
-      error = error.map((message, index) =>
+      var flattenedErrors = [].concat.apply([], error);
+      error = flattenedErrors.map((message, index) =>
         <li key={index}><AutolinkComponent text={message} /></li>
       );
     } else {

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -395,6 +395,9 @@ function processResponseErrors(responseErrors, response, statusCode) {
 
   } else if (statusCode === 422 && response != null &&
       Util.isArray(response.details)) {
+
+    responseErrors.general = [];
+
     response.details.forEach(detail => {
       var attributePath = "general";
 
@@ -419,8 +422,14 @@ function processResponseErrors(responseErrors, response, statusCode) {
         error = response.message;
       }
 
-      responseErrors[fieldId] =
+      let serverResponseMessage =
         AppFormErrorMessages.lookupServerResponseMessage(error);
+
+      if (fieldId === "general") {
+        responseErrors.general.push(serverResponseMessage);
+      } else {
+        responseErrors[fieldId] = serverResponseMessage;
+      }
     });
 
   } else if (statusCode === 409 && responseHasDeployments) {

--- a/src/test/scenarios/createApplication.test.js
+++ b/src/test/scenarios/createApplication.test.js
@@ -226,6 +226,38 @@ describe("Create Application", function () {
         });
       });
 
+      it("processes a 422 multiple error response correctly",
+          function (done) {
+
+        nock(config.apiURL)
+          .post("/v2/apps")
+          .reply(422, {
+            "message": "Object is not valid",
+            "details": [{
+              "path": "/",
+              "errors": ["Groups and Applications may not have the same " +
+                "identifier: /sleep"]
+            }, {
+              "path": "/",
+              "errors": ["This is a second unmapped error"]
+            }]
+          });
+
+        AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
+          expectAsync(function () {
+            expect(AppFormStore.responseErrors.general)
+              .to.deep.equal(["Groups and Applications may not have the same " +
+                  "identifier: /sleep",
+                  "This is a second unmapped error"
+                ]);
+          }, done);
+        });
+
+        AppsActions.createApp({
+          id: "sleep/my-app"
+        });
+      });
+
       it("processes a 422 error response with no error details correctly",
         function (done) {
 

--- a/src/test/scenarios/createApplication.test.js
+++ b/src/test/scenarios/createApplication.test.js
@@ -204,7 +204,7 @@ describe("Create Application", function () {
 
         AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
           expectAsync(function () {
-            expect(AppFormStore.responseErrors.general)
+            expect(AppFormStore.responseErrors.general[0])
               .to.equal("Groups and Applications may not have the same " +
                 "identifier: /sleep");
           }, done);
@@ -231,7 +231,7 @@ describe("Create Application", function () {
 
           AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
             expectAsync(function () {
-              expect(AppFormStore.responseErrors.general)
+              expect(AppFormStore.responseErrors.general[0])
                 .to.equal("Object is not valid");
             }, done);
           });
@@ -255,7 +255,7 @@ describe("Create Application", function () {
 
           AppsStore.once(AppsEvents.CREATE_APP_ERROR, function () {
             expectAsync(function () {
-              expect(AppFormStore.responseErrors.general)
+              expect(AppFormStore.responseErrors.general[0])
                 .to.equal("May not be changed.");
             }, done);
           });


### PR DESCRIPTION
This closes https://github.com/mesosphere/marathon/issues/3763

![multiple](https://cloud.githubusercontent.com/assets/859154/14527734/4508429e-024c-11e6-97ff-87ab2d9efa62.png)