### PR TITLE
Fix docker image causing errors on submit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unversioned
+### Fixed
+- \#3790 - Remove Docker on submit if no image is provided
+
 ## 1.1.2 - 2016-04-14
 ### Fixed
 - \#3763 - Enable multiple general errors from server response

--- a/src/js/stores/transforms/AppFormModelPostProcess.js
+++ b/src/js/stores/transforms/AppFormModelPostProcess.js
@@ -33,7 +33,9 @@ const AppFormModelPostProcess = {
       return;
     }
 
-    if (container.docker == null &&
+    if ((container.docker == null ||
+        container.docker.image == null ||
+        container.docker.image === "") &&
         container.volumes != null &&
         container.volumes.length > 0) {
       delete container.docker;


### PR DESCRIPTION
When switching to the docker section but not adding any information
this leads to a server error. Also if the user adds a docker image
and then removes it again it will also cause a server error. This
fix removes the docker part of the configuration if no image is provided.

This closes mesosphere/marathon#3790