### PR TITLE
remove port in default schemes

### DIFF
--- a/src/js/stores/schemes/healthChecksRowScheme.js
+++ b/src/js/stores/schemes/healthChecksRowScheme.js
@@ -7,7 +7,6 @@ const healthChecksRowScheme = {
   protocol: HealthCheckProtocols.HTTP,
   command: null,
   path: null,
-  port: 0,
   portIndex: 0,
   portType: HealthCheckPortTypes.PORT_INDEX,
   gracePeriodSeconds: 300,


### PR DESCRIPTION
When I add a health check, it is added by default port:0 , but this will override the portIndex parameter