### PR TITLE
Fix long line linter error

### DIFF
--- a/src/js/constants/ValidConstraints.js
+++ b/src/js/constants/ValidConstraints.js
@@ -1,3 +1,10 @@
-const ValidConstraints = ["unique", "like", "unlike", "cluster", "group_by", "max_per"];
+const ValidConstraints = [
+  "unique",
+  "like",
+  "unlike",
+  "cluster",
+  "group_by",
+  "max_per"
+];
 
 export default Object.freeze(ValidConstraints);


### PR DESCRIPTION
Fixes following [error](https://travis-ci.org/mesosphere/marathon-ui/builds/158667969#L3338)

> ERROR in ./src/js/constants/ValidConstraints.js
> /home/travis/build/mesosphere/marathon-ui/src/js/constants/ValidConstraints.js
>  1:1  error  Line 1 exceeds the maximum line length of 80  max-len
