### PR TITLE
Sort by hostname instead of task ID

### DIFF
--- a/src/js/components/TaskListComponent.jsx
+++ b/src/js/components/TaskListComponent.jsx
@@ -163,7 +163,7 @@ var TaskListComponent = React.createClass({
     });
 
     var idClassSet = classNames({
-      "cell-highlighted": state.sortKey === "id"
+      "cell-highlighted": state.sortKey === "host"
     });
 
     var statusClassSet = classNames("text-center", {
@@ -207,9 +207,9 @@ var TaskListComponent = React.createClass({
                   onChange={props.toggleAllTasks} />
               </th>
               <th className={idClassSet}>
-                <span onClick={this.sortBy.bind(null, "id")}
+                <span onClick={this.sortBy.bind(null, "host")}
                     className={headerClassSet}>
-                  ID {this.getCaret("id")}
+                  ID {this.getCaret("host")}
                 </span>
               </th>
               <th className={hasHealthClassSet}>

--- a/src/js/components/TaskListItemComponent.jsx
+++ b/src/js/components/TaskListItemComponent.jsx
@@ -202,7 +202,7 @@ var TaskListItemComponent = React.createClass({
     }
 
     var idClassSet = classNames({
-      "cell-highlighted": sortKey === "id"
+      "cell-highlighted": sortKey === "host"
     });
 
     var versionClassSet = classNames("text-right", {


### PR DESCRIPTION
When a user click on "ID" column header in task list view, the real intent
is likely to sort by hostname instead of sorting by task id.
Marathon task ids are ~random so sorting on them does not really make sense.
Sorting on hostname can be useful.

A better commit would sort on host+port but this one is likely good
enough.