### PR TITLE
Fix that the 'apply' button is broken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 before_install:
-  - npm install -g npm
   - npm cache clear
   - npm install -g gulp
 node_js:

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -166,6 +166,7 @@ var AppPageComponent = React.createClass({
 
     if (state.view === "configuration") {
       AppVersionsActions.requestAppVersions(state.appId);
+      AppVersionsActions.requestAppVersion(state.appId, state.app.version);
     }
   },
 


### PR DESCRIPTION
I found that 'apply' button is broken on the marathon v1.1.1.
It's because 'appVersions' property of 'AppVersionsStore' object hasn't the latest version app.
```
// Diff the new configuration against the current app settings
  getAppConfigDiff: function (appId, newConfig) {
    var allVersions = this.getAppVersions(appId);
    if (allVersions.length === 0) {
      return newConfig;
    }
    var latestVersion = allVersions[0];
    return AppConfigTransforms.diff(this.appVersions[latestVersion], newConfig);
  }
```
The 'requestAppVersion' function is called when clicking the configurations tab.


