### PR TITLE
Adjust the app change version handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Fixed
 - MARATHON-1339: Handling secrets in environment variables
 - Fix app version order
+- Fix "initial" app version request
 
 ## 1.1.6 - 2016-12-14
 ### Fixed

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -166,7 +166,7 @@ var AppPageComponent = React.createClass({
 
     if (state.view === "configuration") {
       AppVersionsActions.requestAppVersions(state.appId);
-      AppVersionsActions.requestAppVersion(state.appId, state.app.version);
+      AppVersionsActions.requestAppVersion(state.appId, app.version);
     }
   },
 


### PR DESCRIPTION
Change the app page component to properly request the current app version on app change. This fixes cases in which the app version apply didn't work due to failing version request. 