### PR TITLE
Fix data passing from plugins to DialogActions

### DIFF
--- a/src/js/plugin/PluginActionProxy.js
+++ b/src/js/plugin/PluginActionProxy.js
@@ -35,7 +35,7 @@ var PluginActionProxy = {
     PluginDispatcher.register(function (action) {
       proxies.forEach(proxy => {
         if (proxy.pluginActionType === action.actionType) {
-          proxy.actionFunction(...action.data);
+          proxy.actionFunction(action.data);
         }
       });
     });


### PR DESCRIPTION
Hello all, 

Plugins are currently unable to show any usable dialogs. Any call to

```javascript
PluginHelper.callAction(PluginActions.DIALOG_ALERT, {
  title: "Hello world",
  message: "Hi, Plugin speaking here."
});
```

will result in a blank Alert Dialog Box. The problem seems to be on the
transformation that `action.data` suffers prior to be passed to
`proxy.actionFunction()`.

With `action.data` being an object, in this case, `{title: "...",
message: "..."}`, when calling `actionFunction(...action.data)` the result is
`actionFunction([])`, which creates the empty Dialog Box.

This happens because every registered actionFunction, in this case
`DialogActions.{alert,insert,updatem,delete}`, already has its signature
as `DialogActions.<func-name>(...data)`.

If we prefer to leave this elipsis also on the callling side, another
way to fix is to change tha call to:

```javascript
proxy.actionFunction(...[action.data]);
```

Let me know what you all think about this change. The code example was extracted from the example plugin, [here](https://github.com/mesosphere/marathon-ui-example-plugin/blob/master/src/main/js/components/ExamplePluginComponent.jsx#L33-L37).