### PR TITLE
Containerize the development environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:5.4.1
+
+MAINTAINER Orlando Hohmeier <orlando@mesosphere.io>
+
+WORKDIR /opt/marathon-ui
+
+ADD . /opt/marathon-ui/
+
+USER root
+
+VOLUME "/opt/marathon-ui/tests"
+VOLUME "/opt/marathon-ui/dist"
+
+ENTRYPOINT ["npm"]
+CMD ["run", "serve"]

--- a/README.md
+++ b/README.md
@@ -96,17 +96,9 @@ you've installed and properly configured the following software:
 Please make sure you've installed and properly configured the following
 software:
 
-* [Node 5.4.1](https://nodejs.org/en/blog/release/v5.4.1/) including
-  [NPM](https://npmjs.org/)
-* [Docker 1.9](https://www.docker.com/)
+* [Docker 1.13](https://www.docker.com/)
 
-
-##### 🐳 1. Install all dependencies
-
-        npm install
-        npm install -g gulp
-
-##### 🐳 2. Configure your hosts
+##### 🐳 1. Configure your hosts
 
 If you're not using something like
 [dnsdock](https://github.com/tonistiigi/dnsdock) or
@@ -124,18 +116,9 @@ machine ip and add those lines to your `etc/hosts` configuration.*
 ##### 🐳 4. Start your environment
 
 The following command will download, configure and start a basic Zookeeper,
-Mesos and Marathon setup for you. It will also serve the Marathon UI.
+Mesos and Marathon setup for you. It will also build and serve the Marathon UI.
 
        docker-compose up
-
-##### 🐳 5. Build your very own Marathon UI
-
-Running the following command will build the Marathon UI and watch for file
-changes to rerun the build.
-
-       npm run serve
-
-Open http://marathon.docker:8080 to enjoy your fresh build.
 
 #### Contributing to this project
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,79 +1,90 @@
-zookeeper:
-  image: zookeeper:3.4.9
-  hostname: zookeeper
-  ports:
-    - "2181:2181"
-mesos-master:
-  image: mesosphere/mesos-master:1.1.0-2.0.107.ubuntu1404
-  hostname: mesos-master
-  entrypoint: [ "mesos-master" ]
-  ports:
-    - "5050:5050"
-  links:
-    - zookeeper
-  environment:
-    - MESOS_CLUSTER=local
-    - MESOS_HOSTNAME=mesos-master.docker
-    - MESOS_LOG_DIR=/var/log
-    - MESOS_QUORUM=1
-    - MESOS_WORK_DIR=/var/lib/mesos
-    - MESOS_ROLES=public
-    - MESOS_ZK=zk://zookeeper:2181/mesos
-    - MESOS_ACLS=file:///mesos-config/acls
-    - MESOS_CREDENTIALS=file:///mesos-config/credentials
-  volumes:
-    - ./resources/mesos-config:/mesos-config
-mesos-slave:
-  image: mesosphere/mesos-slave:1.1.0-2.0.107.ubuntu1404
-  entrypoint:
-    - mesos-slave
-  privileged: true
-  hostname: mesos-slave
-  ports:
-    - "5051:5051"
-  links:
-    - zookeeper
-    - mesos-master
-  environment:
-    - MESOS_CONTAINERIZERS=mesos
-    - MESOS_ISOLATOR=cgroups/cpu, cgroups/mem
-    - MESOS_LOG_DIR=var/log
-    - MESOS_MASTER=zk://zookeeper:2181/mesos
-    - MESOS_PORT=5051
-    - MESOS_WORK_DIR=/var/lib/mesos
-    - MESOS_EXECUTOR_REGISTRATION_TIMEOUT=5mins
-    - MESOS_EXECUTOR_SHUTDOWN_GRACE_PERIOD=90secs
-    - MESOS_DOCKER_STOP_TIMEOUT=60secs
-    - MESOS_RESOURCES=cpus:4;mem:1280;disk:25600;ports(*):[12000-12999]
-marathon-service:
-  image: mesosphere/marathon:latest-dev
-  expose:
-    - "8080"
-  links:
-    - zookeeper
-    - mesos-master
-  environment:
-    - MARATHON_ZK=zk://zookeeper:2181/marathon
-    - MARATHON_MASTER=zk://zookeeper:2181/mesos
-    - MARATHON_DECLINE_OFFER_DURATION=3600000
-    - MARATHON_PLUGIN_DIR=/plugins
-    - MARATHON_PLUGIN_CONF=/plugin-conf.json
-    - MARATHON_MESOS_AUTHENTICATION_PRINCIPAL=marathon
-    - MARATHON_MESOS_AUTHENTICATION_SECRET_FILE=/marathon.secret
-    - MARATHON_MESOS_ROLE=public
-  volumes:
-    - ./resources/marathon-plugins:/plugins
-    - ./resources/marathon.plugin-conf.json:/plugin-conf.json
-    - ./resources/marathon.secret:/marathon.secret
-marathon-ui:
-  image: nginx:latest
-  hostname: marathon-ui
-  ports:
-   - "8080:8080"
-  links:
-    - marathon-service
-  environment:
-    - DNSDOCK_ALIAS=marathon.docker
-  volumes:
-    - ./dist:/usr/share/nginx/html
-    - ./resources/marathon-ui.nginx.conf:/etc/nginx/nginx.conf
+version: '2'
+
+services:
+  zookeeper:
+    image: zookeeper:3.4.9
+    hostname: zookeeper
+    ports:
+      - "2181:2181"
+  mesos-master:
+    image: mesosphere/mesos-master:1.1.0-2.0.107.ubuntu1404
+    hostname: mesos-master
+    entrypoint: [ "mesos-master" ]
+    ports:
+      - "5050:5050"
+    links:
+      - zookeeper
+    environment:
+      - MESOS_CLUSTER=local
+      - MESOS_HOSTNAME=mesos-master.docker
+      - MESOS_LOG_DIR=/var/log
+      - MESOS_QUORUM=1
+      - MESOS_WORK_DIR=/var/lib/mesos
+      - MESOS_ROLES=public
+      - MESOS_ZK=zk://zookeeper:2181/mesos
+      - MESOS_ACLS=file:///mesos-config/acls
+      - MESOS_CREDENTIALS=file:///mesos-config/credentials
+    volumes:
+      - ./resources/mesos-config:/mesos-config
+  mesos-slave:
+    image: mesosphere/mesos-slave:1.1.0-2.0.107.ubuntu1404
+    entrypoint:
+      - mesos-slave
+    privileged: true
+    hostname: mesos-slave
+    ports:
+      - "5051:5051"
+    links:
+      - zookeeper
+      - mesos-master
+    environment:
+      - MESOS_CONTAINERIZERS=mesos
+      - MESOS_ISOLATOR=cgroups/cpu, cgroups/mem
+      - MESOS_LOG_DIR=var/log
+      - MESOS_MASTER=zk://zookeeper:2181/mesos
+      - MESOS_PORT=5051
+      - MESOS_WORK_DIR=/var/lib/mesos
+      - MESOS_EXECUTOR_REGISTRATION_TIMEOUT=5mins
+      - MESOS_EXECUTOR_SHUTDOWN_GRACE_PERIOD=90secs
+      - MESOS_DOCKER_STOP_TIMEOUT=60secs
+      - MESOS_RESOURCES=cpus:4;mem:1280;disk:25600;ports(*):[12000-12999]
+  marathon-service:
+    image: mesosphere/marathon:latest
+    expose:
+      - "8080"
+    links:
+      - zookeeper
+      - mesos-master
+    environment:
+      - MARATHON_ZK=zk://zookeeper:2181/marathon
+      - MARATHON_MASTER=zk://zookeeper:2181/mesos
+      - MARATHON_DECLINE_OFFER_DURATION=3600000
+      - MARATHON_PLUGIN_DIR=/plugins
+      - MARATHON_PLUGIN_CONF=/plugin-conf.json
+      - MARATHON_MESOS_AUTHENTICATION_PRINCIPAL=marathon
+      - MARATHON_MESOS_AUTHENTICATION_SECRET_FILE=/marathon.secret
+      - MARATHON_MESOS_ROLE=public
+    volumes:
+      - ./resources/marathon-plugins:/plugins
+      - ./resources/marathon.plugin-conf.json:/plugin-conf.json
+      - ./resources/marathon.secret:/marathon.secret
+  marathon-ui:
+    image: nginx:latest
+    hostname: marathon-ui
+    ports:
+     - "8080:8080"
+    links:
+      - marathon-service
+    environment:
+      - DNSDOCK_ALIAS=marathon.docker
+    volumes:
+      - ./resources/marathon-ui.nginx.conf:/etc/nginx/nginx.conf
+      -  dist:/usr/share/nginx/html
+  develop-environment:
+    build:
+        context: .
+    volumes:
+      - ./src:/opt/marathon-ui/src
+      - dist:/opt/marathon-ui/dist
+volumes:
+  dist: {}


### PR DESCRIPTION
Improve the developer experience by containerizing the development environment – this is in particular helpful when switching between projects that require different node and npm versions.

Changes:
* Update the docker-compose to the new format (version: 2)
* Add Dockerfile to build the development environment
* Adjust  docker-compose to build and run the `development-environment`
* Update the documentation to reflect the changes