### PR TITLE
Fix the portDefinition transform util

### DIFF
--- a/src/js/stores/transforms/AppFormModelToFieldTransforms.js
+++ b/src/js/stores/transforms/AppFormModelToFieldTransforms.js
@@ -3,6 +3,10 @@ import HealthCheckPortTypes from "../../constants/HealthCheckPortTypes";
 import Util from "../../helpers/Util";
 
 function transformPortDefinitionRows(portDefinitionRows, portField) {
+  if (portDefinitionRows == null) {
+    return [];
+  }
+
   return portDefinitionRows.map((row, i) => {
     row[portField] = row[portField];
     row.consecutiveKey = i;


### PR DESCRIPTION
Adjust the portDefinition transform util to handle undefined port definitions; this fixes an issue wich prevented users from editing app configurations if `portMappings.containerPort` is undefined.

/closes mesosphere/marathon#4340