### PR TITLE
Fix URIs not displayed in the configuration of applications

### DIFF
--- a/src/js/components/AppVersionComponent.jsx
+++ b/src/js/components/AppVersionComponent.jsx
@@ -143,7 +143,6 @@ var AppVersionComponent = React.createClass({
 
   render: function () {
     var appVersion = this.props.appVersion;
-
     var acceptedResourceRoles = (appVersion.acceptedResourceRoles == null ||
         appVersion.acceptedResourceRoles.length === 0)
       ? <UnspecifiedNodeComponent />
@@ -224,9 +223,13 @@ var AppVersionComponent = React.createClass({
       ? <UnspecifiedNodeComponent />
       : getHighlightNode(appVersion.networks);
 
-    var urisNode = (appVersion.uris == null || appVersion.uris.length === 0)
+    const uris = (appVersion.fetch instanceof Array)
+      ? appVersion.fetch.map((fetch) => { return fetch["uri"]; })
+      : [];
+
+    var urisNode = (uris.length === 0)
       ? <UnspecifiedNodeComponent />
-      : appVersion.uris.map(function (uri, i) {
+      : uris.map(function (uri, i) {
         var parsedURI = url.parse(uri);
         var linkNode = uri;
 
@@ -282,7 +285,7 @@ var AppVersionComponent = React.createClass({
           {networksNode}
           <dt>Port Definitions</dt>
           {portDefinitionsNode}
-          <dt>Backoff Factor</dt>
+          <dt>Backoff Factors</dt>
           {invalidateValue(appVersion.backoffFactor)}
           <dt>Backoff</dt>
           {invalidateValue(appVersion.backoffSeconds, "seconds")}

--- a/src/js/stores/schemes/appScheme.js
+++ b/src/js/stores/schemes/appScheme.js
@@ -24,7 +24,7 @@ const appScheme = {
   networks: [],
   disk: null,
   portDefinitions: [],
-  uris: [],
+  fetch: [],
   user: null,
   tasks: [],
   tasksRunning: 0,

--- a/src/test/units/AppVersionComponent.test.js
+++ b/src/test/units/AppVersionComponent.test.js
@@ -7,7 +7,7 @@ import AppVersionComponent
 
 describe("AppVersionComponent", function () {
 
-  before(function () {
+  beforeEach(function () {
     this.model = {
       "id": "/sleep10",
       "cmd": "sleep 10",
@@ -32,6 +32,7 @@ describe("AppVersionComponent", function () {
       "executor": "",
       "constraints": [],
       "uris": [],
+      "fetch": [],
       "storeUrls": [],
       "requirePorts": false,
       "backoffSeconds": 1,
@@ -63,7 +64,7 @@ describe("AppVersionComponent", function () {
     this.rows = this.table.children();
   });
 
-  after(function () {
+  afterEach(function () {
     this.component.instance().componentWillUnmount();
   });
 
@@ -189,4 +190,35 @@ describe("AppVersionComponent", function () {
       .to.equal("c=C");
   });
 
+  it("has one uri", function () {
+    this.model.fetch = [{
+      uri: "http://localhost/test",
+      executable: false,
+      extract: false,
+      cache: false
+    }];
+    this.component = mount(<AppVersionComponent appVersion={this.model} />);
+    this.table = this.component.find("dl.dl-horizontal");
+    this.rows = this.table.children();
+    expect(this.rows.at(41).text().trim()).to.equal("http://localhost/test");
+  });
+
+  it("has multiple uris", function () {
+    this.model.fetch = [{
+      uri: "http://localhost/test",
+      executable: false,
+      extract: false,
+      cache: false
+    }, {
+      uri: "http://localhost/test2",
+      executable: false,
+      extract: false,
+      cache: false
+    }];
+    this.component = mount(<AppVersionComponent appVersion={this.model} />);
+    this.table = this.component.find("dl.dl-horizontal");
+    this.rows = this.table.children();
+    expect(this.rows.at(41).text().trim()).to.equal("http://localhost/test");
+    expect(this.rows.at(42).text().trim()).to.equal("http://localhost/test2");
+  });
 });


### PR DESCRIPTION
After upgrading from Marathon 1.4.3 to 1.5.6, the display of URIs in the
configuration view was set to "Unspecified" even if some URIs were set
for the application. The problem was due to a change in the schema of
/v2/apps. The "uris" field disappeared and has been completely replaced
by the "fetch" field.

This commit add tests covering an app declaring one and several URIs to
detect the issue and fixes it.

Warning: This fix might not be backward compatible with versions below 1.4.3.