### PR TITLE
Making taskKillGracePeriodSeconds a known property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Fixed
 - \#4569: npm run serve error
 - \#4679: Updating "user" in configuration in web gui has no effect
+- \#4338: Adding "taskKillGracePeriodSeconds" to known properties
 
 ## 1.1.5 - 2016-10-06
 ### Fixed

--- a/src/js/constants/AppConfigDefaults.js
+++ b/src/js/constants/AppConfigDefaults.js
@@ -49,6 +49,7 @@ export const AllAppConfigDefaultValues = Util.deepFreeze(
       "protocol": "tcp"
     }],
     readinessChecks: [],
-    user: null
+    user: null,
+    taskKillGracePeriodSeconds: null
   })
 );


### PR DESCRIPTION
Make `taskKillGracePeriodSeconds` a known property for fixing this issue: https://github.com/mesosphere/marathon/issues/4338