### PR TITLE
DCOS-15571: Make sure networks are visible in the new marathon API

### DIFF
--- a/src/js/components/AppVersionComponent.jsx
+++ b/src/js/components/AppVersionComponent.jsx
@@ -220,6 +220,10 @@ var AppVersionComponent = React.createClass({
       ? <UnspecifiedNodeComponent />
       : getHighlightNode(appVersion.portDefinitions);
 
+    var networksNode = (appVersion.networks == null)
+      ? <UnspecifiedNodeComponent />
+      : getHighlightNode(appVersion.networks);
+
     var urisNode = (appVersion.uris == null || appVersion.uris.length === 0)
       ? <UnspecifiedNodeComponent />
       : appVersion.uris.map(function (uri, i) {
@@ -274,6 +278,8 @@ var AppVersionComponent = React.createClass({
           {invalidateValue(appVersion.mem, "MiB")}
           <dt>Disk Space</dt>
           {invalidateValue(appVersion.disk, "MiB")}
+          <dt>Networks</dt>
+          {networksNode}
           <dt>Port Definitions</dt>
           {portDefinitionsNode}
           <dt>Backoff Factor</dt>

--- a/src/js/stores/schemes/appScheme.js
+++ b/src/js/stores/schemes/appScheme.js
@@ -21,6 +21,7 @@ const appScheme = {
   lastTaskFailure: null,
   status: null,
   mem: null,
+  networks: [],
   disk: null,
   portDefinitions: [],
   uris: [],

--- a/src/test/units/AppVersionComponent.test.js
+++ b/src/test/units/AppVersionComponent.test.js
@@ -138,37 +138,37 @@ describe("AppVersionComponent", function () {
   });
 
   it("has correct backoff factor", function () {
-    var children = this.rows.at(33).props().children;
+    var children = this.rows.at(35).props().children;
     expect(children[0]).to.equal(1.15);
   });
 
   it("has correct backoff", function () {
-    var children = this.rows.at(35).props().children;
+    var children = this.rows.at(37).props().children;
     expect(children[0]).to.equal(1);
     expect(children[2]).to.equal("seconds");
   });
 
   it("has correct max launch delay", function () {
-    var children = this.rows.at(37).props().children;
+    var children = this.rows.at(39).props().children;
     expect(children[0]).to.equal(3600);
     expect(children[2]).to.equal("seconds");
   });
 
   it("has correct URIs", function () {
-    expect(this.rows.at(39).text().trim()).to.equal("Unspecified");
+    expect(this.rows.at(41).text().trim()).to.equal("Unspecified");
   });
 
   it("has correct User", function () {
-    expect(this.rows.at(41).props().children[0]).to.equal("testuser");
+    expect(this.rows.at(43).props().children[0]).to.equal("testuser");
   });
 
   it("has correct args", function () {
-    expect(this.rows.at(43).text()).to.equal("arg1");
-    expect(this.rows.at(44).text()).to.equal("arg2");
+    expect(this.rows.at(45).text()).to.equal("arg1");
+    expect(this.rows.at(46).text()).to.equal("arg2");
   });
 
   it("has correct version", function () {
-    expect(this.rows.at(46).props().children[0])
+    expect(this.rows.at(48).props().children[0])
       .to.equal("2015-06-29T12:57:02.269Z");
   });
 


### PR DESCRIPTION
This PR ensures that the new `networks` section from the app definition is visible in the configuration versions display:

![image](https://cloud.githubusercontent.com/assets/883486/25849266/0dcadd32-34be-11e7-98f9-43870e89714e.png)
