### PR TITLE
Show correct app status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - \#3770 - External Volumes validation
 - \#3794 - Applications with Docker volumes are mistakenly treated as stateful
   applications
+- \#3793 Wrong application status
 
 ## 1.1.2 - 2016-04-14
 ### Fixed

--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -241,8 +241,7 @@ function applyAppDelayStatus(app, queue) {
   if (queueEntry) {
     let status;
 
-    if (queueEntry.delay.overdue === false
-        && queueEntry.delay.timeLeftSeconds > 0) {
+    if (queueEntry.delay.overdue === false) {
       status = AppStatus.DELAYED;
     } else if (queueEntry.delay.overdue === true) {
       status = AppStatus.WAITING;

--- a/src/js/stores/AppsStore.js
+++ b/src/js/stores/AppsStore.js
@@ -239,20 +239,14 @@ function applyAppDelayStatus(app, queue) {
   });
 
   if (queueEntry) {
-    let status;
+    let status = queueEntry.delay.overdue
+      ? AppStatus.WAITING
+      : AppStatus.DELAYED;
 
-    if (queueEntry.delay.overdue === false) {
-      status = AppStatus.DELAYED;
-    } else if (queueEntry.delay.overdue === true) {
-      status = AppStatus.WAITING;
+    if (app.status !== status) {
+      hasChanges = true;
     }
-
-    if (status) {
-      if (app.status !== status) {
-        hasChanges = true;
-      }
-      app.status = status;
-    }
+    app.status = status;
   }
 
   return hasChanges;

--- a/src/js/stores/schemes/appScheme.js
+++ b/src/js/stores/schemes/appScheme.js
@@ -1,7 +1,6 @@
 import Util from "../../helpers/Util";
 
 import AppTypes from "../../constants/AppTypes";
-import AppStatus from "../../constants/AppStatus";
 
 const appScheme = {
   cmd: null,
@@ -20,7 +19,7 @@ const appScheme = {
   instances: 0,
   labels: {},
   lastTaskFailure: null,
-  status: AppStatus.SUSPENDED,
+  status: null,
   mem: null,
   disk: null,
   portDefinitions: [],

--- a/src/test/scenarios/queueUpdate.test.js
+++ b/src/test/scenarios/queueUpdate.test.js
@@ -43,7 +43,7 @@ describe("queue update", function () {
           },
           "delay": {
             "overdue": false,
-            "timeLeftSeconds": 784
+            "timeLeftSeconds": 0
           }
         }
       ]
@@ -101,7 +101,7 @@ describe("queue update", function () {
         "queue": [
           {
             "app": {
-              "id": "/app-1",
+              "id": "/another-app",
               "maxLaunchDelaySeconds": 3600
             },
             "delay": {


### PR DESCRIPTION
This PR fixes the wrong assumption that an app status should be "Suspended" by default, and it changes the logic needed to set the status as "Delayed". 
@kolloch clarified that the strict check against the queue `delay.timeLeftSeconds === 0` would inevitably lead to edge cases due to rounding issues, so technically it's correct to display `Delayed` as soon as `overdue === false`. 

In a separate PR I will update the docs for https://mesosphere.github.io/marathon/docs/marathon-ui.html to reflect this change.

This fixes https://github.com/mesosphere/marathon/issues/3793