### PR TITLE
Fix app update for marathon 1.4.x

### DIFF
--- a/src/js/stores/AppVersionsStore.js
+++ b/src/js/stores/AppVersionsStore.js
@@ -41,7 +41,16 @@ var AppVersionsStore = Util.extendObject(EventEmitter.prototype, {
 
   getAppVersions: function (appId) {
     if (appId === storeData.currentAppId) {
-      return this.availableAppVersions;
+      return this.availableAppVersions
+        .sort(function (a, b) {
+          if (a < b) {
+            return 1;
+          }
+          if (a > b) {
+            return -1;
+          }
+          return 0;
+        });
     }
     return [];
   },


### PR DESCRIPTION
Since Marathon 1.4.x, it seems that app versions are not returned in a
specific order, but some of the logic in marathon-ui relies on it. This
is fixed by sorting the versions list received in descending order, as
it was returned by previous Marathon versions.

The corresponding test case has also been fixed to expect to find the
latest version in first position.