### PR TITLE
Fix - 4569 plugin helper exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unversioned
+### Fixed
+- \#4569: npm run serve error
+
 ## 1.1.5 - 2016-10-06
 ### Fixed
 - DCOS-10184: Fix service port handling

--- a/src/js/plugin/shared/PluginHelper.js
+++ b/src/js/plugin/shared/PluginHelper.js
@@ -44,5 +44,3 @@ export default class PluginHelper {
   }
 
 }
-
-export default PluginHelper;


### PR DESCRIPTION
Adjust PluginHelper to remove the duplicate default export, as only one default export is allowed per module.