### PR TITLE
DCOS-10184: Fix service port handling

### DIFF
--- a/src/js/components/AppConfigEditFormComponent.jsx
+++ b/src/js/components/AppConfigEditFormComponent.jsx
@@ -194,7 +194,8 @@ var AppConfigEditFormComponent = React.createClass({
   getOptionalPortsComponent: function () {
     var state = this.state;
 
-    if (state.fields.dockerNetwork === ContainerConstants.NETWORK.BRIDGE) {
+    if (state.fields.dockerNetwork === ContainerConstants.NETWORK.BRIDGE ||
+      state.fields.dockerNetwork === ContainerConstants.NETWORK.USER) {
       return (
         <OptionalDockerPortMappingsComponent
           errorIndices={state.errorIndices}

--- a/src/js/components/ContainerSettingsComponent.jsx
+++ b/src/js/components/ContainerSettingsComponent.jsx
@@ -143,6 +143,9 @@ var ContainerSettingsComponent = React.createClass({
                 <option value={ContainerConstants.NETWORK.BRIDGE}>
                   Bridged
                 </option>
+                <option value={ContainerConstants.NETWORK.USER}>
+                  User
+                </option>
               </select>
             </FormGroupComponent>
           </div>

--- a/src/js/constants/ContainerConstants.js
+++ b/src/js/constants/ContainerConstants.js
@@ -3,6 +3,7 @@ import Util from "../helpers/Util";
 const ContainerConstants = {
   NETWORK: {
     BRIDGE: "BRIDGE",
+    USER: "USER",
     HOST: "HOST"
   },
   PORTMAPPINGS: {

--- a/src/js/mixins/DuplicableRowsMixin.jsx
+++ b/src/js/mixins/DuplicableRowsMixin.jsx
@@ -79,12 +79,10 @@ var DuplicableRowsMixin = {
   },
 
   getDuplicableRowValues: function (fieldId, i) {
-    var findDOMNode = React.findDOMNode;
-    var refs = this.refs;
+    const findDOMNode = React.findDOMNode;
+    const refs = this.refs;
 
-    const row = {
-      consecutiveKey: this.state.rows[fieldId][i].consecutiveKey
-    };
+    const row = Util.deepCopy(this.state.rows[fieldId][i]);
 
     return Object.keys(this.duplicableRowsScheme[fieldId])
       .reduce(function (memo, key) {

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -501,7 +501,8 @@ var AppFormStore = Util.extendObject(EventEmitter.prototype, {
       objectPath.get(app, "container.docker.network");
 
     if (dockerNetwork != null &&
-        dockerNetwork === ContainerConstants.NETWORK.BRIDGE) {
+      (dockerNetwork === ContainerConstants.NETWORK.BRIDGE ||
+      dockerNetwork === ContainerConstants.NETWORK.USER)) {
       delete app.portDefinitions;
     } else if (objectPath.get(app, "container.docker.portMappings") != null) {
       delete app.container.docker.portMappings;

--- a/src/test/scenarios/createApplication.test.js
+++ b/src/test/scenarios/createApplication.test.js
@@ -798,7 +798,8 @@ describe("Create Application", function () {
           });
 
           describe("the network field", function () {
-            it("updates correctly", function (done) {
+
+            it("updates to BRIDGE", function (done) {
               AppFormStore.once(FormEvents.CHANGE, function () {
                 expectAsync(function () {
                   expect(AppFormStore.fields.dockerNetwork)
@@ -807,6 +808,17 @@ describe("Create Application", function () {
               });
 
               FormActions.update("dockerNetwork", "BRIDGE");
+            });
+
+            it("updates to USER", function (done) {
+              AppFormStore.once(FormEvents.CHANGE, function () {
+                expectAsync(function () {
+                  expect(AppFormStore.fields.dockerNetwork)
+                    .to.equal("USER");
+                }, done);
+              });
+
+              FormActions.update("dockerNetwork", "USER");
             });
           });
 

--- a/src/test/units/AppFormModelPostProcess.test.js
+++ b/src/test/units/AppFormModelPostProcess.test.js
@@ -87,7 +87,7 @@ describe("App Form Model Post Process", function () {
         .to.equal(ContainerConstants.NETWORK.HOST);
     });
 
-    it("sets network mode to HOST when nothing is selected", function () {
+    it("sets network mode to BRIDGE", function () {
       var app = {
         container: {
           docker: {

--- a/src/test/units/AppFormModelPostProcess.test.js
+++ b/src/test/units/AppFormModelPostProcess.test.js
@@ -104,6 +104,22 @@ describe("App Form Model Post Process", function () {
         .to.equal(ContainerConstants.NETWORK.BRIDGE);
     });
 
+    it("sets network mode to USER", function () {
+      var app = {
+        container: {
+          docker: {
+            image: "group/image",
+            network: ContainerConstants.NETWORK.USER
+          },
+          type: "DOCKER"
+        }
+      };
+      var app2 = Object.assign({}, app);
+      AppFormModelPostProcess.container(app2);
+
+      expect(app2.container.docker.network)
+        .to.equal(ContainerConstants.NETWORK.USER);
+    });
   });
 
   describe("health checks", function () {


### PR DESCRIPTION
Add the `USER` network type option and adjust the duplicable rows mixin to handle unknown data.
This resolves an issue where the service port configuration (unknown to the form)  is removed every time the form is used.
