### PR TITLE
DCOS-15407, DCOS-15570: Adding support for the new API

### DIFF
--- a/src/js/components/AppConfigEditFormComponent.jsx
+++ b/src/js/components/AppConfigEditFormComponent.jsx
@@ -197,15 +197,14 @@ var AppConfigEditFormComponent = React.createClass({
     if (state.fields.dockerNetwork === ContainerConstants.NETWORK.MANY) {
       return (
           <p>
-            For more advanced port configuration options, including service ports,
-            use <a className="json-link clickable"
-            onClick={this.props.handleModeToggle}>
-            JSON mode</a>.
+            For more advanced port configuration options, including service
+            ports, use <a className="json-link clickable"
+            onClick={this.props.handleModeToggle}>JSON mode</a>.
           </p>
         );
 
-    } else if (state.fields.dockerNetwork === ContainerConstants.NETWORK.BRIDGE ||
-      state.fields.dockerNetwork === ContainerConstants.NETWORK.USER) {
+    } else if (state.fields.dockerNetwork === ContainerConstants.NETWORK.BRIDGE
+      || state.fields.dockerNetwork === ContainerConstants.NETWORK.USER) {
       return (
         <OptionalDockerPortMappingsComponent
           errorIndices={state.errorIndices}
@@ -382,6 +381,7 @@ var AppConfigEditFormComponent = React.createClass({
               errorIndices={state.errorIndices}
               fields={state.fields}
               getErrorMessage={this.getErrorMessage}
+              handleModeToggle={this.props.handleModeToggle}
               openPorts={this.setViewPorts}
               openVolumes={this.setViewVolumes}/>
           </SectionComponent>

--- a/src/js/components/AppConfigEditFormComponent.jsx
+++ b/src/js/components/AppConfigEditFormComponent.jsx
@@ -194,7 +194,17 @@ var AppConfigEditFormComponent = React.createClass({
   getOptionalPortsComponent: function () {
     var state = this.state;
 
-    if (state.fields.dockerNetwork === ContainerConstants.NETWORK.BRIDGE ||
+    if (state.fields.dockerNetwork === ContainerConstants.NETWORK.MANY) {
+      return (
+          <p>
+            For more advanced port configuration options, including service ports,
+            use <a className="json-link clickable"
+            onClick={this.props.handleModeToggle}>
+            JSON mode</a>.
+          </p>
+        );
+
+    } else if (state.fields.dockerNetwork === ContainerConstants.NETWORK.BRIDGE ||
       state.fields.dockerNetwork === ContainerConstants.NETWORK.USER) {
       return (
         <OptionalDockerPortMappingsComponent

--- a/src/js/components/AppVersionComponent.jsx
+++ b/src/js/components/AppVersionComponent.jsx
@@ -220,6 +220,10 @@ var AppVersionComponent = React.createClass({
       ? <UnspecifiedNodeComponent />
       : getHighlightNode(appVersion.portDefinitions);
 
+    var networksNode = (appVersion.networks == null)
+      ? <UnspecifiedNodeComponent />
+      : getHighlightNode(appVersion.networks);
+
     var urisNode = (appVersion.uris == null || appVersion.uris.length === 0)
       ? <UnspecifiedNodeComponent />
       : appVersion.uris.map(function (uri, i) {
@@ -274,6 +278,8 @@ var AppVersionComponent = React.createClass({
           {invalidateValue(appVersion.mem, "MiB")}
           <dt>Disk Space</dt>
           {invalidateValue(appVersion.disk, "MiB")}
+          <dt>Networks</dt>
+          {networksNode}
           <dt>Port Definitions</dt>
           {portDefinitionsNode}
           <dt>Backoff Factor</dt>

--- a/src/js/components/ContainerSettingsComponent.jsx
+++ b/src/js/components/ContainerSettingsComponent.jsx
@@ -7,6 +7,7 @@ import DuplicableRowsMixin from "../mixins/DuplicableRowsMixin";
 import dockerRowSchemes from "../stores/schemes/dockerRowSchemes";
 import FormActions from "../actions/FormActions";
 import FormGroupComponent from "../components/FormGroupComponent";
+import TooltipComponent from "./TooltipComponent.jsx";
 
 var ContainerSettingsComponent = React.createClass({
   displayName: "ContainerSettingsComponent",
@@ -112,6 +113,48 @@ var ContainerSettingsComponent = React.createClass({
     });
   },
 
+  getNetworkGroupComponent: function () {
+    var props = this.props;
+    var fieldIds = ContainerSettingsComponent.fieldIds;
+    var dockerNetwork = props.fields[fieldIds.dockerNetwork];
+    var label = "Network";
+    var disabled = false;
+
+    if (dockerNetwork === ContainerConstants.NETWORK.MANY) {
+      label = (
+        <span>
+          Network
+          <TooltipComponent className="right"
+              message="Not availble when multiple networks are defined. Use JSON Mode.">
+            <i className="icon icon-xs help" />
+          </TooltipComponent>
+        </span>
+      );
+      disabled = true;
+    }
+
+    return (
+      <FormGroupComponent
+          errorMessage={props.getErrorMessage(fieldIds.dockerNetwork)}
+          fieldId={fieldIds.dockerNetwork}
+          label={label}
+          value={dockerNetwork}
+          onChange={this.handleSingleFieldUpdate}>
+        <select defaultValue="" disabled={disabled}>
+          <option value={ContainerConstants.NETWORK.HOST}>
+            Host
+          </option>
+          <option value={ContainerConstants.NETWORK.BRIDGE}>
+            Bridged
+          </option>
+          <option value={ContainerConstants.NETWORK.USER}>
+            User
+          </option>
+        </select>
+      </FormGroupComponent>
+    );
+  },
+
   render: function () {
     var props = this.props;
     var fieldIds = ContainerSettingsComponent.fieldIds;
@@ -130,24 +173,7 @@ var ContainerSettingsComponent = React.createClass({
             </FormGroupComponent>
           </div>
           <div className="col-sm-6">
-            <FormGroupComponent
-                errorMessage={props.getErrorMessage(fieldIds.dockerNetwork)}
-                fieldId={fieldIds.dockerNetwork}
-                label="Network"
-                value={props.fields[fieldIds.dockerNetwork]}
-                onChange={this.handleSingleFieldUpdate}>
-              <select defaultValue="">
-                <option value={ContainerConstants.NETWORK.HOST}>
-                  Host
-                </option>
-                <option value={ContainerConstants.NETWORK.BRIDGE}>
-                  Bridged
-                </option>
-                <option value={ContainerConstants.NETWORK.USER}>
-                  User
-                </option>
-              </select>
-            </FormGroupComponent>
+            {this.getNetworkGroupComponent()}
           </div>
         </div>
         <div className="row">

--- a/src/js/components/ContainerSettingsComponent.jsx
+++ b/src/js/components/ContainerSettingsComponent.jsx
@@ -29,6 +29,7 @@ var ContainerSettingsComponent = React.createClass({
   propTypes: {
     fields: React.PropTypes.object.isRequired,
     getErrorMessage: React.PropTypes.func.isRequired,
+    handleModeToggle: React.PropTypes.func.isRequired,
     openPorts: React.PropTypes.func,
     openVolumes: React.PropTypes.func
   },
@@ -125,7 +126,13 @@ var ContainerSettingsComponent = React.createClass({
         <span>
           Network
           <TooltipComponent className="right"
-              message="Not availble when multiple networks are defined. Use JSON Mode.">
+              message={
+                <span>
+                  Not availble when multiple networks are defined.
+                  <a className="json-link clickable"
+                    onClick={this.props.handleModeToggle}>Use JSON Mode</a>
+                </span>
+              }>
             <i className="icon icon-xs help" />
           </TooltipComponent>
         </span>

--- a/src/js/constants/AppConfigDefaults.js
+++ b/src/js/constants/AppConfigDefaults.js
@@ -51,6 +51,9 @@ export const AllAppConfigDefaultValues = Util.deepFreeze(
     readinessChecks: [],
     user: null,
     taskKillGracePeriodSeconds: null,
-    secrets: {}
+    secrets: {},
+    networks: [
+      {mode: "host"}
+    ]
   })
 );

--- a/src/js/constants/ContainerConstants.js
+++ b/src/js/constants/ContainerConstants.js
@@ -2,9 +2,10 @@ import Util from "../helpers/Util";
 
 const ContainerConstants = {
   NETWORK: {
-    BRIDGE: "BRIDGE",
-    USER: "USER",
-    HOST: "HOST"
+    BRIDGE: "container/bridge",
+    USER: "container",
+    HOST: "host",
+    MANY: null
   },
   PORTMAPPINGS: {
     PROTOCOL: {

--- a/src/js/stores/AppFormStore.js
+++ b/src/js/stores/AppFormStore.js
@@ -106,10 +106,10 @@ const resolveFieldIdToAppKeyMap = {
   disk: "disk",
   dockerForcePullImage: "container.docker.forcePullImage",
   dockerImage: "container.docker.image",
-  dockerNetwork: "container.docker.network",
+  dockerNetwork: "networks",
   dockerParameters: "container.docker.parameters",
   dockerPrivileged: "container.docker.privileged",
-  dockerPortMappings: "container.docker.portMappings",
+  dockerPortMappings: "container.portMappings",
   healthChecks: "healthChecks",
   instances: "instances",
   env: "env",
@@ -135,7 +135,7 @@ const responseAttributePathToFieldIdMap = {
   "/constraints": "constraints",
   "/constraints({INDEX})": "constraints",
   "/container/docker/forcePullImage": "dockerForcePullImage",
-  "/container/docker/image": "dockerImage",
+  "/networks": "dockerImage",
   "/container/docker/network": "dockerNetwork",
   "/container/docker/privileged": "dockerPrivileged",
   "/container/docker/parameters({INDEX})/key":
@@ -174,13 +174,13 @@ const responseAttributePathToFieldIdMap = {
   "/portDefinitions({INDEX})/name": "portDefinitions/{INDEX}/name",
   "/portDefinitions({INDEX})/port": "portDefinitions/{INDEX}/port",
   "/portDefinitions({INDEX})/protocol": "portDefinitions/{INDEX}/protocol",
-  "/container/docker/portMappings": "dockerPortMappings",
-  "/container/docker/portMappings({INDEX})/containerPort":
+  "/container/portMappings": "dockerPortMappings",
+  "/container/portMappings({INDEX})/containerPort":
     "dockerPortMappings/{INDEX}/port",
-  "/container/docker/portMappings({INDEX})/protocol":
+  "/container/portMappings({INDEX})/protocol":
     "dockerPortMappings/{INDEX}/protocol",
-  "/container/docker/portMappings({INDEX})/hostPort": "dockerPortMappings",
-  "/container/docker/portMappings({INDEX})/servicePort": "dockerPortMappings",
+  "/container/portMappings({INDEX})/hostPort": "dockerPortMappings",
+  "/container/portMappings({INDEX})/servicePort": "dockerPortMappings",
   "/labels": "labels",
   "/uris": "uris",
   "/user": "user",
@@ -194,12 +194,12 @@ const responseAttributePathToFieldIdMap = {
  */
 const resolveAppKeyToFieldIdMap = {
   "id": ["appId"],
+  "networks": ["dockerNetwork"],
   "container.docker.forcePullImage": ["dockerForcePullImage"],
   "container.docker.image": ["dockerImage"],
-  "container.docker.network": ["dockerNetwork"],
-  "container.docker.portMappings": ["dockerPortMappings"],
   "container.docker.parameters": ["dockerParameters"],
   "container.docker.privileged": ["dockerPrivileged"],
+  "container.portMappings": ["dockerPortMappings"],
   "container.volumes": [
     "containerVolumes",
     "localVolumes",
@@ -497,15 +497,20 @@ var AppFormStore = Util.extendObject(EventEmitter.prototype, {
       }
     });
 
-    var dockerNetwork =
-      objectPath.get(app, "container.docker.network");
+    var dockerNetwork = ContainerConstants.NETWORK.MANY;
+    var networks = app.networks || [];
+    if (networks.length) {
+      if (networks.length === 1) {
+        dockerNetwork = networks[0].mode;
+      }
+    }
 
     if (dockerNetwork != null &&
       (dockerNetwork === ContainerConstants.NETWORK.BRIDGE ||
       dockerNetwork === ContainerConstants.NETWORK.USER)) {
       delete app.portDefinitions;
-    } else if (objectPath.get(app, "container.docker.portMappings") != null) {
-      delete app.container.docker.portMappings;
+    } else if (objectPath.get(app, "container.portMappings") != null) {
+      delete app.container.portMappings;
     }
 
     return app;

--- a/src/js/stores/schemes/appScheme.js
+++ b/src/js/stores/schemes/appScheme.js
@@ -21,6 +21,7 @@ const appScheme = {
   lastTaskFailure: null,
   status: null,
   mem: null,
+  networks: [],
   disk: null,
   portDefinitions: [],
   uris: [],

--- a/src/js/stores/transforms/AppFormFieldToModelTransforms.js
+++ b/src/js/stores/transforms/AppFormFieldToModelTransforms.js
@@ -1,3 +1,4 @@
+import ContainerConstants from "../../constants/ContainerConstants";
 import HealthCheckProtocols from "../../constants/HealthCheckProtocols";
 
 import dockerRowSchemes from "../schemes/dockerRowSchemes";
@@ -116,6 +117,19 @@ const AppFormFieldToModelTransforms = {
     return rows;
   },
   dockerForcePullImage: (isChecked) => !!isChecked,
+  dockerNetwork: (network) => {
+    if (network == null) {
+      return [];
+    }
+
+    const networkDefinition = {mode: network};
+
+    if (network === ContainerConstants.NETWORK.USER) {
+      networkDefinition.name = "dcos";
+    }
+
+    return [networkDefinition];
+  },
   dockerParameters: (rows) => lazy(rows)
     .map((row) => ensureObjectScheme(row, dockerRowSchemes.dockerParameters))
     .compact()

--- a/src/js/stores/transforms/AppFormModelPostProcess.js
+++ b/src/js/stores/transforms/AppFormModelPostProcess.js
@@ -61,11 +61,9 @@ const AppFormModelPostProcess = {
         app.cmd = null;
       }
 
-      if (app.container != null &&
-          app.container.type === ContainerConstants.TYPE.DOCKER &&
-          app.container.docker.network == null) {
-        Util.objectPathSet(app, "container.docker.network",
-          ContainerConstants.NETWORK.HOST);
+      // Make sure there is always a default network
+      if (app.networks == null) {
+        app.networks = [{mode: "host"}];
       }
     }
   },

--- a/src/js/stores/transforms/AppFormModelToFieldTransforms.js
+++ b/src/js/stores/transforms/AppFormModelToFieldTransforms.js
@@ -1,3 +1,4 @@
+import ContainerConstants from "../../constants/ContainerConstants";
 import HealthCheckProtocols from "../../constants/HealthCheckProtocols";
 import HealthCheckPortTypes from "../../constants/HealthCheckPortTypes";
 import Util from "../../helpers/Util";
@@ -28,6 +29,16 @@ const AppFormModelToFieldTransforms = {
     return constraints
       .map((constraint) => constraint.join(":"))
       .join(", ");
+  },
+  dockerNetwork: networks =>  {
+    if (!Array.isArray(networks) || networks.length === 0) {
+      return ContainerConstants.NETWORK.HOST;
+    }
+    if (networks.length > 1) {
+      return ContainerConstants.NETWORK.MANY;
+    }
+
+    return networks[0].mode;
   },
   dockerPortMappings: portMappings => {
     return transformPortDefinitionRows(portMappings, "containerPort");

--- a/src/test/scenarios/requestSpecificApplicationVersion.test.js
+++ b/src/test/scenarios/requestSpecificApplicationVersion.test.js
@@ -67,7 +67,8 @@ describe("request specific application version", function () {
           );
           expect(config).to.deep.equal({
             id: "/app-id",
-            cmd: "some --cmd"
+            cmd: "some --cmd",
+            networks: []
           });
         }, done);
       });
@@ -94,7 +95,8 @@ describe("request specific application version", function () {
           expect(config).to.deep.equal({
             id: "/app-id",
             cmd: "some --cmd",
-            labels: {testing: "123"}
+            labels: {testing: "123"},
+            networks: []
           });
         }, done);
       });

--- a/src/test/units/AppFormModelPostProcess.test.js
+++ b/src/test/units/AppFormModelPostProcess.test.js
@@ -83,8 +83,8 @@ describe("App Form Model Post Process", function () {
       var app2 = Object.assign({}, app);
       AppFormModelPostProcess.container(app2);
 
-      expect(app2.container.docker.network)
-        .to.equal(ContainerConstants.NETWORK.HOST);
+      expect(app2.networks)
+        .to.deep.equal([{mode: ContainerConstants.NETWORK.HOST}]);
     });
 
     it("sets network mode to BRIDGE", function () {

--- a/src/test/units/AppVersionComponent.test.js
+++ b/src/test/units/AppVersionComponent.test.js
@@ -138,37 +138,37 @@ describe("AppVersionComponent", function () {
   });
 
   it("has correct backoff factor", function () {
-    var children = this.rows.at(33).props().children;
+    var children = this.rows.at(35).props().children;
     expect(children[0]).to.equal(1.15);
   });
 
   it("has correct backoff", function () {
-    var children = this.rows.at(35).props().children;
+    var children = this.rows.at(37).props().children;
     expect(children[0]).to.equal(1);
     expect(children[2]).to.equal("seconds");
   });
 
   it("has correct max launch delay", function () {
-    var children = this.rows.at(37).props().children;
+    var children = this.rows.at(39).props().children;
     expect(children[0]).to.equal(3600);
     expect(children[2]).to.equal("seconds");
   });
 
   it("has correct URIs", function () {
-    expect(this.rows.at(39).text().trim()).to.equal("Unspecified");
+    expect(this.rows.at(41).text().trim()).to.equal("Unspecified");
   });
 
   it("has correct User", function () {
-    expect(this.rows.at(41).props().children[0]).to.equal("testuser");
+    expect(this.rows.at(43).props().children[0]).to.equal("testuser");
   });
 
   it("has correct args", function () {
-    expect(this.rows.at(43).text()).to.equal("arg1");
-    expect(this.rows.at(44).text()).to.equal("arg2");
+    expect(this.rows.at(45).text()).to.equal("arg1");
+    expect(this.rows.at(46).text()).to.equal("arg2");
   });
 
   it("has correct version", function () {
-    expect(this.rows.at(46).props().children[0])
+    expect(this.rows.at(48).props().children[0])
       .to.equal("2015-06-29T12:57:02.269Z");
   });
 


### PR DESCRIPTION
This PR introduces proper support for the new networking API to the marathon UI. In detail:

- Re-mapped `container.docker.portMapping` to `container.portMapping`
- Re-mapped `container.docker.network` to `networks` **and**
- Added high-level tranformation for networks array
- Ensuring a default network (host) always exist
- Detecting when multiple networks are specified
- Disabling respective UI sections when multiple networks are detected