### PR TITLE
Backport PR #813 to 1.1.7 series

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 *.iml
 .idea/*
+*.swp
 
 # npm
 node_modules/

--- a/src/js/plugin/PluginLoader.js
+++ b/src/js/plugin/PluginLoader.js
@@ -10,6 +10,9 @@ import PluginActions from "./shared/PluginActions";
 import PluginHelper from "./shared/PluginHelper";
 import PluginDispatcherProxy from "./PluginDispatcherProxy";
 
+import MarathonService from "./sdk/services/MarathonService";
+import MarathonActions from "./sdk/actions/MarathonActions";
+
 const PLUGIN_STARTUP_TIMEOUT = 10000; // in ms
 
 const PluginLoader = {
@@ -45,7 +48,9 @@ const PluginLoader = {
           PluginMountPoints: PluginMountPoints,
           pluginId: pluginId,
           React: React,
-          UIVersion: config.version
+          config: Object.freeze(config),
+          MarathonService: MarathonService,
+          MarathonActions: MarathonActions,
         });
 
         let dispatchToken = PluginDispatcher.register(function (event) {

--- a/src/js/plugin/sdk/actions/MarathonActions.js
+++ b/src/js/plugin/sdk/actions/MarathonActions.js
@@ -1,0 +1,28 @@
+import MarathonService from "../services/MarathonService";
+
+export default class MarathonActions {
+
+  static getDeployments() {
+    return MarathonService.request({
+      resource: "/v2/deployments"
+    });
+  }
+
+  static getGroup(group) {
+    let groupName = group.replace(/\/?(.*)/,"/$1");
+    return MarathonService.request({
+      resource: `/v2/groups${groupName}`
+    });
+  }
+
+  static getGroups() {
+    return this.getGroup("/");
+  }
+
+  static getApp(appId) {
+    return MarathonService.request({
+      resource: `/v2/apps${appId}`
+    });
+  }
+
+};

--- a/src/js/plugin/sdk/services/MarathonService.js
+++ b/src/js/plugin/sdk/services/MarathonService.js
@@ -1,0 +1,20 @@
+
+import config from "../../../config/config";
+import ajaxWrapper from "../../../helpers/ajaxWrapper";
+
+export default class MarathonService {
+
+  static request({resource, method="GET", data}) {
+
+    if (resource) {
+      resource.replace(/\/?(.*)/,"/$1");
+    }
+
+    return ajaxWrapper({
+      url: `${config.apiURL}${resource}`,
+      method: method,
+      data: data
+    });
+  }
+
+};


### PR DESCRIPTION
Hi,

I would like to know if it would be possible to backport this PR (#813) to Marathon UI `1.1.x` series. I will try to explain the reasoning behind this.

We run our infra-structure (currently) fully based on Apache Mesos and Mesosphere Marathon for orchestration of every task we run.  We run Marathon backend without the UI and deploy the UI separately (it's indeed managed by marathon itself). This gives us the ability to evolve the UI (write plugins, changing code, etc) without having to mess with the Marathon backend process.

We run Marathon backend version `1.1.1` and are in the process to update to `1.3.13`. And Marathon UI `1.1.7` is the last version of the UI that is compatible with Marathon backend `1.3.13` (After `1.1.7` there were introduced some incompatible changes, eg: 
76d1eabf2c10e08fe766478c851112263657ae07. In fact, we are already running UI version `1.1.7` talking to Backend version `1.1.1` and will soon update to  backend `1.3.13`.

Since the modification made by  PR #813 is unrelated to other areas of the code and is a self-contained implementation, I though it would be OK to backport this to `1.1.x` series and release a new "minor version" for this series, I don't know if it would be `1.1.7.1` or `1.1.8`. I see also that some commits mention `1.1.8` so maybe would be better to jump to `1.1.9` instead.

Until we update our backend to marathon `1.4.x` or `1.5.x` we can't update our UI also. That's why it would be immensely useful if we could just forward our UI to `1.1.9` so we would be able to use this new interface and some of our plugins would directly benefit from this implementation.


We are currently running our UI from the `1.1.7` branch, with PR #813 applied (plus other changes that we plan to open future PRs), but would be  much better not to have a too much diverged code base from the original project. That's why we started to contribute to the Marathon UI project in a way that we change the core to make it possible to write better plugins. That's how we are using Marathon currently and plan to customize it to our needs, but always making the project stronger and more useful to others.

So I would like to ask you to consider merging this code and releasing a new minor version for `1.1.x` series. it would be much valuable.

About how I did this PR, I only cherry-picked the merge commit from master. I don't know if this is the best way to do it. If you are willing to confirm this merge+release I would adjust anything needed, just let me know.

Thank you very much.

