### PR TITLE
Update changelog version header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unversioned
+## 1.1.2 - 2016-04-14
 ### Fixed
 - \#3763 - Enable multiple general errors from server response
 


### PR DESCRIPTION
The changelog in the v1.1.2 tag is also incorrect, but I think nobody cares..
At least I don't. ^^