### PR TITLE
Implement request filter pipeline

### DIFF
--- a/src/js/helpers/ajaxWrapper.js
+++ b/src/js/helpers/ajaxWrapper.js
@@ -1,7 +1,10 @@
 import fetch from "isomorphic-fetch";
 import Util from "./Util";
+import PipelineStore from "../plugin/sdk/pipeline/PipelineStore";
+import * as PipelineNames from "../plugin/sdk/pipeline/PipelineNames";
 
 var uniqueCalls = [];
+const pipeline = PipelineStore;
 
 function removeCall(options) {
   uniqueCalls.splice(uniqueCalls.indexOf(options.url), 1);
@@ -47,6 +50,10 @@ var ajaxWrapper = function (opts = {}) {
       });
     }
 
+    options = pipeline.applyPipeline(
+                  PipelineNames.PRE_AJAX_REQUEST,
+                  options
+              );
     return fetch(options.url, fetchOptions);
   };
 

--- a/src/js/plugin/PluginLoader.js
+++ b/src/js/plugin/PluginLoader.js
@@ -12,6 +12,8 @@ import PluginDispatcherProxy from "./PluginDispatcherProxy";
 
 import MarathonService from "./sdk/services/MarathonService";
 import MarathonActions from "./sdk/actions/MarathonActions";
+import PipelineStore from "./sdk/pipeline/PipelineStore";
+import * as PipelineNames from "./sdk/pipeline/PipelineNames";
 
 const PLUGIN_STARTUP_TIMEOUT = 10000; // in ms
 
@@ -51,6 +53,8 @@ const PluginLoader = {
           config: Object.freeze(config),
           MarathonService: MarathonService,
           MarathonActions: MarathonActions,
+          PipelineStore: PipelineStore,
+          PipelineNames: PipelineNames,
         });
 
         let dispatchToken = PluginDispatcher.register(function (event) {

--- a/src/js/plugin/sdk/pipeline/PipelineModel.js
+++ b/src/js/plugin/sdk/pipeline/PipelineModel.js
@@ -1,0 +1,46 @@
+
+export default class PipelineModel {
+
+  constructor() {
+    this.pipelines = new Map();
+  };
+
+  applyPipeline(pipelineName, filterParameters) {
+    if (!this.pipelines.has(pipelineName)) {
+      return filterParameters;
+    }
+    return this.pipelines.get(pipelineName)
+      .reduce((accumulator, operator) => {
+        try {
+          return operator(accumulator);
+        } catch (error) {
+          // We might want to log a proper error to help users debug
+          return accumulator;
+        }
+      }, filterParameters);
+  };
+
+  registerOperator(pipelineName, operator) {
+    if (!this.pipelines.has(pipelineName)) {
+      this.pipelines.set(pipelineName, [operator]);
+    } else {
+      const operatorPipeline = this.pipelines.get(pipelineName);
+      if (operatorPipeline.indexOf(operator) === -1) {
+        operatorPipeline.push(operator);
+      }
+    }
+  };
+
+  deregisterOperator(pipelineName, operator) {
+    if (this.pipelines.has(pipelineName)) {
+      const operatorPipeline = this.pipelines.get(pipelineName);
+
+      const operatorIndex = operatorPipeline.indexOf(operator);
+      if (operatorIndex !== -1) {
+        operatorPipeline.splice(operatorIndex, 1);
+      }
+    }
+  };
+
+};
+

--- a/src/js/plugin/sdk/pipeline/PipelineNames.js
+++ b/src/js/plugin/sdk/pipeline/PipelineNames.js
@@ -1,0 +1,3 @@
+
+export const PRE_AJAX_REQUEST = "PRE_AJAX_REQUEST";
+

--- a/src/js/plugin/sdk/pipeline/PipelineStore.js
+++ b/src/js/plugin/sdk/pipeline/PipelineStore.js
@@ -1,0 +1,23 @@
+import PipelineModel from "./PipelineModel";
+
+class PipelineStore {
+
+  constructor() {
+    Object.defineProperty(this, "pipelines", {value: new PipelineModel()});
+  };
+
+  applyPipeline(operationName, filterParameters) {
+    return this.pipelines.applyPipeline(operationName, filterParameters);
+  };
+
+  registerOperator(operationName, operator) {
+    return this.pipelines.registerOperator(operationName, operator);
+  };
+
+  deregisterOperator(operationName, operator) {
+    return this.pipelines.deregisterOperator(operationName, operator);
+  };
+
+};
+
+export default new PipelineStore();

--- a/src/test/units/PipelineModel.test.js
+++ b/src/test/units/PipelineModel.test.js
@@ -1,0 +1,96 @@
+import {expect} from "chai";
+import PipelineModel from "../../js/plugin/sdk/pipeline/PipelineModel"
+
+import {PRE_AJAX_REQUEST} from "../../js/plugin/sdk/pipeline/PipelineNames"
+
+const pipelineModel = new PipelineModel();
+
+describe("PipelineModel tests", function () {
+
+    beforeEach(function (){
+      this.pipelineModel = new PipelineModel();
+    });
+
+    it("should call registered operators in the right order", function () {
+      var firstOperator = function(data) {
+        return Object.assign({}, data, {value: data.value + "_first_suffix"});
+      };
+      var secondOperaator = function(data) {
+        return Object.assign({}, data, {value: data.value + "_second_suffix"});
+      };
+
+      this.pipelineModel.registerOperator(PRE_AJAX_REQUEST, firstOperator);
+      this.pipelineModel.registerOperator(PRE_AJAX_REQUEST, secondOperaator);
+      let filtered_data = this.pipelineModel.applyPipeline(PRE_AJAX_REQUEST, {value: "initial"});
+      expect(filtered_data.value).to.be.equal("initial_first_suffix_second_suffix");
+    });
+
+    it("should register a new operator to the pipeline", function () {
+      const operator = function(data) {return data;};
+
+      this.pipelineModel.registerOperator(PRE_AJAX_REQUEST, operator);
+      expect(this.pipelineModel.pipelines.get(PRE_AJAX_REQUEST)).to.have.lengthOf(1);
+      expect(this.pipelineModel.pipelines.get(PRE_AJAX_REQUEST)[0]).to.be.equal(operator);
+    });
+
+    it("should register multiple operators to the pipeline", function () {
+      var operator = function(data) {return data;};
+      var operator2 = function(data) {return data;};
+
+      this.pipelineModel.registerOperator(PRE_AJAX_REQUEST, operator);
+      this.pipelineModel.registerOperator(PRE_AJAX_REQUEST, operator2);
+      expect(this.pipelineModel.pipelines.get(PRE_AJAX_REQUEST)).to.have.lengthOf(2);
+      expect(this.pipelineModel.pipelines.get(PRE_AJAX_REQUEST)[0]).to.be.equal(operator);
+      expect(this.pipelineModel.pipelines.get(PRE_AJAX_REQUEST)[1]).to.be.equal(operator2);
+    });
+
+    it("should deregister operator from the pipeline", function () {
+      var operator = function(data) {return data;};
+
+      this.pipelineModel.registerOperator(PRE_AJAX_REQUEST, operator);
+      expect(this.pipelineModel.pipelines.get(PRE_AJAX_REQUEST)).to.have.lengthOf(1);
+
+      this.pipelineModel.deregisterOperator(PRE_AJAX_REQUEST, operator);
+      expect(this.pipelineModel.pipelines.get(PRE_AJAX_REQUEST)).to.have.lengthOf(0);
+    });
+
+    it("should not error when removing the same operator twice", function () {
+      var operator = function(data) {return data;};
+
+      this.pipelineModel.registerOperator(PRE_AJAX_REQUEST, operator);
+
+      this.pipelineModel.deregisterOperator(PRE_AJAX_REQUEST, operator);
+      this.pipelineModel.deregisterOperator(PRE_AJAX_REQUEST, operator);
+      expect(this.pipelineModel.pipelines.get(PRE_AJAX_REQUEST)).to.have.lengthOf(0);
+    });
+
+    it("should not register the same operator twice", function () {
+      var operator = function(data) {return data;};
+
+      this.pipelineModel.registerOperator(PRE_AJAX_REQUEST, operator);
+      this.pipelineModel.registerOperator(PRE_AJAX_REQUEST, operator);
+      expect(this.pipelineModel.pipelines.get(PRE_AJAX_REQUEST)).to.have.lengthOf(1);
+      expect(this.pipelineModel.pipelines.get(PRE_AJAX_REQUEST)[0]).to.be.equal(operator);
+    });
+
+    it("should call all operators of the chosen pipeline", function () {
+      var filter_one = function(data) {
+        return Object.assign({}, data, {value: data.value + "_filter_one"});
+      };
+      var filter_two = function(data) {
+        return Object.assign({}, data, {value: data.value + "_filter_two"});
+      };
+
+      this.pipelineModel.registerOperator(PRE_AJAX_REQUEST, filter_one);
+      this.pipelineModel.registerOperator(PRE_AJAX_REQUEST, filter_two);
+      let filtered_data = this.pipelineModel.applyPipeline(PRE_AJAX_REQUEST, {value: "initial"});
+      expect(filtered_data.value).to.be.equal("initial_filter_one_filter_two");
+    });
+
+    it("should be able to run an empty pipeline", function () {
+      const filtered_data = this.pipelineModel.applyPipeline(PRE_AJAX_REQUEST, {value: "initial"});
+      expect(filtered_data.value).to.be.equal("initial");
+    });
+
+});
+

--- a/src/test/units/PipelineStore.test.js
+++ b/src/test/units/PipelineStore.test.js
@@ -1,0 +1,32 @@
+import {expect} from "chai";
+import sinon from "sinon";
+import PipelineStore from "../../js/plugin/sdk/pipeline/PipelineStore";
+import {default as TestPipelineStore} from  "../../js/plugin/sdk/pipeline/PipelineStore";
+import pipelineModel from "../../js/plugin/sdk/pipeline/PipelineModel";
+import * as PipelineNames from "../../js/plugin/sdk/pipeline/PipelineNames";
+
+describe("PipelineStore tests", function () {
+
+    it("shoult share the same pipeline model", function () {
+      expect(TestPipelineStore.pipelines === PipelineStore.pipelines);
+    });
+
+    it("it should proxy applyPipeline calls to PipelineModel", function () {
+      var pipelineSpy = sinon.spy(PipelineStore.pipelines, "applyPipeline");
+      PipelineStore.applyPipeline(PipelineNames.PRE_AJAX_REQUEST, {});
+      expect(pipelineSpy.called).to.be.true;
+    });
+
+    it("it should proxy registerOperator calls to PipelineModel", function () {
+      var pipelineSpy = sinon.spy(PipelineStore.pipelines, "registerOperator");
+      PipelineStore.registerOperator(PipelineNames.PRE_AJAX_REQUEST, (data) => {return data;});
+      expect(pipelineSpy.called).to.be.true;
+    });
+
+    it("it should proxy deregisterOperator calls to PipelineModel", function () {
+      var pipelineSpy = sinon.spy(PipelineStore.pipelines, "deregisterOperator");
+      PipelineStore.deregisterOperator(PipelineNames.PRE_AJAX_REQUEST, (data) => {return data;});
+      expect(pipelineSpy.called).to.be.true;
+    });
+
+});


### PR DESCRIPTION
Hello @orlandohohmeier,

Here is a implementation candidate for a "filters pipeline" feature. This will enrich plugin even more, as long as the core Marathon UI adds some extension points where it calls the filter pipeline.

Let me know what do you think about this implementation, so I can adjust the code to be able to eventually merge.

Things I didn't like the way it's done, but don't know how to do it differently.

* The constants that define the name of the filters: Don't know if there'a a way to continue to use `PipelineStore.PRE_AJAX_REQUEST` without the need of the constructor.
* The `clearPipeline()` method is only used in the tests. I could not clean the pipeline before each tests without this method.
* Ideally the object that holds all pipelines (here `FILTERS_PIPELINE`) should be visible only to the `PipelineStore` module, and not be an attribute of the `PipelineStore` class, also don't know how to achieve this.


Thanks a lot!
